### PR TITLE
Add theme selection to settings page

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,8 +1,5 @@
 :root {
-  color-scheme: light;
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-  background-color: #f6f7f9;
-  color: #1f2937;
 }
 
 *,
@@ -15,11 +12,24 @@
 
 body {
   min-height: 100vh;
-  background-color: #f3f4f6;
+  background-color: var(--body-background-color);
+  color: var(--body-text-color);
   display: flex;
   justify-content: center;
   align-items: flex-start;
   padding: 2.5rem 1.5rem 4rem;
+}
+
+body[data-theme="light"] {
+  --body-background-color: #f3f4f6;
+  --body-text-color: #1f2937;
+  color-scheme: light;
+}
+
+body[data-theme="dark"] {
+  --body-background-color: #0f172a;
+  --body-text-color: #e2e8f0;
+  color-scheme: dark;
 }
 
 a {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import SessionProvider from "@/components/SessionProvider";
+import ThemeProvider from "@/components/ThemeProvider";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -10,8 +11,10 @@ export const metadata: Metadata = {
 
 const RootLayout = ({ children }: { children: ReactNode }) => (
   <html lang="ru">
-    <body>
-      <SessionProvider>{children}</SessionProvider>
+    <body data-theme="light">
+      <SessionProvider>
+        <ThemeProvider>{children}</ThemeProvider>
+      </SessionProvider>
     </body>
   </html>
 );

--- a/components/ThemeProvider.tsx
+++ b/components/ThemeProvider.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction
+} from "react";
+
+export type ThemeName = "light" | "dark";
+
+type ThemeContextValue = {
+  theme: ThemeName;
+  setTheme: Dispatch<SetStateAction<ThemeName>>;
+};
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+const STORAGE_KEY = "iskcon-finance-theme";
+
+const isThemeName = (value: string | null): value is ThemeName =>
+  value === "light" || value === "dark";
+
+const applyTheme = (theme: ThemeName) => {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  document.body.dataset.theme = theme;
+  document.documentElement.style.colorScheme = theme === "dark" ? "dark" : "light";
+};
+
+const ThemeProvider = ({ children }: { children: ReactNode }) => {
+  const [theme, setTheme] = useState<ThemeName>("light");
+  const [initialized, setInitialized] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+
+    if (isThemeName(stored)) {
+      setTheme(stored);
+      applyTheme(stored);
+      setInitialized(true);
+      return;
+    }
+
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const fallbackTheme: ThemeName = prefersDark ? "dark" : "light";
+
+    setTheme(fallbackTheme);
+    applyTheme(fallbackTheme);
+    setInitialized(true);
+  }, []);
+
+  useEffect(() => {
+    if (!initialized || typeof window === "undefined") {
+      return;
+    }
+
+    applyTheme(theme);
+    window.localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme, initialized]);
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({
+      theme,
+      setTheme
+    }),
+    [theme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+
+  if (!context) {
+    throw new Error("useTheme must be used within ThemeProvider");
+  }
+
+  return context;
+};
+
+export default ThemeProvider;


### PR DESCRIPTION
## Summary
- add a client ThemeProvider that persists the selected light or dark mode and applies it to the document
- wire the provider through the root layout and update global styles to react to the active theme
- refresh the settings screen styles and add a theme selector card so users can switch between light and dark palettes

## Testing
- npm run lint *(fails: `next` not found because dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d17250d0bc83319b7746ee0a12bf84