### PR TITLE
feat: init Next.js TS in-memory MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+.next
+out
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+.env*

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from "next/server";
 
-export const GET = () => {
-  return NextResponse.json({ ok: true, time: new Date().toISOString() });
-};
+export const GET = () =>
+  NextResponse.json({ ok: true, time: new Date().toISOString() });

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export const GET = () => {
+  return NextResponse.json({ ok: true, time: new Date().toISOString() });
+};

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,4 +1,2 @@
-import { NextResponse } from "next/server";
-
 export const GET = () =>
-  NextResponse.json({ ok: true, time: new Date().toISOString() });
+  Response.json({ ok: true, time: new Date().toISOString() });

--- a/app/api/operations/route.ts
+++ b/app/api/operations/route.ts
@@ -1,5 +1,5 @@
-import { db } from "@/lib/operationsStore";
-import type { Operation } from "@/lib/types";
+import { db } from "../../../lib/operationsStore";
+import type { Operation } from "../../../lib/types";
 
 type OperationInput = {
   type: Operation["type"];

--- a/app/api/operations/route.ts
+++ b/app/api/operations/route.ts
@@ -2,7 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { db } from "@/lib/operationsStore";
 import type { Operation } from "@/lib/types";
 
-type OperationInput = {
+type OperationPayload = {
   type: Operation["type"];
   amount: number;
   currency?: string;
@@ -11,32 +11,62 @@ type OperationInput = {
   source?: string;
 };
 
-export const GET = () => {
-  return NextResponse.json(db.operations);
-};
+const isOperationType = (value: unknown): value is Operation["type"] =>
+  value === "income" || value === "expense";
+
+export const GET = () => NextResponse.json(db.operations);
 
 export const POST = async (request: NextRequest) => {
-  const payload = (await request.json()) as Partial<OperationInput>;
+  let data: unknown;
 
-  if (
-    !payload ||
-    (payload.type !== "income" && payload.type !== "expense") ||
-    typeof payload.amount !== "number"
-  ) {
-    return NextResponse.json(
-      { error: "Invalid payload" },
-      { status: 400 }
-    );
+  try {
+    data = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
+
+  if (typeof data !== "object" || data === null) {
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+  }
+
+  const payload = data as Partial<OperationPayload>;
+
+  if (!isOperationType(payload.type) || typeof payload.amount !== "number") {
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+  }
+
+  if (!Number.isFinite(payload.amount) || payload.amount <= 0) {
+    return NextResponse.json({ error: "Amount must be a positive number" }, { status: 400 });
+  }
+
+  const currency =
+    typeof payload.currency === "string" && payload.currency.trim().length > 0
+      ? payload.currency.trim()
+      : "USD";
+
+  const category =
+    typeof payload.category === "string" && payload.category.trim().length > 0
+      ? payload.category.trim()
+      : "general";
+
+  const comment =
+    typeof payload.comment === "string" && payload.comment.trim().length > 0
+      ? payload.comment.trim()
+      : undefined;
+
+  const source =
+    typeof payload.source === "string" && payload.source.trim().length > 0
+      ? payload.source.trim()
+      : undefined;
 
   const operation: Operation = {
     id: crypto.randomUUID(),
     type: payload.type,
     amount: payload.amount,
-    currency: payload.currency ?? "USD",
-    category: payload.category ?? "general",
-    comment: payload.comment,
-    source: payload.source,
+    currency,
+    category,
+    comment,
+    source,
     date: new Date().toISOString()
   };
 

--- a/app/api/operations/route.ts
+++ b/app/api/operations/route.ts
@@ -1,3 +1,4 @@
+import { NextResponse, type NextRequest } from "next/server";
 import { db } from "@/lib/operationsStore";
 import type { Operation } from "@/lib/types";
 
@@ -10,11 +11,9 @@ type OperationInput = {
   source?: string;
 };
 
-export const GET = () => {
-  return Response.json(db.operations);
-};
+export const GET = () => NextResponse.json(db.operations);
 
-export const POST = async (request: Request) => {
+export const POST = async (request: NextRequest) => {
   const payload = (await request.json()) as Partial<OperationInput> | null;
 
   if (
@@ -22,7 +21,7 @@ export const POST = async (request: Request) => {
     (payload.type !== "income" && payload.type !== "expense") ||
     typeof payload.amount !== "number"
   ) {
-    return Response.json({ error: "Invalid payload" }, { status: 400 });
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
   }
 
   const operation: Operation = {
@@ -38,5 +37,5 @@ export const POST = async (request: Request) => {
 
   db.operations.unshift(operation);
 
-  return Response.json(operation, { status: 201 });
+  return NextResponse.json(operation, { status: 201 });
 };

--- a/app/api/operations/route.ts
+++ b/app/api/operations/route.ts
@@ -1,5 +1,5 @@
-import { db } from "../../../lib/operationsStore";
-import type { Operation } from "../../../lib/types";
+import { db } from "@/lib/operationsStore";
+import type { Operation } from "@/lib/types";
 
 type OperationInput = {
   type: Operation["type"];

--- a/app/api/operations/route.ts
+++ b/app/api/operations/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { db } from "@/lib/operationsStore";
+import type { Operation } from "@/lib/types";
+
+type OperationInput = {
+  type: Operation["type"];
+  amount: number;
+  currency?: string;
+  category?: string;
+  comment?: string;
+  source?: string;
+};
+
+export const GET = () => {
+  return NextResponse.json(db.operations);
+};
+
+export const POST = async (request: NextRequest) => {
+  const payload = (await request.json()) as Partial<OperationInput>;
+
+  if (
+    !payload ||
+    (payload.type !== "income" && payload.type !== "expense") ||
+    typeof payload.amount !== "number"
+  ) {
+    return NextResponse.json(
+      { error: "Invalid payload" },
+      { status: 400 }
+    );
+  }
+
+  const operation: Operation = {
+    id: crypto.randomUUID(),
+    type: payload.type,
+    amount: payload.amount,
+    currency: payload.currency ?? "USD",
+    category: payload.category ?? "general",
+    comment: payload.comment,
+    source: payload.source,
+    date: new Date().toISOString()
+  };
+
+  db.operations.unshift(operation);
+
+  return NextResponse.json(operation, { status: 201 });
+};

--- a/app/api/operations/route.ts
+++ b/app/api/operations/route.ts
@@ -1,8 +1,7 @@
-import { NextResponse, type NextRequest } from "next/server";
 import { db } from "@/lib/operationsStore";
 import type { Operation } from "@/lib/types";
 
-type OperationPayload = {
+type OperationInput = {
   type: Operation["type"];
   amount: number;
   currency?: string;
@@ -11,66 +10,33 @@ type OperationPayload = {
   source?: string;
 };
 
-const isOperationType = (value: unknown): value is Operation["type"] =>
-  value === "income" || value === "expense";
+export const GET = () => {
+  return Response.json(db.operations);
+};
 
-export const GET = () => NextResponse.json(db.operations);
+export const POST = async (request: Request) => {
+  const payload = (await request.json()) as Partial<OperationInput> | null;
 
-export const POST = async (request: NextRequest) => {
-  let data: unknown;
-
-  try {
-    data = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  if (
+    !payload ||
+    (payload.type !== "income" && payload.type !== "expense") ||
+    typeof payload.amount !== "number"
+  ) {
+    return Response.json({ error: "Invalid payload" }, { status: 400 });
   }
-
-  if (typeof data !== "object" || data === null) {
-    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
-  }
-
-  const payload = data as Partial<OperationPayload>;
-
-  if (!isOperationType(payload.type) || typeof payload.amount !== "number") {
-    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
-  }
-
-  if (!Number.isFinite(payload.amount) || payload.amount <= 0) {
-    return NextResponse.json({ error: "Amount must be a positive number" }, { status: 400 });
-  }
-
-  const currency =
-    typeof payload.currency === "string" && payload.currency.trim().length > 0
-      ? payload.currency.trim()
-      : "USD";
-
-  const category =
-    typeof payload.category === "string" && payload.category.trim().length > 0
-      ? payload.category.trim()
-      : "general";
-
-  const comment =
-    typeof payload.comment === "string" && payload.comment.trim().length > 0
-      ? payload.comment.trim()
-      : undefined;
-
-  const source =
-    typeof payload.source === "string" && payload.source.trim().length > 0
-      ? payload.source.trim()
-      : undefined;
 
   const operation: Operation = {
     id: crypto.randomUUID(),
     type: payload.type,
     amount: payload.amount,
-    currency,
-    category,
-    comment,
-    source,
+    currency: payload.currency ?? "USD",
+    category: payload.category ?? "general",
+    comment: payload.comment,
+    source: payload.source,
     date: new Date().toISOString()
   };
 
   db.operations.unshift(operation);
 
-  return NextResponse.json(operation, { status: 201 });
+  return Response.json(operation, { status: 201 });
 };

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,35 @@
+:root {
+  color-scheme: light;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  background-color: #f6f7f9;
+  color: #222;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  line-height: 1.5;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 2rem;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+}
+
+input, select, textarea {
+  font: inherit;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,22 +2,24 @@
   color-scheme: light;
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
   background-color: #f6f7f9;
-  color: #222;
+  color: #1f2937;
 }
 
-* {
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
   margin: 0;
   padding: 0;
-  box-sizing: border-box;
 }
 
 body {
   min-height: 100vh;
-  line-height: 1.5;
+  background-color: #f3f4f6;
   display: flex;
   justify-content: center;
   align-items: flex-start;
-  padding: 2rem;
+  padding: 2.5rem 1.5rem 4rem;
 }
 
 a {
@@ -25,11 +27,13 @@ a {
   text-decoration: none;
 }
 
-button {
+button,
+input,
+select,
+textarea {
   font: inherit;
-  cursor: pointer;
 }
 
-input, select, textarea {
-  font: inherit;
+button {
+  cursor: pointer;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Финансы храма — MVP"
+};
+
+const RootLayout = ({ children }: { children: ReactNode }) => (
+  <html lang="ru">
+    <body>{children}</body>
+  </html>
+);
+
+export default RootLayout;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,8 @@ import type { ReactNode } from "react";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "Финансы храма — MVP"
+  title: "Финансы храма — MVP",
+  description: "Минимальный трекер приходов и расходов для общины."
 };
 
 const RootLayout = ({ children }: { children: ReactNode }) => (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState, type FormEvent } from "react";
-import type { Operation } from "../lib/types";
+import type { Operation } from "@/lib/types";
 
 const Page = () => {
   const [operations, setOperations] = useState<Operation[]>([]);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+import type { Operation } from "@/lib/types";
+
+const Page = () => {
+  const [operations, setOperations] = useState<Operation[]>([]);
+  const [amount, setAmount] = useState("");
+  const [type, setType] = useState<Operation["type"]>("income");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadOperations = async () => {
+      try {
+        const response = await fetch("/api/operations");
+        if (!response.ok) {
+          throw new Error("Не удалось загрузить операции");
+        }
+        const data = (await response.json()) as Operation[];
+        setOperations(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Неизвестная ошибка");
+      }
+    };
+
+    loadOperations().catch(() => {
+      setError("Не удалось загрузить операции");
+    });
+  }, []);
+
+  const balance = useMemo(
+    () =>
+      operations.reduce((acc, operation) => {
+        return operation.type === "income"
+          ? acc + operation.amount
+          : acc - operation.amount;
+      }, 0),
+    [operations]
+  );
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+
+    const numericAmount = Number(amount);
+
+    if (!Number.isFinite(numericAmount) || numericAmount <= 0) {
+      setError("Введите сумму больше нуля");
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      const response = await fetch("/api/operations", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          type,
+          amount: numericAmount
+        })
+      });
+
+      if (!response.ok) {
+        throw new Error("Не удалось добавить операцию");
+      }
+
+      const created = (await response.json()) as Operation;
+      setOperations((prev) => [created, ...prev]);
+      setAmount("");
+      setType("income");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Неизвестная ошибка");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main
+      style={{
+        width: "min(720px, 100%)",
+        background: "#fff",
+        borderRadius: "16px",
+        padding: "2rem",
+        boxShadow: "0 10px 30px rgba(15, 23, 42, 0.08)",
+        display: "flex",
+        flexDirection: "column",
+        gap: "2rem"
+      }}
+    >
+      <header>
+        <h1 style={{ fontSize: "2rem", marginBottom: "0.5rem" }}>
+          Финансы храма — MVP
+        </h1>
+        <p style={{ color: "#4b5563" }}>
+          Отслеживайте приход и расход средств, чтобы понимать баланс общины.
+        </p>
+      </header>
+
+      <section
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "1rem"
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center"
+          }}
+        >
+          <h2 style={{ fontSize: "1.5rem" }}>Текущий баланс</h2>
+          <strong
+            style={{
+              fontSize: "1.75rem",
+              color: balance >= 0 ? "#15803d" : "#b91c1c"
+            }}
+          >
+            {balance.toLocaleString("ru-RU", {
+              style: "currency",
+              currency: "USD"
+            })}
+          </strong>
+        </div>
+
+        <form
+          onSubmit={handleSubmit}
+          style={{
+            display: "grid",
+            gridTemplateColumns: "2fr 1fr auto",
+            gap: "1rem",
+            alignItems: "end"
+          }}
+        >
+          <label style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+            <span>Сумма</span>
+            <input
+              type="number"
+              min="0"
+              step="0.01"
+              value={amount}
+              onChange={(event) => setAmount(event.target.value)}
+              style={{
+                padding: "0.75rem 1rem",
+                borderRadius: "0.75rem",
+                border: "1px solid #d1d5db"
+              }}
+              required
+            />
+          </label>
+
+          <label style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+            <span>Тип</span>
+            <select
+              value={type}
+              onChange={(event) => setType(event.target.value as Operation["type"])}
+              style={{
+                padding: "0.75rem 1rem",
+                borderRadius: "0.75rem",
+                border: "1px solid #d1d5db"
+              }}
+            >
+              <option value="income">Приход</option>
+              <option value="expense">Расход</option>
+            </select>
+          </label>
+
+          <button
+            type="submit"
+            disabled={loading}
+            style={{
+              padding: "0.85rem 1.75rem",
+              borderRadius: "0.75rem",
+              border: "none",
+              background: "#2563eb",
+              color: "#fff",
+              fontWeight: 600,
+              transition: "background 0.2s ease"
+            }}
+          >
+            {loading ? "Добавляем..." : "Добавить"}
+          </button>
+        </form>
+
+        {error ? (
+          <p style={{ color: "#b91c1c" }}>{error}</p>
+        ) : null}
+      </section>
+
+      <section style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+        <h2 style={{ fontSize: "1.5rem" }}>Последние операции</h2>
+        {operations.length === 0 ? (
+          <p style={{ color: "#6b7280" }}>Пока нет данных. Добавьте первую операцию.</p>
+        ) : (
+          <ul style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+            {operations.map((operation) => (
+              <li
+                key={operation.id}
+                style={{
+                  padding: "1rem 1.25rem",
+                  borderRadius: "1rem",
+                  border: "1px solid #e5e7eb",
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                  background: "#f9fafb"
+                }}
+              >
+                <div>
+                  <p style={{ fontWeight: 600 }}>
+                    {operation.type === "income" ? "Приход" : "Расход"} — {operation.category}
+                  </p>
+                  <p style={{ color: "#6b7280", fontSize: "0.9rem" }}>
+                    {new Date(operation.date).toLocaleString("ru-RU")}
+                  </p>
+                  {operation.comment ? (
+                    <p style={{ color: "#4b5563", marginTop: "0.25rem" }}>{operation.comment}</p>
+                  ) : null}
+                </div>
+                <span
+                  style={{
+                    fontWeight: 700,
+                    color: operation.type === "income" ? "#15803d" : "#b91c1c"
+                  }}
+                >
+                  {`${operation.type === "income" ? "+" : "-"}${operation.amount.toLocaleString("ru-RU", {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2
+                  })} ${operation.currency}`}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+};
+
+export default Page;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState, type FormEvent } from "react";
-import type { Operation } from "@/lib/types";
+import type { Operation } from "../lib/types";
 
 const Page = () => {
   const [operations, setOperations] = useState<Operation[]>([]);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@ import type { Operation } from "@/lib/types";
 
 const Page = () => {
   const [operations, setOperations] = useState<Operation[]>([]);
-  const [amount, setAmount] = useState("");
+  const [amount, setAmount] = useState<string>("");
   const [type, setType] = useState<Operation["type"]>("income");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -17,16 +17,15 @@ const Page = () => {
         if (!response.ok) {
           throw new Error("Не удалось загрузить операции");
         }
+
         const data = (await response.json()) as Operation[];
         setOperations(data);
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Неизвестная ошибка");
+        setError(err instanceof Error ? err.message : "Произошла ошибка");
       }
     };
 
-    loadOperations().catch(() => {
-      setError("Не удалось загрузить операции");
-    });
+    void loadOperations();
   }, []);
 
   const balance = useMemo(
@@ -46,7 +45,7 @@ const Page = () => {
     const numericAmount = Number(amount);
 
     if (!Number.isFinite(numericAmount) || numericAmount <= 0) {
-      setError("Введите сумму больше нуля");
+      setError("Введите корректную сумму больше нуля");
       return;
     }
 
@@ -65,7 +64,7 @@ const Page = () => {
       });
 
       if (!response.ok) {
-        throw new Error("Не удалось добавить операцию");
+        throw new Error("Не удалось сохранить операцию");
       }
 
       const created = (await response.json()) as Operation;
@@ -73,7 +72,7 @@ const Page = () => {
       setAmount("");
       setType("income");
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Неизвестная ошибка");
+      setError(err instanceof Error ? err.message : "Произошла ошибка");
     } finally {
       setLoading(false);
     }
@@ -83,31 +82,23 @@ const Page = () => {
     <main
       style={{
         width: "min(720px, 100%)",
-        background: "#fff",
+        backgroundColor: "#ffffff",
         borderRadius: "16px",
         padding: "2rem",
-        boxShadow: "0 10px 30px rgba(15, 23, 42, 0.08)",
+        boxShadow: "0 12px 28px rgba(15, 23, 42, 0.12)",
         display: "flex",
         flexDirection: "column",
         gap: "2rem"
       }}
     >
-      <header>
-        <h1 style={{ fontSize: "2rem", marginBottom: "0.5rem" }}>
-          Финансы храма — MVP
-        </h1>
+      <header style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+        <h1 style={{ fontSize: "2rem", fontWeight: 700 }}>Финансы храма — MVP</h1>
         <p style={{ color: "#4b5563" }}>
-          Отслеживайте приход и расход средств, чтобы понимать баланс общины.
+          Отслеживайте приход и расход средств, чтобы понимать финансовый баланс общины.
         </p>
       </header>
 
-      <section
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          gap: "1rem"
-        }}
-      >
+      <section style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}>
         <div
           style={{
             display: "flex",
@@ -115,7 +106,7 @@ const Page = () => {
             alignItems: "center"
           }}
         >
-          <h2 style={{ fontSize: "1.5rem" }}>Текущий баланс</h2>
+          <h2 style={{ fontSize: "1.5rem", fontWeight: 600 }}>Текущий баланс</h2>
           <strong
             style={{
               fontSize: "1.75rem",
@@ -178,25 +169,23 @@ const Page = () => {
               padding: "0.85rem 1.75rem",
               borderRadius: "0.75rem",
               border: "none",
-              background: "#2563eb",
-              color: "#fff",
+              backgroundColor: loading ? "#1d4ed8" : "#2563eb",
+              color: "#ffffff",
               fontWeight: 600,
-              transition: "background 0.2s ease"
+              transition: "background-color 0.2s ease"
             }}
           >
             {loading ? "Добавляем..." : "Добавить"}
           </button>
         </form>
 
-        {error ? (
-          <p style={{ color: "#b91c1c" }}>{error}</p>
-        ) : null}
+        {error ? <p style={{ color: "#b91c1c" }}>{error}</p> : null}
       </section>
 
       <section style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
-        <h2 style={{ fontSize: "1.5rem" }}>Последние операции</h2>
+        <h2 style={{ fontSize: "1.5rem", fontWeight: 600 }}>Последние операции</h2>
         {operations.length === 0 ? (
-          <p style={{ color: "#6b7280" }}>Пока нет данных. Добавьте первую операцию.</p>
+          <p style={{ color: "#6b7280" }}>Пока нет данных — добавьте первую операцию.</p>
         ) : (
           <ul style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
             {operations.map((operation) => (
@@ -209,10 +198,10 @@ const Page = () => {
                   display: "flex",
                   justifyContent: "space-between",
                   alignItems: "center",
-                  background: "#f9fafb"
+                  backgroundColor: "#f9fafb"
                 }}
               >
-                <div>
+                <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem" }}>
                   <p style={{ fontWeight: 600 }}>
                     {operation.type === "income" ? "Приход" : "Расход"} — {operation.category}
                   </p>
@@ -220,7 +209,7 @@ const Page = () => {
                     {new Date(operation.date).toLocaleString("ru-RU")}
                   </p>
                   {operation.comment ? (
-                    <p style={{ color: "#4b5563", marginTop: "0.25rem" }}>{operation.comment}</p>
+                    <p style={{ color: "#4b5563" }}>{operation.comment}</p>
                   ) : null}
                 </div>
                 <span

--- a/lib/operationsStore.ts
+++ b/lib/operationsStore.ts
@@ -1,0 +1,17 @@
+import type { Debt, Goal, Operation, User } from "./types";
+
+export const db: {
+  operations: Operation[];
+  debts: Debt[];
+  goals: Goal[];
+  users: User[];
+} = {
+  operations: [],
+  debts: [],
+  goals: [],
+  users: [
+    { id: "1", role: "admin", login: "admin", password: "admin123" },
+    { id: "2", role: "accountant", login: "buh", password: "buh123" },
+    { id: "3", role: "abbot", login: "abbot", password: "abbot123" }
+  ]
+};

--- a/lib/operationsStore.ts
+++ b/lib/operationsStore.ts
@@ -1,11 +1,13 @@
 import type { Debt, Goal, Operation, User } from "./types";
 
-export const db: {
+type Database = {
   operations: Operation[];
   debts: Debt[];
   goals: Goal[];
   users: User[];
-} = {
+};
+
+export const db: Database = {
   operations: [],
   debts: [],
   goals: [],

--- a/lib/operationsStore.ts
+++ b/lib/operationsStore.ts
@@ -1,13 +1,11 @@
-import type { Debt, Goal, Operation, User } from "./types";
+import type { Debt, Goal, Operation, User } from "@/lib/types";
 
-type Database = {
+export const db: {
   operations: Operation[];
   debts: Debt[];
   goals: Goal[];
   users: User[];
-};
-
-export const db: Database = {
+} = {
   operations: [],
   debts: [],
   goals: [],

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,32 @@
+export type Operation = {
+  id: string;
+  type: "income" | "expense";
+  amount: number;
+  currency: string;
+  category: string;
+  comment?: string;
+  source?: string;
+  date: string;
+};
+
+export type Debt = {
+  id: string;
+  amount: number;
+  status: "open" | "closed";
+  date: string;
+};
+
+export type Goal = {
+  id: string;
+  title: string;
+  targetAmount: number;
+  currentAmount: number;
+  status: "active" | "done";
+};
+
+export type User = {
+  id: string;
+  role: "admin" | "accountant" | "abbot";
+  login: string;
+  password: string;
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   },
   "dependencies": {
     "@types/node": "^20.14.9",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
     "next": "^14.2.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "iskcon-finance-mvp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22 <23"
+  },
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@types/node": "^20.14.9",
+    "next": "^14.2.5",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "typescript": "^5.5.3"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "moduleResolution": "Bundler",
+    "moduleResolution": "NodeNext",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,19 +6,24 @@
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
-    "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "moduleResolution": "NodeNext",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "buildCommand": "next build",
+  "outputDirectory": ".next",
+  "framework": "nextjs"
+}


### PR DESCRIPTION
## Summary
- initialize a minimal Next.js App Router project with strict TypeScript configuration and Node 22 support
- add in-memory domain types and store with seed users for operations, debts, goals, and users
- provide health and operations API routes plus a basic client dashboard for managing temple finances

## Testing
- npm install *(fails: npm error code E403 403 Forbidden - GET https://registry.npmjs.org/@types%2fnode)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2da0bc0083318fea0b2f6aeebc7b