### PR TITLE
feat: add test-db API route

### DIFF
--- a/app/api/test-db/route.ts
+++ b/app/api/test-db/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { Client } from "pg";
+
+export const GET = async () => {
+  const client = new Client({
+    connectionString: process.env.DATABASE_URL
+  });
+
+  try {
+    await client.connect();
+
+    const result = await client.query("SELECT NOW()");
+    const rawTime = result.rows[0]?.now;
+    const time = rawTime instanceof Date ? rawTime.toISOString() : String(rawTime ?? "");
+
+    return NextResponse.json({ status: "ok", time });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unexpected error while querying database";
+
+    return NextResponse.json({ status: "error", message }, { status: 500 });
+  } finally {
+    await client.end();
+  }
+};

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "next": "^14.2.5",
+    "pg": "^8.12.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "typescript": "^5.5.3"


### PR DESCRIPTION
## Summary
- add a test-db API route that connects to PostgreSQL via the pg client and returns the current time
- declare the pg dependency in package.json for database connectivity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d027d5bf048331a24780cff0e605eb