### PR TITLE
Add operation categories and deletion support

### DIFF
--- a/app/api/operations/[id]/route.ts
+++ b/app/api/operations/[id]/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { db } from "@/lib/operationsStore";
+
+export const DELETE = (
+  _request: NextRequest,
+  { params }: { params: { id: string } }
+) => {
+  const { id } = params;
+  const index = db.operations.findIndex((operation) => operation.id === id);
+
+  if (index === -1) {
+    return NextResponse.json({ error: "Operation not found" }, { status: 404 });
+  }
+
+  const [deleted] = db.operations.splice(index, 1);
+
+  return NextResponse.json(deleted);
+};

--- a/app/api/operations/route.ts
+++ b/app/api/operations/route.ts
@@ -24,12 +24,17 @@ export const POST = async (request: NextRequest) => {
     return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
   }
 
+  const sanitizedCategory =
+    typeof payload.category === "string" && payload.category.trim().length > 0
+      ? payload.category.trim()
+      : "прочее";
+
   const operation: Operation = {
     id: crypto.randomUUID(),
     type: payload.type,
     amount: payload.amount,
     currency: payload.currency ?? "USD",
-    category: payload.category ?? "general",
+    category: sanitizedCategory,
     comment: payload.comment,
     source: payload.source,
     date: new Date().toISOString()

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -168,238 +168,293 @@ const Page = () => {
   };
 
   return (
-    <main
+    <div
       style={{
-        width: "min(720px, 100%)",
-        backgroundColor: "#ffffff",
-        borderRadius: "16px",
-        padding: "2rem",
-        boxShadow: "0 12px 28px rgba(15, 23, 42, 0.12)",
+        minHeight: "100vh",
+        backgroundColor: "#e2e8f0",
+        padding: "3rem 1.5rem",
         display: "flex",
-        flexDirection: "column",
-        gap: "2rem"
+        justifyContent: "center",
+        alignItems: "flex-start"
       }}
     >
-      <nav style={{ display: "flex", gap: "1rem" }}>
-        <Link
-          href="/"
-          style={{
-            padding: "0.5rem 1rem",
-            borderRadius: "999px",
-            backgroundColor: "#e0e7ff",
-            color: "#1d4ed8",
-            fontWeight: 600
-          }}
-        >
-          Главная
-        </Link>
-        <Link
-          href="/debts"
-          style={{
-            padding: "0.5rem 1rem",
-            borderRadius: "999px",
-            backgroundColor: "#eef2ff",
-            color: "#4338ca",
-            fontWeight: 600
-          }}
-        >
-          Долги
-        </Link>
-      </nav>
-
-      <header style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
-        <h1 style={{ fontSize: "2rem", fontWeight: 700 }}>Финансы храма — MVP</h1>
-        <p style={{ color: "#4b5563" }}>
-          Отслеживайте приход и расход средств, чтобы понимать финансовый баланс общины.
-        </p>
-      </header>
-
-      <section style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}>
-        <div
+      <main
+        style={{
+          width: "100%",
+          maxWidth: "880px",
+          backgroundColor: "#ffffff",
+          borderRadius: "20px",
+          padding: "2.5rem 2.75rem",
+          boxShadow: "0 20px 45px rgba(15, 23, 42, 0.12)",
+          display: "flex",
+          flexDirection: "column",
+          gap: "2.5rem"
+        }}
+      >
+        <nav
           style={{
             display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center"
-          }}
-        >
-          <h2 style={{ fontSize: "1.5rem", fontWeight: 600 }}>Текущий баланс</h2>
-          <strong
-            style={{
-              fontSize: "1.75rem",
-              color: balance >= 0 ? "#15803d" : "#b91c1c"
-            }}
-          >
-            {balance.toLocaleString("ru-RU", {
-              style: "currency",
-              currency: "USD"
-            })}
-          </strong>
-        </div>
-
-        <form
-          onSubmit={handleSubmit}
-          style={{
-            display: "grid",
-            gridTemplateColumns: "2fr 1fr 1.5fr auto",
+            alignItems: "center",
+            justifyContent: "flex-start",
             gap: "1rem",
-            alignItems: "end"
+            flexWrap: "wrap"
           }}
         >
-          <label style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
-            <span>Сумма</span>
-            <input
-              type="number"
-              min="0"
-              step="0.01"
-              value={amount}
-              onChange={(event) => setAmount(event.target.value)}
-              style={{
-                padding: "0.75rem 1rem",
-                borderRadius: "0.75rem",
-                border: "1px solid #d1d5db"
-              }}
-              required
-            />
-          </label>
-
-          <label style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
-            <span>Тип</span>
-            <select
-              value={type}
-              onChange={(event) => {
-                const newType = event.target.value as Operation["type"];
-                setType(newType);
-                setCategory(
-                  (newType === "income" ? INCOME_CATEGORIES : EXPENSE_CATEGORIES)[0]
-                );
-              }}
-              style={{
-                padding: "0.75rem 1rem",
-                borderRadius: "0.75rem",
-                border: "1px solid #d1d5db"
-              }}
-            >
-              <option value="income">Приход</option>
-              <option value="expense">Расход</option>
-            </select>
-          </label>
-
-          <label style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
-            <span>Категория</span>
-            <select
-              value={category}
-              onChange={(event) => setCategory(event.target.value)}
-              style={{
-                padding: "0.75rem 1rem",
-                borderRadius: "0.75rem",
-                border: "1px solid #d1d5db"
-              }}
-            >
-              {(type === "income" ? INCOME_CATEGORIES : EXPENSE_CATEGORIES).map(
-                (item) => (
-                  <option key={item} value={item}>
-                    {item}
-                  </option>
-                )
-              )}
-            </select>
-          </label>
-
-          <button
-            type="submit"
-            disabled={loading}
+          <Link
+            href="/"
             style={{
-              padding: "0.85rem 1.75rem",
-              borderRadius: "0.75rem",
-              border: "none",
-              backgroundColor: loading ? "#1d4ed8" : "#2563eb",
-              color: "#ffffff",
+              padding: "0.6rem 1.4rem",
+              borderRadius: "999px",
+              backgroundColor: "#e0e7ff",
+              color: "#1d4ed8",
               fontWeight: 600,
-              transition: "background-color 0.2s ease"
+              boxShadow: "0 4px 12px rgba(59, 130, 246, 0.25)"
             }}
           >
-            {loading ? "Добавляем..." : "Добавить"}
-          </button>
-        </form>
+            Главная
+          </Link>
+          <Link
+            href="/debts"
+            style={{
+              padding: "0.6rem 1.4rem",
+              borderRadius: "999px",
+              backgroundColor: "#eef2ff",
+              color: "#4338ca",
+              fontWeight: 600,
+              boxShadow: "0 4px 12px rgba(99, 102, 241, 0.2)"
+            }}
+          >
+            Долги
+          </Link>
+        </nav>
 
-        {error ? <p style={{ color: "#b91c1c" }}>{error}</p> : null}
-      </section>
+        <header
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "0.75rem"
+          }}
+        >
+          <h1 style={{ fontSize: "2.25rem", fontWeight: 700 }}>
+            Финансы храма — MVP
+          </h1>
+          <p style={{ color: "#475569", lineHeight: 1.6 }}>
+            Отслеживайте приход и расход средств, чтобы понимать финансовый баланс общины.
+          </p>
+        </header>
 
