### PR TITLE
Add currency support fields and initial rates storage

### DIFF
--- a/app/api/debts/route.ts
+++ b/app/api/debts/route.ts
@@ -1,10 +1,14 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { db } from "@/lib/operationsStore";
-import type { Debt } from "@/lib/types";
+import { SUPPORTED_CURRENCIES, type Currency, type Debt } from "@/lib/types";
+
+const isSupportedCurrency = (value: unknown): value is Currency =>
+  typeof value === "string" && SUPPORTED_CURRENCIES.includes(value as Currency);
 
 type DebtInput = {
   type?: Debt["type"];
   amount?: number;
+  currency?: Currency;
   from?: string;
   to?: string;
   comment?: string;
@@ -31,10 +35,13 @@ export const POST = async (request: NextRequest) => {
     return NextResponse.json({ error: "Debt requires a recipient" }, { status: 400 });
   }
 
+  const debtCurrency = isSupportedCurrency(payload.currency) ? payload.currency : "USD";
+
   const debt: Debt = {
     id: crypto.randomUUID(),
     type: payload.type,
     amount: payload.amount,
+    currency: debtCurrency,
     status: "open",
     date: new Date().toISOString(),
     from: payload.type === "borrowed" ? payload.from : undefined,

--- a/app/api/goals/route.ts
+++ b/app/api/goals/route.ts
@@ -1,13 +1,17 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { db } from "@/lib/operationsStore";
-import type { Goal } from "@/lib/types";
+import { SUPPORTED_CURRENCIES, type Currency, type Goal } from "@/lib/types";
 
 type GoalInput = {
   title: string;
   targetAmount: number;
+  currency?: Currency;
 };
 
 const normalizeTitle = (title: string) => title.trim();
+
+const isSupportedCurrency = (value: unknown): value is Currency =>
+  typeof value === "string" && SUPPORTED_CURRENCIES.includes(value as Currency);
 
 export const GET = () => NextResponse.json(db.goals);
 
@@ -35,11 +39,14 @@ export const POST = async (request: NextRequest) => {
     return NextResponse.json({ error: "Цель с таким названием уже существует" }, { status: 409 });
   }
 
+  const currency = isSupportedCurrency(payload.currency) ? payload.currency : "USD";
+
   const goal: Goal = {
     id: crypto.randomUUID(),
     title,
     targetAmount: amount,
     currentAmount: 0,
+    currency,
     status: "active"
   };
 

--- a/app/api/operations/[id]/route.ts
+++ b/app/api/operations/[id]/route.ts
@@ -19,7 +19,7 @@ export const DELETE = (
       (goal) => goal.title.toLowerCase() === deleted.category.toLowerCase()
     );
 
-    if (matchedGoal) {
+    if (matchedGoal && matchedGoal.currency === deleted.currency) {
       matchedGoal.currentAmount = Math.max(matchedGoal.currentAmount - deleted.amount, 0);
 
       if (matchedGoal.currentAmount < matchedGoal.targetAmount) {

--- a/lib/operationsStore.ts
+++ b/lib/operationsStore.ts
@@ -1,14 +1,23 @@
-import type { Debt, Goal, Operation, User } from "@/lib/types";
+import { SUPPORTED_CURRENCIES, type Debt, type Goal, type Operation, type Rate, type User } from "@/lib/types";
+
+const createInitialRates = (): Rate[] =>
+  SUPPORTED_CURRENCIES.map((currency) => ({
+    currency,
+    rate: 1,
+    updatedAt: new Date().toISOString()
+  }));
 
 export const db: {
   operations: Operation[];
   debts: Debt[];
   goals: Goal[];
+  rates: Rate[];
   users: User[];
 } = {
   operations: [],
   debts: [],
   goals: [],
+  rates: createInitialRates(),
   users: [
     { id: "1", role: "admin", login: "admin", password: "admin123" },
     { id: "2", role: "accountant", login: "buh", password: "buh123" },

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,8 +1,12 @@
+export const SUPPORTED_CURRENCIES = ["USD", "RUB", "EUR", "GEL"] as const;
+
+export type Currency = (typeof SUPPORTED_CURRENCIES)[number];
+
 export type Operation = {
   id: string;
   type: "income" | "expense";
   amount: number;
-  currency: string;
+  currency: Currency;
   category: string;
   comment?: string;
   source?: string;
@@ -13,6 +17,7 @@ export type Debt = {
   id: string;
   type: "borrowed" | "lent";
   amount: number;
+  currency: Currency;
   status: "open" | "closed";
   date: string;
   from?: string;
@@ -25,7 +30,14 @@ export type Goal = {
   title: string;
   targetAmount: number;
   currentAmount: number;
+  currency: Currency;
   status: "active" | "done";
+};
+
+export type Rate = {
+  currency: Currency;
+  rate: number;
+  updatedAt: string;
 };
 
 export type User = {


### PR DESCRIPTION
## Summary
- define supported currencies and expand domain types to capture currency metadata
- seed in-memory storage with default currency rates
- allow API endpoints for operations, debts, and goals to accept validated currency codes while keeping goal progress consistent

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cd460ddfa483319042ff78e2c81da3