### PR TITLE
feat: allow deleting goals

### DIFF
--- a/app/api/goals/[id]/route.ts
+++ b/app/api/goals/[id]/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { db } from "@/lib/operationsStore";
+
+export const DELETE = (
+  _request: NextRequest,
+  { params }: { params: { id: string } }
+) => {
+  const { id } = params;
+  const goalIndex = db.goals.findIndex((goal) => goal.id === id);
+
+  if (goalIndex === -1) {
+    return NextResponse.json({ error: "Goal not found" }, { status: 404 });
+  }
+
+  const [deletedGoal] = db.goals.splice(goalIndex, 1);
+  let removedOperationsCount = 0;
+  const goalTitle = deletedGoal.title.trim().toLowerCase();
+
+  for (let index = db.operations.length - 1; index >= 0; index -= 1) {
+    const operation = db.operations[index];
+    const operationCategory = operation.category.trim().toLowerCase();
+
+    if (operationCategory === goalTitle) {
+      removedOperationsCount += 1;
+      db.operations.splice(index, 1);
+    }
+  }
+
+  return NextResponse.json({
+    goal: deletedGoal,
+    removedOperationsCount
+  });
+};

--- a/app/planning/page.tsx
+++ b/app/planning/page.tsx
@@ -9,6 +9,7 @@ const PlanningPage = () => {
   const [title, setTitle] = useState<string>("");
   const [targetAmount, setTargetAmount] = useState<string>("");
   const [loading, setLoading] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const loadGoals = useCallback(async () => {
@@ -89,6 +90,29 @@ const PlanningPage = () => {
       setError(err instanceof Error ? err.message : "Произошла ошибка");
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleDelete = async (goalId: string) => {
+    setError(null);
+    setDeletingId(goalId);
+
+    try {
+      const response = await fetch(`/api/goals/${goalId}`, { method: "DELETE" });
+
+      if (response.status === 404) {
+        throw new Error("Цель не найдена");
+      }
+
+      if (!response.ok) {
+        throw new Error("Не удалось удалить цель");
+      }
+
+      setGoals((prev) => prev.filter((goal) => goal.id !== goalId));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Произошла ошибка");
+    } finally {
+      setDeletingId(null);
     }
   };
 
@@ -319,29 +343,66 @@ const PlanningPage = () => {
                       gap: "0.75rem"
                     }}
                   >
-                    <div style={{ display: "flex", justifyContent: "space-between", gap: "1rem" }}>
-                      <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
-                        <h3 style={{ fontSize: "1.25rem", fontWeight: 600, color: "#0f172a" }}>
-                          {goal.title}
-                        </h3>
-                        <span style={{ color: "#475569", fontSize: "0.95rem" }}>
-                          {goal.status === "done" ? "Цель достигнута" : "В процессе"}
-                        </span>
+                    <div
+                      style={{
+                        display: "flex",
+                        justifyContent: "space-between",
+                        gap: "1rem",
+                        alignItems: "flex-start",
+                        flexWrap: "wrap"
+                      }}
+                    >
+                      <div
+                        style={{
+                          display: "flex",
+                          justifyContent: "space-between",
+                          gap: "1rem",
+                          flex: "1 1 240px"
+                        }}
+                      >
+                        <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
+                          <h3 style={{ fontSize: "1.25rem", fontWeight: 600, color: "#0f172a" }}>
+                            {goal.title}
+                          </h3>
+                          <span style={{ color: "#475569", fontSize: "0.95rem" }}>
+                            {goal.status === "done" ? "Цель достигнута" : "В процессе"}
+                          </span>
+                        </div>
+                        <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end" }}>
+                          <strong style={{ color: "#047857" }}>
+                            {goal.currentAmount.toLocaleString("ru-RU", {
+                              style: "currency",
+                              currency: "USD"
+                            })}
+                          </strong>
+                          <span style={{ color: "#64748b", fontSize: "0.9rem" }}>
+                            из {goal.targetAmount.toLocaleString("ru-RU", {
+                              style: "currency",
+                              currency: "USD"
+                            })}
+                          </span>
+                        </div>
                       </div>
-                      <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end" }}>
-                        <strong style={{ color: "#047857" }}>
-                          {goal.currentAmount.toLocaleString("ru-RU", {
-                            style: "currency",
-                            currency: "USD"
-                          })}
-                        </strong>
-                        <span style={{ color: "#64748b", fontSize: "0.9rem" }}>
-                          из {goal.targetAmount.toLocaleString("ru-RU", {
-                            style: "currency",
-                            currency: "USD"
-                          })}
-                        </span>
-                      </div>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          void handleDelete(goal.id);
+                        }}
+                        disabled={deletingId === goal.id}
+                        style={{
+                          padding: "0.5rem 0.9rem",
+                          borderRadius: "0.75rem",
+                          border: "none",
+                          backgroundColor: "#f87171",
+                          color: "#ffffff",
+                          fontWeight: 600,
+                          boxShadow: "0 6px 18px rgba(248, 113, 113, 0.35)",
+                          cursor: deletingId === goal.id ? "not-allowed" : "pointer",
+                          transition: "opacity 0.2s ease"
+                        }}
+                      >
+                        {deletingId === goal.id ? "Удаляем..." : "Удалить"}
+                      </button>
                     </div>
                     <div
                       style={{


### PR DESCRIPTION
## Summary
- add an API endpoint to remove a goal together with all operations categorized by its title
- extend the planning page to expose a delete action and keep UI state in sync

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cd38559fa883319981bf63e8c460f6