### PR TITLE
Add multi-currency support with settings

### DIFF
--- a/app/api/debts/route.ts
+++ b/app/api/debts/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server";
+import { sanitizeCurrency } from "@/lib/currency";
 import { db } from "@/lib/operationsStore";
 import type { Debt } from "@/lib/types";
 
@@ -8,6 +9,7 @@ type DebtInput = {
   from?: string;
   to?: string;
   comment?: string;
+  currency?: Debt["currency"];
 };
 
 export const GET = () => NextResponse.json(db.debts);
@@ -31,10 +33,13 @@ export const POST = async (request: NextRequest) => {
     return NextResponse.json({ error: "Debt requires a recipient" }, { status: 400 });
   }
 
+  const currency = sanitizeCurrency(payload.currency, db.settings.baseCurrency);
+
   const debt: Debt = {
     id: crypto.randomUUID(),
     type: payload.type,
     amount: payload.amount,
+    currency,
     status: "open",
     date: new Date().toISOString(),
     from: payload.type === "borrowed" ? payload.from : undefined,

--- a/app/api/goals/[id]/route.ts
+++ b/app/api/goals/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { db } from "@/lib/operationsStore";
+import { db, recalculateGoalProgress } from "@/lib/operationsStore";
 
 export const DELETE = (
   _request: NextRequest,
@@ -25,6 +25,8 @@ export const DELETE = (
       db.operations.splice(index, 1);
     }
   }
+
+  recalculateGoalProgress();
 
   return NextResponse.json({
     goal: deletedGoal,

--- a/app/api/operations/[id]/route.ts
+++ b/app/api/operations/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { db } from "@/lib/operationsStore";
+import { db, recalculateGoalProgress } from "@/lib/operationsStore";
 
 export const DELETE = (
   _request: NextRequest,
@@ -14,19 +14,7 @@ export const DELETE = (
 
   const [deleted] = db.operations.splice(index, 1);
 
-  if (deleted.type === "expense") {
-    const matchedGoal = db.goals.find(
-      (goal) => goal.title.toLowerCase() === deleted.category.toLowerCase()
-    );
-
-    if (matchedGoal) {
-      matchedGoal.currentAmount = Math.max(matchedGoal.currentAmount - deleted.amount, 0);
-
-      if (matchedGoal.currentAmount < matchedGoal.targetAmount) {
-        matchedGoal.status = "active";
-      }
-    }
-  }
+  recalculateGoalProgress();
 
   return NextResponse.json(deleted);
 };

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { SUPPORTED_CURRENCIES, DEFAULT_SETTINGS } from "@/lib/currency";
+import { db, recalculateGoalProgress } from "@/lib/operationsStore";
+import type { Currency, Settings } from "@/lib/types";
+
+type SettingsPayload = {
+  rates?: Partial<Record<Currency, number>>;
+};
+
+export const GET = () => NextResponse.json(db.settings ?? DEFAULT_SETTINGS);
+
+export const PATCH = async (request: NextRequest) => {
+  const payload = (await request.json()) as SettingsPayload | null;
+
+  if (!payload || typeof payload !== "object" || !payload.rates) {
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+  }
+
+  const updatedRates: Settings["rates"] = { ...db.settings.rates };
+
+  for (const currency of SUPPORTED_CURRENCIES) {
+    if (currency === db.settings.baseCurrency) {
+      updatedRates[currency] = 1;
+      continue;
+    }
+
+    const rawRate = payload.rates[currency];
+
+    if (rawRate === undefined) {
+      continue;
+    }
+
+    const numericRate = typeof rawRate === "number" ? rawRate : Number(rawRate);
+
+    if (!Number.isFinite(numericRate) || numericRate <= 0) {
+      return NextResponse.json(
+        {
+          error: `Invalid rate for ${currency}`
+        },
+        { status: 400 }
+      );
+    }
+
+    updatedRates[currency] = numericRate;
+  }
+
+  db.settings.rates = updatedRates;
+  recalculateGoalProgress();
+
+  return NextResponse.json(db.settings);
+};

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,297 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { DEFAULT_SETTINGS, SUPPORTED_CURRENCIES } from "@/lib/currency";
+import type { Currency, Settings } from "@/lib/types";
+
+const buildRatesState = (settings: Settings) =>
+  SUPPORTED_CURRENCIES.reduce<Record<Currency, string>>((acc, code) => {
+    acc[code] = settings.rates[code]?.toString() ?? "1";
+    return acc;
+  }, {} as Record<Currency, string>);
+
+const SettingsPage = () => {
+  const [settings, setSettings] = useState<Settings>(DEFAULT_SETTINGS);
+  const [rates, setRates] = useState<Record<Currency, string>>(() =>
+    buildRatesState(DEFAULT_SETTINGS)
+  );
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadSettings = async () => {
+      try {
+        const response = await fetch("/api/settings");
+
+        if (!response.ok) {
+          throw new Error("Не удалось загрузить настройки");
+        }
+
+        const data = (await response.json()) as Settings;
+        setSettings(data);
+        setRates(buildRatesState(data));
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Произошла ошибка");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    void loadSettings();
+  }, []);
+
+  const baseCurrency = settings.baseCurrency;
+  const baseFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat("ru-RU", {
+        style: "currency",
+        currency: baseCurrency
+      }),
+    [baseCurrency]
+  );
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setMessage(null);
+    setSaving(true);
+
+    const payloadRates: Partial<Record<Currency, number>> = {};
+
+    for (const currency of SUPPORTED_CURRENCIES) {
+      if (currency === baseCurrency) {
+        continue;
+      }
+
+      const value = rates[currency];
+      const numeric = Number(value);
+
+      if (!Number.isFinite(numeric) || numeric <= 0) {
+        setError(`Введите положительный курс для ${currency}`);
+        setSaving(false);
+        return;
+      }
+
+      payloadRates[currency] = numeric;
+    }
+
+    try {
+      const response = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({ rates: payloadRates })
+      });
+
+      if (!response.ok) {
+        const data = (await response.json().catch(() => null)) as
+          | { error?: string }
+          | null;
+        throw new Error(data?.error ?? "Не удалось сохранить настройки");
+      }
+
+      const updated = (await response.json()) as Settings;
+      setSettings(updated);
+      setRates(buildRatesState(updated));
+      setMessage("Курсы успешно обновлены");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Произошла ошибка");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        backgroundColor: "#ede9fe",
+        padding: "3rem 1.5rem",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "flex-start"
+      }}
+    >
+      <main
+        style={{
+          width: "100%",
+          maxWidth: "820px",
+          backgroundColor: "#ffffff",
+          borderRadius: "20px",
+          padding: "2.5rem 2.75rem",
+          boxShadow: "0 20px 45px rgba(109, 40, 217, 0.15)",
+          display: "flex",
+          flexDirection: "column",
+          gap: "2.25rem"
+        }}
+      >
+        <nav
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "flex-start",
+            gap: "1rem",
+            flexWrap: "wrap"
+          }}
+        >
+          <Link
+            href="/"
+            style={{
+              padding: "0.6rem 1.4rem",
+              borderRadius: "999px",
+              backgroundColor: "#e0e7ff",
+              color: "#1d4ed8",
+              fontWeight: 600,
+              boxShadow: "0 4px 12px rgba(59, 130, 246, 0.25)"
+            }}
+          >
+            Главная
+          </Link>
+          <Link
+            href="/debts"
+            style={{
+              padding: "0.6rem 1.4rem",
+              borderRadius: "999px",
+              backgroundColor: "#eef2ff",
+              color: "#4338ca",
+              fontWeight: 600,
+              boxShadow: "0 4px 12px rgba(99, 102, 241, 0.2)"
+            }}
+          >
+            Долги
+          </Link>
+          <Link
+            href="/planning"
+            style={{
+              padding: "0.6rem 1.4rem",
+              borderRadius: "999px",
+              backgroundColor: "#dcfce7",
+              color: "#15803d",
+              fontWeight: 600,
+              boxShadow: "0 4px 12px rgba(34, 197, 94, 0.2)"
+            }}
+          >
+            Планирование
+          </Link>
+          <Link
+            href="/reports"
+            style={{
+              padding: "0.6rem 1.4rem",
+              borderRadius: "999px",
+              backgroundColor: "#fef3c7",
+              color: "#b45309",
+              fontWeight: 600,
+              boxShadow: "0 4px 12px rgba(217, 119, 6, 0.2)"
+            }}
+          >
+            Отчёты
+          </Link>
+          <Link
+            href="/settings"
+            style={{
+              padding: "0.6rem 1.4rem",
+              borderRadius: "999px",
+              backgroundColor: "#ede9fe",
+              color: "#6d28d9",
+              fontWeight: 600,
+              boxShadow: "0 4px 12px rgba(109, 40, 217, 0.2)"
+            }}
+          >
+            Настройки
+          </Link>
+        </nav>
+
+        <header style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+          <h1 style={{ fontSize: "2.25rem", fontWeight: 700 }}>
+            Настройки валют и курсов обмена
+          </h1>
+          <p style={{ color: "#475569", lineHeight: 1.6 }}>
+            Базовая валюта системы — {baseCurrency}. Все расчёты выполняются с учётом
+            указанных ниже курсов.
+          </p>
+        </header>
+
+        {loading ? (
+          <p style={{ color: "#6b7280" }}>Загружаем текущие настройки...</p>
+        ) : (
+          <section style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}>
+            <form
+              onSubmit={handleSubmit}
+              style={{
+                display: "grid",
+                gap: "1rem",
+                gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))"
+              }}
+            >
+              {SUPPORTED_CURRENCIES.map((code) => {
+                const isBase = code === baseCurrency;
+
+                return (
+                  <label
+                    key={code}
+                    style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}
+                  >
+                    <span style={{ fontWeight: 600, color: "#4c1d95" }}>
+                      1 {code} = {isBase ? "1" : rates[code] ?? ""} {baseCurrency}
+                    </span>
+                    <input
+                      type="number"
+                      min="0"
+                      step="0.0001"
+                      value={isBase ? "1" : rates[code] ?? ""}
+                      onChange={(event) =>
+                        setRates((prev) => ({
+                          ...prev,
+                          [code]: event.target.value
+                        }))
+                      }
+                      disabled={isBase}
+                      style={{
+                        padding: "0.75rem 1rem",
+                        borderRadius: "0.75rem",
+                        border: "1px solid #d1d5db",
+                        backgroundColor: isBase ? "#ede9fe" : "#ffffff",
+                        color: isBase ? "#6d28d9" : "#0f172a"
+                      }}
+                      required={!isBase}
+                    />
+                    <small style={{ color: "#6b21a8" }}>
+                      {isBase
+                        ? "Базовая валюта (курс фиксирован)"
+                        : `Укажите, сколько ${baseFormatter.format(1)} составляет 1 ${code}.`}
+                    </small>
+                  </label>
+                );
+              })}
+
+              <button
+                type="submit"
+                disabled={saving}
+                style={{
+                  padding: "0.95rem 1.5rem",
+                  borderRadius: "0.75rem",
+                  border: "none",
+                  backgroundColor: saving ? "#6d28d9" : "#7c3aed",
+                  color: "#ffffff",
+                  fontWeight: 600,
+                  transition: "background-color 0.2s ease",
+                  gridColumn: "1 / -1"
+                }}
+              >
+                {saving ? "Сохраняем..." : "Сохранить курсы"}
+              </button>
+            </form>
+            {error ? <p style={{ color: "#b91c1c" }}>{error}</p> : null}
+            {message ? <p style={{ color: "#15803d" }}>{message}</p> : null}
+          </section>
+        )}
+      </main>
+    </div>
+  );
+};
+
+export default SettingsPage;

