### PR TITLE
Add debts tracking page and balance integration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/app/api/debts/route.ts
+++ b/app/api/debts/route.ts
@@ -46,3 +46,22 @@ export const POST = async (request: NextRequest) => {
 
   return NextResponse.json(debt, { status: 201 });
 };
+
+export const DELETE = (request: NextRequest) => {
+  const { searchParams } = new URL(request.url);
+  const id = searchParams.get("id");
+
+  if (!id) {
+    return NextResponse.json({ error: "Debt id is required" }, { status: 400 });
+  }
+
+  const index = db.debts.findIndex((debt) => debt.id === id);
+
+  if (index === -1) {
+    return NextResponse.json({ error: "Debt not found" }, { status: 404 });
+  }
+
+  db.debts.splice(index, 1);
+
+  return NextResponse.json({ success: true });
+};

--- a/app/api/debts/route.ts
+++ b/app/api/debts/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { db } from "@/lib/operationsStore";
+import type { Debt } from "@/lib/types";
+
+type DebtInput = {
+  type?: Debt["type"];
+  amount?: number;
+  from?: string;
+  to?: string;
+  comment?: string;
+};
+
+export const GET = () => NextResponse.json(db.debts);
+
+export const POST = async (request: NextRequest) => {
+  const payload = (await request.json()) as DebtInput | null;
+
+  if (!payload || (payload.type !== "borrowed" && payload.type !== "lent")) {
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+  }
+
+  if (typeof payload.amount !== "number" || !Number.isFinite(payload.amount) || payload.amount <= 0) {
+    return NextResponse.json({ error: "Invalid amount" }, { status: 400 });
+  }
+
+  if (payload.type === "borrowed" && (!payload.from || typeof payload.from !== "string")) {
+    return NextResponse.json({ error: "Debt requires a lender" }, { status: 400 });
+  }
+
+  if (payload.type === "lent" && (!payload.to || typeof payload.to !== "string")) {
+    return NextResponse.json({ error: "Debt requires a recipient" }, { status: 400 });
+  }
+
+  const debt: Debt = {
+    id: crypto.randomUUID(),
+    type: payload.type,
+    amount: payload.amount,
+    status: "open",
+    date: new Date().toISOString(),
+    from: payload.type === "borrowed" ? payload.from : undefined,
+    to: payload.type === "lent" ? payload.to : undefined,
+    comment: payload.comment?.trim() ? payload.comment.trim() : undefined
+  };
+
+  db.debts.unshift(debt);
+
+  return NextResponse.json(debt, { status: 201 });
+};

--- a/app/debts/page.tsx
+++ b/app/debts/page.tsx
@@ -44,14 +44,14 @@ const DebtPage = () => {
             return {
               ...acc,
               borrowed: acc.borrowed + debt.amount,
-              balanceEffect: acc.balanceEffect + debt.amount
+              balanceEffect: acc.balanceEffect - debt.amount
             };
           }
 
           return {
             ...acc,
             lent: acc.lent + debt.amount,
-            balanceEffect: acc.balanceEffect - debt.amount
+            balanceEffect: acc.balanceEffect + debt.amount
           };
         },
         { borrowed: 0, lent: 0, balanceEffect: 0 }

--- a/app/debts/page.tsx
+++ b/app/debts/page.tsx
@@ -12,6 +12,7 @@ const DebtPage = () => {
   const [to, setTo] = useState<string>("");
   const [comment, setComment] = useState<string>("");
   const [loading, setLoading] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -60,6 +61,25 @@ const DebtPage = () => {
   );
 
   const { borrowed, lent } = totals;
+
+  const handleDelete = async (id: string) => {
+    setError(null);
+    setDeletingId(id);
+
+    try {
+      const response = await fetch(`/api/debts?id=${id}`, { method: "DELETE" });
+
+      if (!response.ok) {
+        throw new Error("Не удалось удалить долг");
+      }
+
+      setDebts((prev) => prev.filter((debt) => debt.id !== id));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Произошла ошибка");
+    } finally {
+      setDeletingId(null);
+    }
+  };
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -360,19 +380,45 @@ const DebtPage = () => {
                     <p style={{ color: "#4b5563" }}>{debt.comment}</p>
                   ) : null}
                 </div>
-                <span
+                <div
                   style={{
-                    fontWeight: 600,
-                    color: debt.type === "borrowed" ? "#15803d" : "#b91c1c"
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "flex-end",
+                    gap: "0.5rem"
                   }}
                 >