-      <section style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
-        <h2 style={{ fontSize: "1.5rem", fontWeight: 600 }}>Последние операции</h2>
-        {operations.length === 0 ? (
-          <p style={{ color: "#6b7280" }}>Пока нет данных — добавьте первую операцию.</p>
-        ) : (
-          <ul style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
-            {operations.map((operation) => (
-              <li
-                key={operation.id}
+        <section style={{ display: "flex", flexDirection: "column", gap: "1.75rem" }}>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              flexWrap: "wrap",
+              gap: "1rem"
+            }}
+          >
+            <h2 style={{ fontSize: "1.5rem", fontWeight: 600, color: "#0f172a" }}>
+              Текущий баланс
+            </h2>
+            <strong
+              style={{
+                fontSize: "1.75rem",
+                color: balance >= 0 ? "#15803d" : "#b91c1c"
+              }}
+            >
+              {balance.toLocaleString("ru-RU", {
+                style: "currency",
+                currency: "USD"
+              })}
+            </strong>
+          </div>
+
+          <form
+            onSubmit={handleSubmit}
+            style={{
+              display: "grid",
+              gap: "1rem",
+              gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))",
+              alignItems: "end"
+            }}
+          >
+            <label style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+              <span>Сумма</span>
+              <input
+                type="number"
+                min="0"
+                step="0.01"
+                value={amount}
+                onChange={(event) => setAmount(event.target.value)}
                 style={{
-                  padding: "1rem 1.25rem",
-                  borderRadius: "1rem",
-                  border: "1px solid #e5e7eb",
-                  display: "flex",
-                  justifyContent: "space-between",
-                  alignItems: "center",
-                  gap: "1rem",
-                  backgroundColor: "#f9fafb"
+                  padding: "0.75rem 1rem",
+                  borderRadius: "0.75rem",
+                  border: "1px solid #d1d5db"
+                }}
+                required
+              />
+            </label>
+
+            <label style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+              <span>Тип</span>
+              <select
+                value={type}
+                onChange={(event) => {
+                  const newType = event.target.value as Operation["type"];
+                  setType(newType);
+                  setCategory(
+                    (newType === "income" ? INCOME_CATEGORIES : EXPENSE_CATEGORIES)[0]
+                  );
+                }}
+                style={{
+                  padding: "0.75rem 1rem",
+                  borderRadius: "0.75rem",
+                  border: "1px solid #d1d5db"
                 }}
               >
-                <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem" }}>
-                  <p style={{ fontWeight: 600 }}>
-                    {operation.type === "income" ? "Приход" : "Расход"} — {operation.category}
-                  </p>
-                  <p style={{ color: "#6b7280", fontSize: "0.9rem" }}>
-                    {new Date(operation.date).toLocaleString("ru-RU")}
-                  </p>
-                  {operation.comment ? (
-                    <p style={{ color: "#4b5563" }}>{operation.comment}</p>
-                  ) : null}
-                </div>
-                <div
+                <option value="income">Приход</option>
+                <option value="expense">Расход</option>
+              </select>
+            </label>
+
+            <label style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+              <span>Категория</span>
+              <select
+                value={category}
+                onChange={(event) => setCategory(event.target.value)}
+                style={{
+                  padding: "0.75rem 1rem",
+                  borderRadius: "0.75rem",
+                  border: "1px solid #d1d5db"
+                }}
+              >
+                {(type === "income" ? INCOME_CATEGORIES : EXPENSE_CATEGORIES).map(
+                  (item) => (
+                    <option key={item} value={item}>
+                      {item}
+                    </option>
+                  )
+                )}
+              </select>
+            </label>
+
+            <button
+              type="submit"
+              disabled={loading}
+              style={{
+                padding: "0.95rem 1.5rem",
+                borderRadius: "0.75rem",
+                border: "none",
+                backgroundColor: loading ? "#1d4ed8" : "#2563eb",
+                color: "#ffffff",
+                fontWeight: 600,
+                transition: "background-color 0.2s ease",
+                boxShadow: "0 10px 20px rgba(37, 99, 235, 0.25)",
+                width: "100%"
+              }}
+            >
+              {loading ? "Добавляем..." : "Добавить"}
+            </button>
+          </form>
+
+          {error ? <p style={{ color: "#b91c1c" }}>{error}</p> : null}
+        </section>
+
+        <section style={{ display: "flex", flexDirection: "column", gap: "1.25rem" }}>
+          <h2 style={{ fontSize: "1.5rem", fontWeight: 600, color: "#0f172a" }}>
+            Последние операции
+          </h2>
+          {operations.length === 0 ? (
+            <p style={{ color: "#64748b" }}>
+              Пока нет данных — добавьте первую операцию.
+            </p>
+          ) : (
+            <ul style={{ display: "flex", flexDirection: "column", gap: "0.85rem" }}>
+              {operations.map((operation) => (
+                <li
+                  key={operation.id}
                   style={{
+                    padding: "1.1rem 1.35rem",
+                    borderRadius: "1rem",
+                    border: "1px solid #e2e8f0",
                     display: "flex",
-                    alignItems: "center",
-                    gap: "0.75rem"
+                    justifyContent: "space-between",
+                    alignItems: "flex-start",
+                    gap: "1.25rem",
+                    backgroundColor: "#f8fafc",
+                    boxShadow: "0 12px 24px rgba(15, 23, 42, 0.08)",
+                    flexWrap: "wrap"
                   }}
                 >
-                  <span
+                  <div
                     style={{
-                      fontWeight: 600,
-                      color: operation.type === "income" ? "#15803d" : "#b91c1c"
+                      display: "flex",
+                      flexDirection: "column",
+                      gap: "0.35rem",
+                      minWidth: "220px"
                     }}
                   >
-                    {`${operation.type === "income" ? "+" : "-"}${operation.amount.toLocaleString(
-                      "ru-RU",
-                      {
-                        minimumFractionDigits: 2,
-                        maximumFractionDigits: 2
-                      }
-                    )} ${operation.currency}`}
-                  </span>
-                  <button
-                    type="button"
-                    onClick={() => handleDelete(operation.id)}
-                    disabled={deletingId === operation.id}
+                    <p style={{ fontWeight: 600, color: "#0f172a" }}>
+                      {operation.type === "income" ? "Приход" : "Расход"} — {operation.category}
+                    </p>
+                    <p style={{ color: "#64748b", fontSize: "0.9rem" }}>
+                      {new Date(operation.date).toLocaleString("ru-RU")}
+                    </p>
+                    {operation.comment ? (
+                      <p style={{ color: "#475569", lineHeight: 1.5 }}>{operation.comment}</p>
+                    ) : null}
+                  </div>
+                  <div
                     style={{
-                      padding: "0.5rem 0.75rem",
-                      borderRadius: "0.75rem",
-                      border: "1px solid #ef4444",
-                      backgroundColor: deletingId === operation.id ? "#fca5a5" : "#fee2e2",
-                      color: "#b91c1c",
-                      fontWeight: 600,
-                      cursor: deletingId === operation.id ? "not-allowed" : "pointer"
+                      display: "flex",
+                      flexDirection: "column",
+                      alignItems: "flex-end",
+                      gap: "0.65rem",
+                      minWidth: "140px"
                     }}
                   >
-                    {deletingId === operation.id ? "Удаляем..." : "Удалить"}
-                  </button>
-                </div>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
-    </main>
+                    <span
+                      style={{
+                        fontWeight: 700,
+                        color: operation.type === "income" ? "#15803d" : "#b91c1c",
+                        fontSize: "1.1rem"
+                      }}
+                    >
+                      {`${operation.type === "income" ? "+" : "-"}${operation.amount.toLocaleString(
+                        "ru-RU",
+                        {
+                          minimumFractionDigits: 2,
+                          maximumFractionDigits: 2
+                        }
+                      )} ${operation.currency}`}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(operation.id)}
+                      disabled={deletingId === operation.id}
+                      style={{
+                        padding: "0.55rem 0.95rem",
+                        borderRadius: "0.75rem",
+                        border: "1px solid #ef4444",
+                        backgroundColor: deletingId === operation.id ? "#fecaca" : "#fee2e2",
+                        color: "#b91c1c",
+                        fontWeight: 600,
+                        cursor: deletingId === operation.id ? "not-allowed" : "pointer",
+                        transition: "background-color 0.2s ease, transform 0.2s ease",
+                        boxShadow: "0 10px 18px rgba(239, 68, 68, 0.15)",
+                        width: "100%"
+                      }}
+                    >
+                      {deletingId === operation.id ? "Удаляем..." : "Удалить"}
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </main>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- add predefined income and expense categories to the finance form and display
- allow deleting operations from the UI via a dedicated control
- sanitize incoming categories on the operations API and expose a DELETE handler

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68cd2fc55928833180703c1695e22108