--- a/lib/currency.ts
+++ b/lib/currency.ts
@@ -1,0 +1,41 @@
+import { CURRENCIES, type Currency, type Settings } from "@/lib/types";
+
+export const SUPPORTED_CURRENCIES: readonly Currency[] = CURRENCIES;
+
+export const DEFAULT_SETTINGS: Settings = {
+  baseCurrency: "USD",
+  rates: {
+    USD: 1,
+    GEL: 1,
+    RUB: 1,
+    EUR: 1
+  }
+};
+
+export const isSupportedCurrency = (value: unknown): value is Currency =>
+  typeof value === "string" && SUPPORTED_CURRENCIES.includes(value as Currency);
+
+export const sanitizeCurrency = (value: unknown, fallback: Currency = "USD"): Currency =>
+  isSupportedCurrency(value) ? value : fallback;
+
+const getRate = (currency: Currency, settings: Settings) => {
+  const rate = settings.rates[currency];
+
+  return typeof rate === "number" && Number.isFinite(rate) && rate > 0 ? rate : 1;
+};
+
+export const convertToBase = (amount: number, currency: Currency, settings: Settings) => {
+  const rate = getRate(currency, settings);
+
+  return amount * rate;
+};
+
+export const convertFromBase = (
+  amount: number,
+  currency: Currency,
+  settings: Settings
+) => {
+  const rate = getRate(currency, settings);
+
+  return rate === 0 ? amount : amount / rate;
+};