-                  {debt.type === "borrowed" ? "+" : "-"}
-                  {debt.amount.toLocaleString("ru-RU", {
-                    minimumFractionDigits: 2,
-                    maximumFractionDigits: 2
-                  })}
-                  {" USD"}
-                </span>
+                  <span
+                    style={{
+                      fontWeight: 600,
+                      color: debt.type === "borrowed" ? "#15803d" : "#b91c1c"
+                    }}
+                  >
+                    {debt.type === "borrowed" ? "+" : "-"}
+                    {debt.amount.toLocaleString("ru-RU", {
+                      minimumFractionDigits: 2,
+                      maximumFractionDigits: 2
+                    })}
+                    {" USD"}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(debt.id)}
+                    disabled={deletingId === debt.id}
+                    style={{
+                      padding: "0.5rem 1rem",
+                      borderRadius: "0.75rem",
+                      border: "1px solid #ef4444",
+                      backgroundColor:
+                        deletingId === debt.id ? "#fecaca" : "rgba(254, 226, 226, 0.6)",
+                      color: "#b91c1c",
+                      fontWeight: 600,
+                      cursor: deletingId === debt.id ? "not-allowed" : "pointer"
+                    }}
+                  >
+                    {deletingId === debt.id ? "Удаляем..." : "Удалить"}
+                  </button>
+                </div>
               </li>
             ))}
           </ul>

--- a/app/debts/page.tsx
+++ b/app/debts/page.tsx
@@ -59,7 +59,7 @@ const DebtPage = () => {
     [debts]
   );
 
-  const { borrowed, lent, balanceEffect } = totals;
+  const { borrowed, lent } = totals;
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -173,22 +173,6 @@ const DebtPage = () => {
       </header>
 
       <section style={{ display: "grid", gap: "1rem", gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))" }}>
-        <div
-          style={{
-            padding: "1rem 1.25rem",
-            borderRadius: "1rem",
-            backgroundColor: "#f5f3ff",
-            color: "#4c1d95"
-          }}
-        >
-          <p style={{ fontWeight: 600 }}>Влияют на баланс</p>
-          <p style={{ marginTop: "0.25rem" }}>
-            {balanceEffect.toLocaleString("ru-RU", {
-              style: "currency",
-              currency: "USD"
-            })}
-          </p>
-        </div>
         <div
           style={{
             padding: "1rem 1.25rem",

--- a/app/debts/page.tsx
+++ b/app/debts/page.tsx
@@ -1,0 +1,401 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+import type { Debt } from "@/lib/types";
+
+const DebtPage = () => {
+  const [debts, setDebts] = useState<Debt[]>([]);
+  const [type, setType] = useState<Debt["type"]>("borrowed");
+  const [amount, setAmount] = useState<string>("");
+  const [from, setFrom] = useState<string>("");
+  const [to, setTo] = useState<string>("");
+  const [comment, setComment] = useState<string>("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadDebts = async () => {
+      try {
+        const response = await fetch("/api/debts");
+        if (!response.ok) {
+          throw new Error("Не удалось загрузить долги");
+        }
+
+        const data = (await response.json()) as Debt[];
+        setDebts(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Произошла ошибка");
+      }
+    };
+
+    void loadDebts();
+  }, []);
+
+  const totals = useMemo(
+    () =>
+      debts.reduce(
+        (acc, debt) => {
+          if (debt.status === "closed") {
+            return acc;
+          }
+
+          if (debt.type === "borrowed") {
+            return {
+              ...acc,
+              borrowed: acc.borrowed + debt.amount,
+              balanceEffect: acc.balanceEffect + debt.amount
+            };
+          }
+
+          return {
+            ...acc,
+            lent: acc.lent + debt.amount,
+            balanceEffect: acc.balanceEffect - debt.amount
+          };
+        },
+        { borrowed: 0, lent: 0, balanceEffect: 0 }
+      ),
+    [debts]
+  );
+
+  const { borrowed, lent, balanceEffect } = totals;
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+
+    const numericAmount = Number(amount);
+
+    if (!Number.isFinite(numericAmount) || numericAmount <= 0) {
+      setError("Введите корректную сумму больше нуля");
+      return;
+    }
+
+    const payload: Record<string, string | number> = {
+      type,
+      amount: numericAmount
+    };
+
+    if (type === "borrowed") {
+      if (!from.trim()) {
+        setError("Укажите, от кого получен долг");
+        return;
+      }
+
+      payload.from = from.trim();
+    } else {
+      if (!to.trim()) {
+        setError("Укажите, кому выдали долг");
+        return;
+      }
+
+      payload.to = to.trim();
+    }
+
+    if (comment.trim()) {
+      payload.comment = comment.trim();
+    }
+
+    setLoading(true);
+
+    try {
+      const response = await fetch("/api/debts", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify(payload)
+      });
+
+      if (!response.ok) {
+        throw new Error("Не удалось сохранить долг");
+      }
+
+      const created = (await response.json()) as Debt;
+      setDebts((prev) => [created, ...prev]);
+      setAmount("");
+      setFrom("");
+      setTo("");
+      setComment("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Произошла ошибка");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main
+      style={{
+        width: "min(720px, 100%)",
+        backgroundColor: "#ffffff",
+        borderRadius: "16px",
+        padding: "2rem",
+        boxShadow: "0 12px 28px rgba(15, 23, 42, 0.12)",
+        display: "flex",
+        flexDirection: "column",
+        gap: "2rem"
+      }}
+    >
+      <nav style={{ display: "flex", gap: "1rem" }}>
+        <Link
+          href="/"
+          style={{
+            padding: "0.5rem 1rem",
+            borderRadius: "999px",
+            backgroundColor: "#e0f2fe",
+            color: "#075985",
+            fontWeight: 600
+          }}
+        >
+          Главная
+        </Link>
+        <Link
+          href="/debts"
+          style={{
+            padding: "0.5rem 1rem",
+            borderRadius: "999px",
+            backgroundColor: "#e0e7ff",
+            color: "#3730a3",
+            fontWeight: 600
+          }}
+        >
+          Долги
+        </Link>
+      </nav>
+
+      <header style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+        <h1 style={{ fontSize: "2rem", fontWeight: 700 }}>Учёт долгов</h1>
+        <p style={{ color: "#4b5563" }}>
+          Сохраняйте, кто и кому должен, чтобы учитывать их в общем балансе.
+        </p>
+      </header>
+
+      <section style={{ display: "grid", gap: "1rem", gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))" }}>
+        <div
+          style={{
+            padding: "1rem 1.25rem",
+            borderRadius: "1rem",
+            backgroundColor: "#f5f3ff",
+            color: "#4c1d95"
+          }}
+        >
+          <p style={{ fontWeight: 600 }}>Влияют на баланс</p>
+          <p style={{ marginTop: "0.25rem" }}>
+            {balanceEffect.toLocaleString("ru-RU", {
+              style: "currency",
+              currency: "USD"
+            })}
+          </p>
+        </div>
+        <div
+          style={{
+            padding: "1rem 1.25rem",
+            borderRadius: "1rem",
+            backgroundColor: "#ecfdf5",
+            color: "#166534"
+          }}
+        >
+          <p style={{ fontWeight: 600 }}>Нам заняли</p>
+          <p style={{ marginTop: "0.25rem" }}>
+            {borrowed.toLocaleString("ru-RU", {
+              style: "currency",
+              currency: "USD"
+            })}
+          </p>
+        </div>
+        <div
+          style={{
+            padding: "1rem 1.25rem",
+            borderRadius: "1rem",
+            backgroundColor: "#fef2f2",
+            color: "#991b1b"
+          }}
+        >
+          <p style={{ fontWeight: 600 }}>Мы заняли другим</p>
+          <p style={{ marginTop: "0.25rem" }}>
+            {lent.toLocaleString("ru-RU", {
+              style: "currency",
+              currency: "USD"
+            })}
+          </p>
+        </div>
+      </section>
+
+      <section style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}>
+        <h2 style={{ fontSize: "1.5rem", fontWeight: 600 }}>Добавить долг</h2>
+        <form
+          onSubmit={handleSubmit}
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+            gap: "1rem"
+          }}
+        >
+          <label style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+            <span>Сумма</span>
+            <input
+              type="number"
+              min="0"
+              step="0.01"
+              value={amount}
+              onChange={(event) => setAmount(event.target.value)}
+              style={{
+                padding: "0.75rem 1rem",
+                borderRadius: "0.75rem",
+                border: "1px solid #d1d5db"
+              }}
+              required
+            />
+          </label>
+
+          <label style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+            <span>Тип</span>
+            <select
+              value={type}
+              onChange={(event) => {
+                const nextType = event.target.value as Debt["type"];
+                setType(nextType);
+                setFrom("");
+                setTo("");
+              }}
+              style={{
+                padding: "0.75rem 1rem",
+                borderRadius: "0.75rem",
+                border: "1px solid #d1d5db"
+              }}
+            >
+              <option value="borrowed">Нам заняли</option>
+              <option value="lent">Мы заняли</option>
+            </select>
+          </label>
+
+          {type === "borrowed" ? (
+            <label style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+              <span>От кого</span>
+              <input
+                type="text"
+                value={from}
+                onChange={(event) => setFrom(event.target.value)}
+                style={{
+                  padding: "0.75rem 1rem",
+                  borderRadius: "0.75rem",
+                  border: "1px solid #d1d5db"
+                }}
+                placeholder="Имя или организация"
+                required
+              />
+            </label>
+          ) : (
+            <label style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+              <span>Кому</span>
+              <input
+                type="text"
+                value={to}
+                onChange={(event) => setTo(event.target.value)}
+                style={{
+                  padding: "0.75rem 1rem",
+                  borderRadius: "0.75rem",
+                  border: "1px solid #d1d5db"
+                }}
+                placeholder="Имя или организация"
+                required
+              />
+            </label>
+          )}
+
+          <label style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+            <span>Комментарий</span>
+            <textarea
+              value={comment}
+              onChange={(event) => setComment(event.target.value)}
+              style={{
+                padding: "0.75rem 1rem",
+                borderRadius: "0.75rem",
+                border: "1px solid #d1d5db",
+                minHeight: "100px",
+                resize: "vertical"
+              }}
+              placeholder="Условия возврата, контакты и т.д."
+            />
+          </label>
+
+          <button
+            type="submit"
+            disabled={loading}
+            style={{
+              padding: "0.85rem 1.75rem",
+              borderRadius: "0.75rem",
+              border: "none",
+              backgroundColor: loading ? "#1d4ed8" : "#2563eb",
+              color: "#ffffff",
+              fontWeight: 600,
+              transition: "background-color 0.2s ease"
+            }}
+          >
+            {loading ? "Сохраняем..." : "Добавить"}
+          </button>
+        </form>
+        {error ? <p style={{ color: "#b91c1c" }}>{error}</p> : null}
+      </section>
+
+      <section style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+        <h2 style={{ fontSize: "1.5rem", fontWeight: 600 }}>Открытые долги</h2>
+        {debts.length === 0 ? (
+          <p style={{ color: "#6b7280" }}>Пока нет записей о долгах.</p>
+        ) : (
+          <ul style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+            {debts.map((debt) => (
+              <li
+                key={debt.id}
+                style={{
+                  padding: "1rem 1.25rem",
+                  borderRadius: "1rem",
+                  border: "1px solid #e5e7eb",
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                  backgroundColor: debt.type === "borrowed" ? "#f0fdf4" : "#fef2f2"
+                }}
+              >
+                <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem" }}>
+                  <p style={{ fontWeight: 600 }}>
+                    {debt.type === "borrowed" ? "Нам заняли" : "Мы заняли"} — {debt.amount.toLocaleString("ru-RU", {
+                      minimumFractionDigits: 2,
+                      maximumFractionDigits: 2
+                    })} USD
+                  </p>
+                  <p style={{ color: "#6b7280", fontSize: "0.9rem" }}>
+                    {new Date(debt.date).toLocaleString("ru-RU")}
+                  </p>
+                  <p style={{ color: "#4b5563" }}>
+                    {debt.type === "borrowed" ? `От кого: ${debt.from}` : `Кому: ${debt.to}`}
+                  </p>
+                  {debt.comment ? (
+                    <p style={{ color: "#4b5563" }}>{debt.comment}</p>
+                  ) : null}
+                </div>
+                <span
+                  style={{
+                    fontWeight: 600,
+                    color: debt.type === "borrowed" ? "#15803d" : "#b91c1c"
+                  }}
+                >
+                  {debt.type === "borrowed" ? "+" : "-"}
+                  {debt.amount.toLocaleString("ru-RU", {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2
+                  })}
+                  {" USD"}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+};
+
+export default DebtPage;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,25 +1,40 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useMemo, useState, type FormEvent } from "react";
-import type { Operation } from "@/lib/types";
+import type { Debt, Operation } from "@/lib/types";
 
 const Page = () => {
   const [operations, setOperations] = useState<Operation[]>([]);
   const [amount, setAmount] = useState<string>("");
   const [type, setType] = useState<Operation["type"]>("income");
+  const [debts, setDebts] = useState<Debt[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const loadOperations = async () => {
       try {
-        const response = await fetch("/api/operations");
-        if (!response.ok) {
+        const [operationsResponse, debtsResponse] = await Promise.all([
+          fetch("/api/operations"),
+          fetch("/api/debts")
+        ]);
+
+        if (!operationsResponse.ok) {
           throw new Error("Не удалось загрузить операции");
         }
 
-        const data = (await response.json()) as Operation[];
-        setOperations(data);
+        if (!debtsResponse.ok) {
+          throw new Error("Не удалось загрузить данные по долгам");
+        }
+
+        const [operationsData, debtsData] = await Promise.all([
+          operationsResponse.json() as Promise<Operation[]>,
+          debtsResponse.json() as Promise<Debt[]>
+        ]);
+
+        setOperations(operationsData);
+        setDebts(debtsData);
       } catch (err) {
         setError(err instanceof Error ? err.message : "Произошла ошибка");
       }
@@ -28,15 +43,44 @@ const Page = () => {
     void loadOperations();
   }, []);
 
-  const balance = useMemo(
+  const debtSummary = useMemo(
     () =>
-      operations.reduce((acc, operation) => {
-        return operation.type === "income"
-          ? acc + operation.amount
-          : acc - operation.amount;
-      }, 0),
-    [operations]
+      debts.reduce(
+        (acc, debt) => {
+          if (debt.status === "closed") {
+            return acc;
+          }
+
+          if (debt.type === "borrowed") {
+            return {
+              ...acc,
+              borrowed: acc.borrowed + debt.amount,
+              balanceEffect: acc.balanceEffect + debt.amount
+            };
+          }
+
+          return {
+            ...acc,
+            lent: acc.lent + debt.amount,
+            balanceEffect: acc.balanceEffect - debt.amount
+          };
+        },
+        { borrowed: 0, lent: 0, balanceEffect: 0 }
+      ),
+    [debts]
   );
+
+  const { borrowed, lent, balanceEffect } = debtSummary;
+
+  const balance = useMemo(() => {
+    const operationsBalance = operations.reduce((acc, operation) => {
+      return operation.type === "income"
+        ? acc + operation.amount
+        : acc - operation.amount;
+    }, 0);
+
+    return operationsBalance + balanceEffect;
+  }, [operations, balanceEffect]);
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -91,6 +135,33 @@ const Page = () => {
         gap: "2rem"
       }}
     >
+      <nav style={{ display: "flex", gap: "1rem" }}>
+        <Link
+          href="/"
+          style={{
+            padding: "0.5rem 1rem",
+            borderRadius: "999px",
+            backgroundColor: "#e0e7ff",
+            color: "#1d4ed8",
+            fontWeight: 600
+          }}
+        >
+          Главная
+        </Link>
+        <Link
+          href="/debts"
+          style={{
+            padding: "0.5rem 1rem",
+            borderRadius: "999px",
+            backgroundColor: "#eef2ff",
+            color: "#4338ca",
+            fontWeight: 600
+          }}
+        >
+          Долги
+        </Link>
+      </nav>
+
       <header style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
         <h1 style={{ fontSize: "2rem", fontWeight: 700 }}>Финансы храма — MVP</h1>
         <p style={{ color: "#4b5563" }}>
@@ -118,6 +189,63 @@ const Page = () => {
               currency: "USD"
             })}
           </strong>
+        </div>
+
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
+            gap: "1rem"
+          }}
+        >
+          <div
+            style={{
+              padding: "1rem 1.25rem",
+              borderRadius: "1rem",
+              backgroundColor: "#f5f3ff",
+              color: "#4c1d95"
+            }}
+          >
+            <p style={{ fontWeight: 600 }}>Долги в балансе</p>
+            <p style={{ marginTop: "0.25rem" }}>
+              Учтено: {balanceEffect.toLocaleString("ru-RU", {
+                style: "currency",
+                currency: "USD"
+              })}
+            </p>
+          </div>
+          <div
+            style={{
+              padding: "1rem 1.25rem",
+              borderRadius: "1rem",
+              backgroundColor: "#ecfdf5",
+              color: "#166534"
+            }}
+          >
+            <p style={{ fontWeight: 600 }}>Нам заняли</p>
+            <p style={{ marginTop: "0.25rem" }}>
+              {borrowed.toLocaleString("ru-RU", {
+                style: "currency",
+                currency: "USD"
+              })}
+            </p>
+          </div>
+          <div
+            style={{
+              padding: "1rem 1.25rem",
+              borderRadius: "1rem",
+              backgroundColor: "#fef2f2",
+              color: "#991b1b"
+            }}
+          >
+            <p style={{ fontWeight: 600 }}>Мы заняли другим</p>
+            <p style={{ marginTop: "0.25rem" }}>
+              {lent.toLocaleString("ru-RU", {
+                style: "currency",
+                currency: "USD"
+              })}
+            </p>
+          </div>
         </div>
 
         <form

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -70,7 +70,7 @@ const Page = () => {
     [debts]
   );
 
-  const { borrowed, lent, balanceEffect } = debtSummary;
+  const { balanceEffect } = debtSummary;
 
   const balance = useMemo(() => {
     const operationsBalance = operations.reduce((acc, operation) => {
@@ -189,63 +189,6 @@ const Page = () => {
               currency: "USD"
             })}
           </strong>
-        </div>
-
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
-            gap: "1rem"
-          }}
-        >
-          <div
-            style={{
-              padding: "1rem 1.25rem",
-              borderRadius: "1rem",
-              backgroundColor: "#f5f3ff",
-              color: "#4c1d95"
-            }}
-          >
-            <p style={{ fontWeight: 600 }}>Долги в балансе</p>
-            <p style={{ marginTop: "0.25rem" }}>
-              Учтено: {balanceEffect.toLocaleString("ru-RU", {
-                style: "currency",
-                currency: "USD"
-              })}
-            </p>
-          </div>
-          <div
-            style={{
-              padding: "1rem 1.25rem",
-              borderRadius: "1rem",
-              backgroundColor: "#ecfdf5",
-              color: "#166534"
-            }}
-          >
-            <p style={{ fontWeight: 600 }}>Нам заняли</p>
-            <p style={{ marginTop: "0.25rem" }}>
-              {borrowed.toLocaleString("ru-RU", {
-                style: "currency",
-                currency: "USD"
-              })}
-            </p>
-          </div>
-          <div
-            style={{
-              padding: "1rem 1.25rem",
-              borderRadius: "1rem",
-              backgroundColor: "#fef2f2",
-              color: "#991b1b"
-            }}
-          >
-            <p style={{ fontWeight: 600 }}>Мы заняли другим</p>
-            <p style={{ marginTop: "0.25rem" }}>
-              {lent.toLocaleString("ru-RU", {
-                style: "currency",
-                currency: "USD"
-              })}
-            </p>
-          </div>
         </div>
 
         <form

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -55,14 +55,14 @@ const Page = () => {
             return {
               ...acc,
               borrowed: acc.borrowed + debt.amount,
-              balanceEffect: acc.balanceEffect + debt.amount
+              balanceEffect: acc.balanceEffect - debt.amount
             };
           }
 
           return {
             ...acc,
             lent: acc.lent + debt.amount,
-            balanceEffect: acc.balanceEffect - debt.amount
+            balanceEffect: acc.balanceEffect + debt.amount
           };
         },
         { borrowed: 0, lent: 0, balanceEffect: 0 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -11,9 +11,13 @@ export type Operation = {
 
 export type Debt = {
   id: string;
+  type: "borrowed" | "lent";
   amount: number;
   status: "open" | "closed";
   date: string;
+  from?: string;
+  to?: string;
+  comment?: string;
 };
 
 export type Goal = {

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,11 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -16,8 +20,15 @@
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"]
-    }
+      "@/*": [
+        "./*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
   "include": [
     "next-env.d.ts",
@@ -25,5 +36,7 @@
     "**/*.tsx",
     ".next/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- extend debt domain model and API to support borrowed and lent debts with metadata
- add a dedicated debts management page with conditional fields for lender/recipient and comments
- surface debt impact on the main dashboard balance together with quick navigation links

## Testing
- npm run build
- npm run lint *(fails: ESLint package cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd2814e97c83318b5aa676f57b3969