--- a/lib/operationsStore.ts
+++ b/lib/operationsStore.ts
@@ -1,10 +1,12 @@
-import type { Debt, Goal, Operation, User } from "@/lib/types";
+import { convertToBase, DEFAULT_SETTINGS } from "@/lib/currency";
+import type { Debt, Goal, Operation, Settings, User } from "@/lib/types";
 
 export const db: {
   operations: Operation[];
   debts: Debt[];
   goals: Goal[];
   users: User[];
+  settings: Settings;
 } = {
   operations: [],
   debts: [],
@@ -13,5 +15,35 @@ export const db: {
     { id: "1", role: "admin", login: "admin", password: "admin123" },
     { id: "2", role: "accountant", login: "buh", password: "buh123" },
     { id: "3", role: "abbot", login: "abbot", password: "abbot123" }
-  ]
+  ],
+  settings: { ...DEFAULT_SETTINGS }
+};
+
+const normalizeCategory = (category: string) => category.trim().toLowerCase();
+
+export const recalculateGoalProgress = () => {
+  for (const goal of db.goals) {
+    goal.currentAmount = 0;
+  }
+
+  for (const operation of db.operations) {
+    if (operation.type !== "expense") {
+      continue;
+    }
+
+    const matchedGoal = db.goals.find(
+      (goal) => normalizeCategory(goal.title) === normalizeCategory(operation.category)
+    );
+
+    if (!matchedGoal) {
+      continue;
+    }
+
+    const amountInBase = convertToBase(operation.amount, operation.currency, db.settings);
+    matchedGoal.currentAmount += amountInBase;
+  }
+
+  for (const goal of db.goals) {
+    goal.status = goal.currentAmount >= goal.targetAmount ? "done" : "active";
+  }
 };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,8 +1,12 @@
+export const CURRENCIES = ["USD", "GEL", "RUB", "EUR"] as const;
+
+export type Currency = (typeof CURRENCIES)[number];
+
 export type Operation = {
   id: string;
   type: "income" | "expense";
   amount: number;
-  currency: string;
+  currency: Currency;
   category: string;
   comment?: string;
   source?: string;
@@ -13,6 +17,7 @@ export type Debt = {
   id: string;
   type: "borrowed" | "lent";
   amount: number;
+  currency: Currency;
   status: "open" | "closed";
   date: string;
   from?: string;
@@ -26,6 +31,7 @@ export type Goal = {
   targetAmount: number;
   currentAmount: number;
   status: "active" | "done";
+  currency: Currency;
 };
 
 export type User = {
@@ -33,4 +39,9 @@ export type User = {
   role: "admin" | "accountant" | "abbot";
   login: string;
   password: string;
+};
+
+export type Settings = {
+  baseCurrency: Currency;
+  rates: Record<Currency, number>;
 };


### PR DESCRIPTION
## Summary
- add shared currency utilities and persist exchange rate settings
- extend operations, debts, goals, and reports to handle multiple currencies based on configured rates
- add a settings page to manage currency exchange rates used across the app

## Testing
- npm run lint *(fails: ESLint package is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6311dea08331807a25366747dc5e