### PR TITLE
Add dark/light theme toggle with shared palette

### DIFF
--- a/app/debts/page.tsx
+++ b/app/debts/page.tsx
@@ -292,14 +292,11 @@ const DebtsContent = () => {
 
   return (
     <main
+      className="page-shell bg-white text-black dark:bg-midnight dark:text-slate-100"
       style={{
         width: "min(720px, 100%)",
-        backgroundColor: "#ffffff",
-        borderRadius: "16px",
-        padding: "2rem",
-        boxShadow: "0 12px 28px rgba(15, 23, 42, 0.12)",
-        display: "flex",
-        flexDirection: "column",
+        padding: "2.5rem 2rem",
+        boxShadow: "var(--shadow-soft)",
         gap: "2rem"
       }}
     >
@@ -317,8 +314,8 @@ const DebtsContent = () => {
           style={{
             padding: "0.6rem 1.4rem",
             borderRadius: "999px",
-            backgroundColor: "#e0e7ff",
-            color: "#1d4ed8",
+            backgroundColor: "var(--surface-blue)",
+            color: "var(--accent-blue)",
             fontWeight: 600,
             boxShadow: "0 4px 12px rgba(59, 130, 246, 0.25)"
           }}
@@ -330,8 +327,8 @@ const DebtsContent = () => {
           style={{
             padding: "0.6rem 1.4rem",
             borderRadius: "999px",
-            backgroundColor: "#ccfbf1",
-            color: "#0f766e",
+            backgroundColor: "var(--surface-teal)",
+            color: "var(--accent-teal)",
             fontWeight: 600,
             boxShadow: "0 4px 12px rgba(45, 212, 191, 0.25)"
           }}
@@ -343,8 +340,8 @@ const DebtsContent = () => {
           style={{
             padding: "0.6rem 1.4rem",
             borderRadius: "999px",
-            backgroundColor: "#eef2ff",
-            color: "#4338ca",
+            backgroundColor: "var(--surface-indigo)",
+            color: "var(--accent-indigo)",
             fontWeight: 600,
             boxShadow: "0 4px 12px rgba(99, 102, 241, 0.2)"
           }}
@@ -356,8 +353,8 @@ const DebtsContent = () => {
           style={{
             padding: "0.6rem 1.4rem",
             borderRadius: "999px",
-            backgroundColor: "#dcfce7",
-            color: "#15803d",
+            backgroundColor: "var(--surface-success)",
+            color: "var(--accent-success)",
             fontWeight: 600,
             boxShadow: "0 4px 12px rgba(34, 197, 94, 0.2)"
           }}
@@ -369,8 +366,8 @@ const DebtsContent = () => {
           style={{
             padding: "0.6rem 1.4rem",
             borderRadius: "999px",
-            backgroundColor: "#fef3c7",
-            color: "#b45309",
+            backgroundColor: "var(--surface-amber)",
+            color: "var(--accent-amber)",
             fontWeight: 600,
             boxShadow: "0 4px 12px rgba(217, 119, 6, 0.2)"
           }}
@@ -382,8 +379,8 @@ const DebtsContent = () => {
           style={{
             padding: "0.6rem 1.4rem",
             borderRadius: "999px",
-            backgroundColor: "#f5f3ff",
-            color: "#6d28d9",
+            backgroundColor: "var(--surface-purple)",
+            color: "var(--accent-purple)",
             fontWeight: 600,
             boxShadow: "0 4px 12px rgba(109, 40, 217, 0.2)"
           }}
@@ -393,10 +390,10 @@ const DebtsContent = () => {
       </nav>
 
       <header style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
-        <h1 style={{ fontSize: "1.85rem", fontWeight: 700, color: "#0f172a" }}>
+        <h1 style={{ fontSize: "1.85rem", fontWeight: 700, color: "var(--text-primary)" }}>
           Управление долгами
         </h1>
-        <p style={{ color: "#475569", lineHeight: 1.5 }}>
+        <p style={{ color: "var(--text-secondary)", lineHeight: 1.5 }}>
           Отслеживайте займы и возвраты, чтобы понимать обязательства общины.
         </p>
       </header>
@@ -410,31 +407,31 @@ const DebtsContent = () => {
       >
         <article
           style={{
-            backgroundColor: "#f8fafc",
+            backgroundColor: "var(--surface-subtle)",
             borderRadius: "1rem",
             padding: "1.5rem",
             boxShadow: "0 12px 24px rgba(15, 23, 42, 0.08)"
           }}
         >
-          <h2 style={{ color: "#0f172a", fontWeight: 600, marginBottom: "0.5rem" }}>
+          <h2 style={{ color: "var(--text-primary)", fontWeight: 600, marginBottom: "0.5rem" }}>
             Мы должны
           </h2>
-          <strong style={{ fontSize: "1.5rem", color: "#b91c1c" }}>
+          <strong style={{ fontSize: "1.5rem", color: "var(--accent-danger)" }}>
             {baseFormatter.format(borrowed)}
           </strong>
         </article>
         <article
           style={{
-            backgroundColor: "#f0fdf4",
+            backgroundColor: "var(--surface-success-strong)",
             borderRadius: "1rem",
             padding: "1.5rem",
             boxShadow: "0 12px 24px rgba(34, 197, 94, 0.15)"
           }}
         >
-          <h2 style={{ color: "#0f172a", fontWeight: 600, marginBottom: "0.5rem" }}>
+          <h2 style={{ color: "var(--text-primary)", fontWeight: 600, marginBottom: "0.5rem" }}>
             Нам должны
           </h2>
-          <strong style={{ fontSize: "1.5rem", color: "#15803d" }}>
+          <strong style={{ fontSize: "1.5rem", color: "var(--accent-success)" }}>
             {baseFormatter.format(lent)}
           </strong>
         </article>
@@ -457,7 +454,7 @@ const DebtsContent = () => {
             style={{
               padding: "0.75rem 1rem",
               borderRadius: "0.75rem",
-              border: "1px solid #d1d5db"
+              border: "1px solid var(--border-muted)"
             }}
           >
             <option value="borrowed">Взяли</option>
@@ -478,7 +475,7 @@ const DebtsContent = () => {
             style={{
               padding: "0.75rem 1rem",
               borderRadius: "0.75rem",
-              border: "1px solid #d1d5db"
+              border: "1px solid var(--border-muted)"
             }}
           />
         </label>
@@ -492,7 +489,7 @@ const DebtsContent = () => {
             style={{
               padding: "0.75rem 1rem",
               borderRadius: "0.75rem",
-              border: "1px solid #d1d5db"
+              border: "1px solid var(--border-muted)"
             }}
           >
             {SUPPORTED_CURRENCIES.map((item) => (
@@ -512,7 +509,7 @@ const DebtsContent = () => {
             style={{
               padding: "0.75rem 1rem",
               borderRadius: "0.75rem",
-              border: "1px solid #d1d5db"
+              border: "1px solid var(--border-muted)"
             }}
           >
             {wallets.length === 0 ? (
@@ -538,7 +535,7 @@ const DebtsContent = () => {
             style={{
               padding: "0.75rem 1rem",
               borderRadius: "0.75rem",
-              border: "1px solid #d1d5db"
+              border: "1px solid var(--border-muted)"
             }}
           />
         </label>
@@ -554,7 +551,7 @@ const DebtsContent = () => {
             style={{
               padding: "0.75rem 1rem",
               borderRadius: "0.75rem",
-              border: "1px solid #d1d5db",
+              border: "1px solid var(--border-muted)",
               resize: "vertical"
             }}
           />
@@ -567,8 +564,8 @@ const DebtsContent = () => {
             padding: "0.95rem 1.5rem",
             borderRadius: "0.75rem",
             border: "none",
-            backgroundColor: loading || !canManage ? "#94a3b8" : "#2563eb",
-            color: "#ffffff",
+            backgroundColor: loading || !canManage ? "var(--accent-disabled)" : "var(--accent-primary)",
+            color: "var(--surface-primary)",
             fontWeight: 600,
             boxShadow: "0 10px 20px rgba(37, 99, 235, 0.25)",
             cursor: !canManage || loading ? "not-allowed" : "pointer"
@@ -579,21 +576,21 @@ const DebtsContent = () => {
       </form>
 
       {!canManage ? (
-        <p style={{ color: "#64748b" }}>
+        <p style={{ color: "var(--text-muted)" }}>
           Вы вошли как наблюдатель — формы доступны только для просмотра.
         </p>
       ) : null}
 
-      {initialLoading ? <p style={{ color: "#64748b" }}>Загружаем данные...</p> : null}
+      {initialLoading ? <p style={{ color: "var(--text-muted)" }}>Загружаем данные...</p> : null}
 
-      {error ? <p style={{ color: "#b91c1c" }}>{error}</p> : null}
+      {error ? <p style={{ color: "var(--accent-danger)" }}>{error}</p> : null}
 
       <section style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
-        <h2 style={{ fontSize: "1.4rem", fontWeight: 600, color: "#0f172a" }}>
+        <h2 style={{ fontSize: "1.4rem", fontWeight: 600, color: "var(--text-primary)" }}>
           Текущие долги
         </h2>
         {debts.length === 0 ? (
-          <p style={{ color: "#64748b" }}>
+          <p style={{ color: "var(--text-muted)" }}>
             Пока нет записей о долгах.
           </p>
         ) : (
@@ -604,8 +601,8 @@ const DebtsContent = () => {
                 style={{
                   padding: "1rem 1.25rem",
                   borderRadius: "1rem",
-                  border: "1px solid #e2e8f0",
-                  backgroundColor: "#f8fafc",
+                  border: "1px solid var(--border-strong)",
+                  backgroundColor: "var(--surface-subtle)",
                   display: "flex",
                   flexDirection: "column",
                   gap: "0.65rem"
@@ -620,17 +617,17 @@ const DebtsContent = () => {
                   }}
                 >
                   <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem" }}>
-                    <strong style={{ color: "#0f172a" }}>
+                    <strong style={{ color: "var(--text-primary)" }}>
                       {debt.type === "borrowed" ? "Взяли" : "Выдали"} — {debt.amount.toLocaleString("ru-RU", {
                         minimumFractionDigits: 2,
                         maximumFractionDigits: 2
                       })}{" "}
                       {debt.currency}
                     </strong>
-                    <span style={{ color: "#475569", fontSize: "0.9rem" }}>
+                    <span style={{ color: "var(--text-secondary)", fontSize: "0.9rem" }}>
                       {new Date(debt.date).toLocaleString("ru-RU")}
                     </span>
-                    <span style={{ color: "#475569", fontSize: "0.9rem" }}>
+                    <span style={{ color: "var(--text-secondary)", fontSize: "0.9rem" }}>
                       Кошелёк: {debt.wallet}
                     </span>
                   </div>
@@ -642,9 +639,9 @@ const DebtsContent = () => {
                       style={{
                         padding: "0.55rem 1rem",
                         borderRadius: "0.75rem",
-                        border: "1px solid #ef4444",
-                        backgroundColor: deletingId === debt.id ? "#fecaca" : "#fee2e2",
-                        color: "#b91c1c",
+                        border: "1px solid var(--accent-danger-bright)",
+                        backgroundColor: deletingId === debt.id ? "var(--surface-danger-strong)" : "var(--surface-danger)",
+                        color: "var(--accent-danger)",
                         fontWeight: 600,
                         cursor: deletingId === debt.id ? "not-allowed" : "pointer",
                         boxShadow: "0 10px 18px rgba(239, 68, 68, 0.15)"
@@ -655,7 +652,7 @@ const DebtsContent = () => {
                   ) : null}
                 </div>
                 {debt.comment ? (
-                  <p style={{ color: "#475569", lineHeight: 1.5 }}>{debt.comment}</p>
+                  <p style={{ color: "var(--text-secondary)", lineHeight: 1.5 }}>{debt.comment}</p>
                 ) : null}
               </li>
             ))}
@@ -671,7 +668,7 @@ const DebtsPage = () => (
     <div
       style={{
         minHeight: "100vh",
-        backgroundColor: "#f1f5f9",
+        backgroundColor: "var(--surface-muted)",
         padding: "3rem 1.5rem",
         display: "flex",
         justifyContent: "center",

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,25 +1,129 @@
-:root {
-  color-scheme: light;
-  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-  background-color: #f6f7f9;
-  color: #1f2937;
-}
-
-*,
-*::before,
-*::after {
+* {
   box-sizing: border-box;
   margin: 0;
   padding: 0;
 }
 
+:root {
+  color-scheme: light;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  --page-background: #f3f4f6;
+  --surface-primary: #ffffff;
+  --surface-subtle: #f8fafc;
+  --surface-muted: #f1f5f9;
+  --surface-contrast: #f9fafb;
+  --surface-teal: #ccfbf1;
+  --surface-teal-strong: #99f6e4;
+  --surface-teal-bright: #f0fdfa;
+  --surface-success: #dcfce7;
+  --surface-success-strong: #f0fdf4;
+  --surface-danger: #fee2e2;
+  --surface-danger-strong: #fecaca;
+  --surface-amber: #fef3c7;
+  --surface-amber-soft: #fff7ed;
+  --surface-purple: #f5f3ff;
+  --surface-violet: #ede9fe;
+  --surface-magenta: #fdf4ff;
+  --surface-blue: #e0e7ff;
+  --surface-blue-soft: #eff6ff;
+  --surface-indigo: #eef2ff;
+  --surface-navy: #312e81;
+  --surface-deep: #111827;
+  --border-muted: #d1d5db;
+  --border-strong: #e2e8f0;
+  --border-subtle: #e5e7eb;
+  --text-primary: #0f172a;
+  --text-strong: #1f2937;
+  --text-secondary: #475569;
+  --text-secondary-strong: #334155;
+  --text-muted: #64748b;
+  --text-muted-strong: #6b7280;
+  --accent-primary: #2563eb;
+  --accent-blue: #1d4ed8;
+  --accent-indigo: #4338ca;
+  --accent-indigo-strong: #3730a3;
+  --accent-purple: #6d28d9;
+  --accent-purple-bright: #7c3aed;
+  --accent-purple-deep: #3b0764;
+  --accent-violet: #5b21b6;
+  --accent-amber: #b45309;
+  --accent-teal: #0f766e;
+  --accent-teal-strong: #047857;
+  --accent-success: #15803d;
+  --accent-success-strong: #166534;
+  --accent-danger: #b91c1c;
+  --accent-danger-strong: #991b1b;
+  --accent-danger-bright: #ef4444;
+  --accent-disabled: #94a3b8;
+  --accent-disabled-strong: #9ca3af;
+  --shadow-soft: 0 18px 35px rgba(15, 23, 42, 0.12);
+  --shadow-strong: 0 24px 45px rgba(15, 23, 42, 0.16);
+}
+
+.dark {
+  color-scheme: dark;
+  --page-background: #020617;
+  --surface-primary: #0b1220;
+  --surface-subtle: #111a2e;
+  --surface-muted: #16213a;
+  --surface-contrast: #0e1627;
+  --surface-teal: #0d3a32;
+  --surface-teal-strong: #0f473a;
+  --surface-teal-bright: #115243;
+  --surface-success: #123021;
+  --surface-success-strong: #0f2719;
+  --surface-danger: #3a141d;
+  --surface-danger-strong: #4a1824;
+  --surface-amber: #422006;
+  --surface-amber-soft: #4b2a07;
+  --surface-purple: #261248;
+  --surface-violet: #2f1859;
+  --surface-magenta: #35134f;
+  --surface-blue: #1c2a4e;
+  --surface-blue-soft: #1f315c;
+  --surface-indigo: #1b2a4b;
+  --surface-navy: #1a1f4a;
+  --surface-deep: #0b1220;
+  --border-muted: #27324c;
+  --border-strong: #324163;
+  --border-subtle: #1d2840;
+  --text-primary: #e2e8f0;
+  --text-strong: #f8fafc;
+  --text-secondary: #cbd5f5;
+  --text-secondary-strong: #a5b4fc;
+  --text-muted: #94a3b8;
+  --text-muted-strong: #94a3b8;
+  --accent-primary: #60a5fa;
+  --accent-blue: #60a5fa;
+  --accent-indigo: #a78bfa;
+  --accent-indigo-strong: #c4b5fd;
+  --accent-purple: #c084fc;
+  --accent-purple-bright: #d8b4fe;
+  --accent-purple-deep: #e9d5ff;
+  --accent-violet: #c4b5fd;
+  --accent-amber: #fbbf24;
+  --accent-teal: #34d399;
+  --accent-teal-strong: #2dd4bf;
+  --accent-success: #4ade80;
+  --accent-success-strong: #22c55e;
+  --accent-danger: #f87171;
+  --accent-danger-strong: #dc2626;
+  --accent-danger-bright: #fca5a5;
+  --accent-disabled: #64748b;
+  --accent-disabled-strong: #475569;
+  --shadow-soft: 0 22px 40px rgba(2, 8, 23, 0.45);
+  --shadow-strong: 0 32px 60px rgba(2, 8, 23, 0.55);
+}
+
 body {
   min-height: 100vh;
-  background-color: #f3f4f6;
+  background-color: var(--page-background);
+  color: var(--text-primary);
   display: flex;
   justify-content: center;
   align-items: flex-start;
   padding: 2.5rem 1.5rem 4rem;
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 a {
@@ -36,4 +140,114 @@ textarea {
 
 button {
   cursor: pointer;
+}
+
+.page-shell {
+  width: min(100%, 980px);
+  background-color: var(--surface-primary);
+  color: var(--text-primary);
+  border-radius: 24px;
+  box-shadow: var(--shadow-strong);
+  padding: 2.75rem 2.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2.25rem;
+  transition: background-color 0.3s ease, color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.bg-white {
+  background-color: var(--surface-primary);
+}
+
+.text-black {
+  color: var(--text-strong);
+}
+
+.dark .dark\:bg-midnight {
+  background-color: var(--surface-deep);
+}
+
+.dark .dark\:text-slate-100 {
+  color: var(--text-strong);
+}
+
+.page-shell h1,
+.page-shell h2,
+.page-shell h3,
+.page-shell h4,
+.page-shell h5,
+.page-shell h6 {
+  color: var(--text-strong);
+}
+
+.page-shell .muted {
+  color: var(--text-muted);
+}
+
+.page-shell section {
+  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85rem 1.25rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-muted);
+  background-color: var(--surface-subtle);
+  color: var(--text-secondary);
+  font-weight: 600;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.theme-toggle:hover {
+  background-color: var(--surface-muted);
+  color: var(--text-strong);
+}
+
+.theme-toggle__track {
+  position: relative;
+  width: 48px;
+  height: 24px;
+  border-radius: 999px;
+  background-color: var(--border-muted);
+  transition: background-color 0.2s ease;
+}
+
+.theme-toggle__thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background-color: var(--surface-primary);
+  box-shadow: var(--shadow-soft);
+  transition: transform 0.2s ease, background-color 0.2s ease;
+}
+
+.theme-toggle[data-mode="dark"] .theme-toggle__track {
+  background-color: var(--accent-primary);
+}
+
+.theme-toggle[data-mode="dark"] .theme-toggle__thumb {
+  transform: translateX(24px);
+  background-color: var(--accent-primary);
+}
+
+.theme-toggle__label {
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+}
+
+@media (max-width: 900px) {
+  body {
+    padding: 2rem 1rem 3rem;
+  }
+
+  .page-shell {
+    padding: 2rem 1.5rem;
+    border-radius: 20px;
+  }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import SessionProvider from "@/components/SessionProvider";
+import { ThemeProvider } from "next-themes";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -9,9 +10,11 @@ export const metadata: Metadata = {
 };
 
 const RootLayout = ({ children }: { children: ReactNode }) => (
-  <html lang="ru">
+  <html lang="ru" suppressHydrationWarning>
     <body>
-      <SessionProvider>{children}</SessionProvider>
+      <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
+        <SessionProvider>{children}</SessionProvider>
+      </ThemeProvider>
     </body>
   </html>
 );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -424,29 +424,7 @@ const Dashboard = () => {
     }
   };
   return (
-    <div
-      style={{
-        minHeight: "100vh",
-        backgroundColor: "#e2e8f0",
-        padding: "3rem 1.5rem",
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "flex-start"
-      }}
-    >
-      <main
-        style={{
-          width: "100%",
-          maxWidth: "880px",
-          backgroundColor: "#ffffff",
-          borderRadius: "20px",
-          padding: "2.5rem 2.75rem",
-          boxShadow: "0 20px 45px rgba(15, 23, 42, 0.12)",
-          display: "flex",
-          flexDirection: "column",
-          gap: "2.5rem"
-        }}
-      >
+    <main className="page-shell bg-white text-black dark:bg-midnight dark:text-slate-100">
         <nav
           style={{
             display: "flex",
@@ -461,8 +439,8 @@ const Dashboard = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#e0e7ff",
-              color: "#1d4ed8",
+              backgroundColor: "var(--surface-blue)",
+              color: "var(--accent-blue)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(59, 130, 246, 0.25)"
             }}
@@ -474,8 +452,8 @@ const Dashboard = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#ccfbf1",
-              color: "#0f766e",
+              backgroundColor: "var(--surface-teal)",
+              color: "var(--accent-teal)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(45, 212, 191, 0.25)"
             }}
@@ -487,8 +465,8 @@ const Dashboard = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#eef2ff",
-              color: "#4338ca",
+              backgroundColor: "var(--surface-indigo)",
+              color: "var(--accent-indigo)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(99, 102, 241, 0.2)"
             }}
@@ -500,8 +478,8 @@ const Dashboard = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#dcfce7",
-              color: "#15803d",
+              backgroundColor: "var(--surface-success)",
+              color: "var(--accent-success)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(34, 197, 94, 0.2)"
             }}
@@ -513,8 +491,8 @@ const Dashboard = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#fef3c7",
-              color: "#b45309",
+              backgroundColor: "var(--surface-amber)",
+              color: "var(--accent-amber)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(217, 119, 6, 0.2)"
             }}
@@ -526,8 +504,8 @@ const Dashboard = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#f5f3ff",
-              color: "#6d28d9",
+              backgroundColor: "var(--surface-purple)",
+              color: "var(--accent-purple)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(109, 40, 217, 0.2)"
             }}
@@ -558,13 +536,13 @@ const Dashboard = () => {
               gap: "1rem"
             }}
           >
-            <h2 style={{ fontSize: "1.5rem", fontWeight: 600, color: "#0f172a" }}>
+            <h2 style={{ fontSize: "1.5rem", fontWeight: 600, color: "var(--text-primary)" }}>
               Текущий баланс
             </h2>
             <strong
               style={{
                 fontSize: "1.75rem",
-                color: balance >= 0 ? "#15803d" : "#b91c1c"
+                color: balance >= 0 ? "var(--accent-success)" : "var(--accent-danger)"
               }}
             >
               {balanceFormatter.format(balance)}
@@ -572,7 +550,7 @@ const Dashboard = () => {
           </div>
 
           {initialLoading ? (
-            <p style={{ color: "#64748b" }}>Загружаем данные...</p>
+            <p style={{ color: "var(--text-muted)" }}>Загружаем данные...</p>
           ) : null}
 
           <form
@@ -596,7 +574,7 @@ const Dashboard = () => {
                 style={{
                   padding: "0.75rem 1rem",
                   borderRadius: "0.75rem",
-                  border: "1px solid #d1d5db"
+                  border: "1px solid var(--border-muted)"
                 }}
               >
                 <option value="income">Приход</option>
@@ -617,7 +595,7 @@ const Dashboard = () => {
                 style={{
                   padding: "0.75rem 1rem",
                   borderRadius: "0.75rem",
-                  border: "1px solid #d1d5db"
+                  border: "1px solid var(--border-muted)"
                 }}
               />
             </label>
@@ -631,7 +609,7 @@ const Dashboard = () => {
                 style={{
                   padding: "0.75rem 1rem",
                   borderRadius: "0.75rem",
-                  border: "1px solid #d1d5db"
+                  border: "1px solid var(--border-muted)"
                 }}
               >
                 {SUPPORTED_CURRENCIES.map((item) => (
@@ -651,7 +629,7 @@ const Dashboard = () => {
                 style={{
                   padding: "0.75rem 1rem",
                   borderRadius: "0.75rem",
-                  border: "1px solid #d1d5db"
+                  border: "1px solid var(--border-muted)"
                 }}
               >
                 {wallets.length === 0 ? (
@@ -678,7 +656,7 @@ const Dashboard = () => {
                 style={{
                   padding: "0.75rem 1rem",
                   borderRadius: "0.75rem",
-                  border: "1px solid #d1d5db"
+                  border: "1px solid var(--border-muted)"
                 }}
               >
                 {(type === "income" ? incomeCategories : expenseOptions).length === 0 ? (
@@ -704,8 +682,8 @@ const Dashboard = () => {
                 padding: "0.95rem 1.5rem",
                 borderRadius: "0.75rem",
                 border: "none",
-                backgroundColor: loading || !canManage ? "#94a3b8" : "#2563eb",
-                color: "#ffffff",
+                backgroundColor: loading || !canManage ? "var(--accent-disabled)" : "var(--accent-primary)",
+                color: "var(--surface-primary)",
                 fontWeight: 600,
                 transition: "background-color 0.2s ease",
                 boxShadow: "0 10px 20px rgba(37, 99, 235, 0.25)",
@@ -718,21 +696,21 @@ const Dashboard = () => {
           </form>
 
           {!canManage ? (
-            <p style={{ color: "#64748b" }}>
+            <p style={{ color: "var(--text-muted)" }}>
               Вы вошли как наблюдатель — операции доступны только для просмотра.
             </p>
           ) : null}
 
-          {error ? <p style={{ color: "#b91c1c" }}>{error}</p> : null}
+          {error ? <p style={{ color: "var(--accent-danger)" }}>{error}</p> : null}
         </section>
 
 
         <section style={{ display: "flex", flexDirection: "column", gap: "1.25rem" }}>
-          <h2 style={{ fontSize: "1.5rem", fontWeight: 600, color: "#0f172a" }}>
+          <h2 style={{ fontSize: "1.5rem", fontWeight: 600, color: "var(--text-primary)" }}>
             Последние операции
           </h2>
           {operations.length === 0 ? (
-            <p style={{ color: "#64748b" }}>
+            <p style={{ color: "var(--text-muted)" }}>
               Пока нет данных — добавьте первую операцию.
             </p>
           ) : (
@@ -743,12 +721,12 @@ const Dashboard = () => {
                   style={{
                     padding: "1.1rem 1.35rem",
                     borderRadius: "1rem",
-                    border: "1px solid #e2e8f0",
+                    border: "1px solid var(--border-strong)",
                     display: "flex",
                     justifyContent: "space-between",
                     alignItems: "flex-start",
                     gap: "1.25rem",
-                    backgroundColor: "#f8fafc",
+                    backgroundColor: "var(--surface-subtle)",
                     boxShadow: "0 12px 24px rgba(15, 23, 42, 0.08)",
                     flexWrap: "wrap"
                   }}
@@ -761,17 +739,17 @@ const Dashboard = () => {
                       minWidth: "220px"
                     }}
                   >
-                    <p style={{ fontWeight: 600, color: "#0f172a" }}>
+                    <p style={{ fontWeight: 600, color: "var(--text-primary)" }}>
                       {operation.type === "income" ? "Приход" : "Расход"} — {operation.category}
                     </p>
-                    <p style={{ color: "#64748b", fontSize: "0.9rem" }}>
+                    <p style={{ color: "var(--text-muted)", fontSize: "0.9rem" }}>
                       {new Date(operation.date).toLocaleString("ru-RU")}
                     </p>
-                    <p style={{ color: "#475569", fontSize: "0.9rem" }}>
+                    <p style={{ color: "var(--text-secondary)", fontSize: "0.9rem" }}>
                       Кошелёк: {operation.wallet}
                     </p>
                     {operation.comment ? (
-                      <p style={{ color: "#475569", lineHeight: 1.5 }}>{operation.comment}</p>
+                      <p style={{ color: "var(--text-secondary)", lineHeight: 1.5 }}>{operation.comment}</p>
                     ) : null}
                   </div>
                   <div
@@ -786,7 +764,7 @@ const Dashboard = () => {
                     <span
                       style={{
                         fontWeight: 700,
-                        color: operation.type === "income" ? "#15803d" : "#b91c1c",
+                        color: operation.type === "income" ? "var(--accent-success)" : "var(--accent-danger)",
                         fontSize: "1.1rem"
                       }}
                     >
@@ -806,10 +784,10 @@ const Dashboard = () => {
                         style={{
                           padding: "0.55rem 0.95rem",
                           borderRadius: "0.75rem",
-                          border: "1px solid #ef4444",
+                          border: "1px solid var(--accent-danger-bright)",
                           backgroundColor:
-                            deletingId === operation.id ? "#fecaca" : "#fee2e2",
-                          color: "#b91c1c",
+                            deletingId === operation.id ? "var(--surface-danger-strong)" : "var(--surface-danger)",
+                          color: "var(--accent-danger)",
                           fontWeight: 600,
                           cursor: deletingId === operation.id ? "not-allowed" : "pointer",
                           transition: "background-color 0.2s ease, transform 0.2s ease",
@@ -826,8 +804,7 @@ const Dashboard = () => {
             </ul>
           )}
         </section>
-      </main>
-    </div>
+    </main>
   );
 };
 

--- a/app/planning/page.tsx
+++ b/app/planning/page.tsx
@@ -245,29 +245,15 @@ const PlanningContent = () => {
   };
 
   return (
-    <div
+    <main
+      className="page-shell bg-white text-black dark:bg-midnight dark:text-slate-100"
       style={{
-        minHeight: "100vh",
-        backgroundColor: "#f1f5f9",
-        padding: "3rem 1.5rem",
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "flex-start"
+        maxWidth: "840px",
+        width: "100%",
+        padding: "2.5rem 2.75rem",
+        gap: "2.25rem"
       }}
     >
-      <main
-        style={{
-          width: "100%",
-          maxWidth: "840px",
-          backgroundColor: "#ffffff",
-          borderRadius: "20px",
-          padding: "2.5rem 2.75rem",
-          boxShadow: "0 20px 45px rgba(15, 23, 42, 0.12)",
-          display: "flex",
-          flexDirection: "column",
-          gap: "2.25rem"
-        }}
-      >
         <nav
           style={{
             display: "flex",
@@ -282,8 +268,8 @@ const PlanningContent = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#e0e7ff",
-              color: "#1d4ed8",
+              backgroundColor: "var(--surface-blue)",
+              color: "var(--accent-blue)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(59, 130, 246, 0.25)"
             }}
@@ -295,8 +281,8 @@ const PlanningContent = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#ccfbf1",
-              color: "#0f766e",
+              backgroundColor: "var(--surface-teal)",
+              color: "var(--accent-teal)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(45, 212, 191, 0.25)"
             }}
@@ -308,8 +294,8 @@ const PlanningContent = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#eef2ff",
-              color: "#4338ca",
+              backgroundColor: "var(--surface-indigo)",
+              color: "var(--accent-indigo)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(99, 102, 241, 0.2)"
             }}
@@ -321,8 +307,8 @@ const PlanningContent = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#dcfce7",
-              color: "#15803d",
+              backgroundColor: "var(--surface-success)",
+              color: "var(--accent-success)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(34, 197, 94, 0.2)"
             }}
@@ -334,8 +320,8 @@ const PlanningContent = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#fef3c7",
-              color: "#b45309",
+              backgroundColor: "var(--surface-amber)",
+              color: "var(--accent-amber)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(217, 119, 6, 0.2)"
             }}
@@ -347,8 +333,8 @@ const PlanningContent = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#f5f3ff",
-              color: "#6d28d9",
+              backgroundColor: "var(--surface-purple)",
+              color: "var(--accent-purple)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(109, 40, 217, 0.2)"
             }}
@@ -364,10 +350,10 @@ const PlanningContent = () => {
             gap: "0.75rem"
           }}
         >
-          <h1 style={{ fontSize: "2rem", fontWeight: 700, color: "#0f172a" }}>
+          <h1 style={{ fontSize: "2rem", fontWeight: 700, color: "var(--text-primary)" }}>
             Планирование проектов и целей
           </h1>
-          <p style={{ color: "#475569", lineHeight: 1.6 }}>
+          <p style={{ color: "var(--text-secondary)", lineHeight: 1.6 }}>
             Следите за прогрессом накоплений по ключевым инициативам общины.
           </p>
         </header>
@@ -381,31 +367,31 @@ const PlanningContent = () => {
         >
           <article
             style={{
-              backgroundColor: "#eef2ff",
+              backgroundColor: "var(--surface-indigo)",
               borderRadius: "1rem",
               padding: "1.5rem",
               boxShadow: "0 16px 35px rgba(99, 102, 241, 0.12)"
             }}
           >
-            <h2 style={{ color: "#312e81", fontWeight: 600, marginBottom: "0.5rem" }}>
+            <h2 style={{ color: "var(--surface-navy)", fontWeight: 600, marginBottom: "0.5rem" }}>
               Сохранено
             </h2>
-            <strong style={{ fontSize: "1.5rem", color: "#3730a3" }}>
+            <strong style={{ fontSize: "1.5rem", color: "var(--accent-indigo-strong)" }}>
               {baseCurrencyFormatter.format(totals.saved)}
             </strong>
           </article>
           <article
             style={{
-              backgroundColor: "#dcfce7",
+              backgroundColor: "var(--surface-success)",
               borderRadius: "1rem",
               padding: "1.5rem",
               boxShadow: "0 16px 35px rgba(34, 197, 94, 0.12)"
             }}
           >
-            <h2 style={{ color: "#166534", fontWeight: 600, marginBottom: "0.5rem" }}>
+            <h2 style={{ color: "var(--accent-success-strong)", fontWeight: 600, marginBottom: "0.5rem" }}>
               Цель
             </h2>
-            <strong style={{ fontSize: "1.5rem", color: "#15803d" }}>
+            <strong style={{ fontSize: "1.5rem", color: "var(--accent-success)" }}>
               {baseCurrencyFormatter.format(totals.target)}
             </strong>
           </article>
@@ -430,7 +416,7 @@ const PlanningContent = () => {
               style={{
                 padding: "0.75rem 1rem",
                 borderRadius: "0.75rem",
-                border: "1px solid #d1d5db"
+                border: "1px solid var(--border-muted)"
               }}
             />
           </label>
@@ -448,7 +434,7 @@ const PlanningContent = () => {
               style={{
                 padding: "0.75rem 1rem",
                 borderRadius: "0.75rem",
-                border: "1px solid #d1d5db"
+                border: "1px solid var(--border-muted)"
               }}
             />
           </label>
@@ -462,7 +448,7 @@ const PlanningContent = () => {
               style={{
                 padding: "0.75rem 1rem",
                 borderRadius: "0.75rem",
-                border: "1px solid #d1d5db"
+                border: "1px solid var(--border-muted)"
               }}
             >
               {SUPPORTED_CURRENCIES.map((item) => (
@@ -480,8 +466,8 @@ const PlanningContent = () => {
               padding: "0.95rem 1.5rem",
               borderRadius: "0.75rem",
               border: "none",
-              backgroundColor: loading || !canManage ? "#94a3b8" : "#2563eb",
-              color: "#ffffff",
+              backgroundColor: loading || !canManage ? "var(--accent-disabled)" : "var(--accent-primary)",
+              color: "var(--surface-primary)",
               fontWeight: 600,
               boxShadow: "0 10px 20px rgba(37, 99, 235, 0.25)",
               cursor: !canManage || loading ? "not-allowed" : "pointer"
@@ -492,22 +478,22 @@ const PlanningContent = () => {
         </form>
 
         {!canManage ? (
-          <p style={{ color: "#64748b" }}>
+          <p style={{ color: "var(--text-muted)" }}>
             Вы вошли как наблюдатель — цели доступны только для просмотра.
           </p>
         ) : null}
 
-        {initialLoading ? <p style={{ color: "#64748b" }}>Загружаем данные...</p> : null}
+        {initialLoading ? <p style={{ color: "var(--text-muted)" }}>Загружаем данные...</p> : null}
 
-        {error ? <p style={{ color: "#b91c1c" }}>{error}</p> : null}
-        {message ? <p style={{ color: "#15803d" }}>{message}</p> : null}
+        {error ? <p style={{ color: "var(--accent-danger)" }}>{error}</p> : null}
+        {message ? <p style={{ color: "var(--accent-success)" }}>{message}</p> : null}
 
         <section style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}>
-          <h2 style={{ fontSize: "1.5rem", fontWeight: 600, color: "#0f172a" }}>
+          <h2 style={{ fontSize: "1.5rem", fontWeight: 600, color: "var(--text-primary)" }}>
             Активные цели
           </h2>
           {goals.length === 0 ? (
-            <p style={{ color: "#64748b" }}>
+            <p style={{ color: "var(--text-muted)" }}>
               Пока нет активных целей.
             </p>
           ) : (
@@ -521,10 +507,10 @@ const PlanningContent = () => {
                   <li
                     key={goal.id}
                     style={{
-                      border: "1px solid #e2e8f0",
+                      border: "1px solid var(--border-strong)",
                       borderRadius: "1rem",
                       padding: "1.5rem",
-                      backgroundColor: "#f8fafc",
+                      backgroundColor: "var(--surface-subtle)",
                       boxShadow: "0 12px 24px rgba(15, 23, 42, 0.08)",
                       display: "flex",
                       flexDirection: "column",
@@ -541,10 +527,10 @@ const PlanningContent = () => {
                       }}
                     >
                       <div style={{ display: "flex", flexDirection: "column", gap: "0.4rem" }}>
-                        <strong style={{ fontSize: "1.1rem", color: "#0f172a" }}>
+                        <strong style={{ fontSize: "1.1rem", color: "var(--text-primary)" }}>
                           {goal.title}
                         </strong>
-                        <span style={{ color: "#475569", fontSize: "0.95rem" }}>
+                        <span style={{ color: "var(--text-secondary)", fontSize: "0.95rem" }}>
                           Сохранено: {baseCurrencyFormatter.format(goal.currentAmount)} из {baseCurrencyFormatter.format(goal.targetAmount)}
                         </span>
                       </div>
@@ -556,9 +542,9 @@ const PlanningContent = () => {
                           style={{
                             padding: "0.55rem 1rem",
                             borderRadius: "0.75rem",
-                            border: "1px solid #ef4444",
-                            backgroundColor: deletingId === goal.id ? "#fecaca" : "#fee2e2",
-                            color: "#b91c1c",
+                            border: "1px solid var(--accent-danger-bright)",
+                            backgroundColor: deletingId === goal.id ? "var(--surface-danger-strong)" : "var(--surface-danger)",
+                            color: "var(--accent-danger)",
                             fontWeight: 600,
                             cursor: deletingId === goal.id ? "not-allowed" : "pointer",
                             boxShadow: "0 10px 18px rgba(239, 68, 68, 0.15)"
@@ -580,19 +566,19 @@ const PlanningContent = () => {
                         style={{
                           height: "0.75rem",
                           borderRadius: "999px",
-                          backgroundColor: "#e2e8f0",
+                          backgroundColor: "var(--border-strong)",
                           overflow: "hidden"
                         }}
                       >
                         <div
                           style={{
                             width: `${progress}%`,
-                            backgroundColor: "#2563eb",
+                            backgroundColor: "var(--accent-primary)",
                             height: "100%"
                           }}
                         />
                       </div>
-                      <span style={{ color: "#475569", fontSize: "0.9rem" }}>
+                      <span style={{ color: "var(--text-secondary)", fontSize: "0.9rem" }}>
                         {progress}% — {current.toLocaleString("ru-RU", {
                           minimumFractionDigits: 2,
                           maximumFractionDigits: 2
@@ -606,8 +592,7 @@ const PlanningContent = () => {
             </ul>
           )}
         </section>
-      </main>
-    </div>
+    </main>
   );
 };
 

--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -343,18 +343,18 @@ const ReportsContent = () => {
               :root {
                 color-scheme: light;
                 font-family: 'Inter', 'Segoe UI', sans-serif;
-                --accent: #5b21b6;
+                --accent: var(--accent-violet);
               }
               body {
                 margin: 0;
                 padding: 40px 24px;
-                background: #f9fafb;
-                color: #111827;
+                background: var(--surface-contrast);
+                color: var(--surface-deep);
               }
               .container {
                 margin: 0 auto;
                 max-width: 720px;
-                background: #ffffff;
+                background: var(--surface-primary);
                 padding: 32px 40px;
                 border-radius: 16px;
                 box-shadow: 0 24px 55px rgba(88, 28, 135, 0.15);
@@ -367,14 +367,14 @@ const ReportsContent = () => {
               h2 {
                 font-size: 18px;
                 margin: 24px 0 12px;
-                color: #3b0764;
+                color: var(--accent-purple-deep);
               }
               p {
                 margin: 0 0 8px;
                 line-height: 1.6;
               }
               .muted {
-                color: #6b7280;
+                color: var(--text-muted-strong);
               }
               .summary-list {
                 list-style: none;
@@ -387,14 +387,14 @@ const ReportsContent = () => {
               .summary-list li {
                 padding: 12px 16px;
                 border-radius: 12px;
-                background: #ede9fe;
+                background: var(--surface-violet);
                 border: 1px solid rgba(91, 33, 182, 0.12);
               }
               .summary-list strong {
                 display: block;
                 margin-top: 6px;
                 font-size: 16px;
-                color: #1f2937;
+                color: var(--text-strong);
               }
               .data-table {
                 width: 100%;
@@ -403,24 +403,24 @@ const ReportsContent = () => {
               .data-table thead th {
                 text-align: left;
                 padding: 12px;
-                background: #f5f3ff;
-                color: #3b0764;
-                border-bottom: 1px solid #e0e7ff;
+                background: var(--surface-purple);
+                color: var(--accent-purple-deep);
+                border-bottom: 1px solid var(--surface-blue);
               }
               .data-table tbody td {
                 padding: 12px;
-                border-bottom: 1px solid #e5e7eb;
+                border-bottom: 1px solid var(--border-subtle);
               }
               .data-table tbody tr:last-child td {
                 border-bottom: none;
               }
               .empty {
-                color: #6b7280;
+                color: var(--text-muted-strong);
                 font-style: italic;
               }
               @media print {
                 body {
-                  background: #ffffff;
+                  background: var(--surface-primary);
                   padding: 0;
                 }
                 .container {
@@ -489,29 +489,15 @@ const ReportsContent = () => {
 
 
   return (
-    <div
+    <main
+      className="page-shell bg-white text-black dark:bg-midnight dark:text-slate-100"
       style={{
-        minHeight: "100vh",
-        backgroundColor: "#fdf4ff",
-        padding: "3rem 1.5rem",
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "flex-start"
+        maxWidth: "900px",
+        width: "100%",
+        padding: "2.75rem",
+        gap: "2.5rem"
       }}
     >
-      <main
-        style={{
-          width: "100%",
-          maxWidth: "900px",
-          backgroundColor: "#ffffff",
-          borderRadius: "24px",
-          padding: "2.75rem",
-          boxShadow: "0 24px 55px rgba(88, 28, 135, 0.2)",
-          display: "flex",
-          flexDirection: "column",
-          gap: "2.5rem"
-        }}
-      >
         <nav
           style={{
             display: "flex",
@@ -526,8 +512,8 @@ const ReportsContent = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#e0e7ff",
-              color: "#1d4ed8",
+              backgroundColor: "var(--surface-blue)",
+              color: "var(--accent-blue)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(59, 130, 246, 0.25)"
             }}
@@ -539,8 +525,8 @@ const ReportsContent = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#ccfbf1",
-              color: "#0f766e",
+              backgroundColor: "var(--surface-teal)",
+              color: "var(--accent-teal)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(45, 212, 191, 0.25)"
             }}
@@ -552,8 +538,8 @@ const ReportsContent = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#eef2ff",
-              color: "#4338ca",
+              backgroundColor: "var(--surface-indigo)",
+              color: "var(--accent-indigo)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(99, 102, 241, 0.2)"
             }}
@@ -565,8 +551,8 @@ const ReportsContent = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#dcfce7",
-              color: "#15803d",
+              backgroundColor: "var(--surface-success)",
+              color: "var(--accent-success)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(34, 197, 94, 0.2)"
             }}
@@ -578,8 +564,8 @@ const ReportsContent = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#fef3c7",
-              color: "#b45309",
+              backgroundColor: "var(--surface-amber)",
+              color: "var(--accent-amber)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(217, 119, 6, 0.2)"
             }}
@@ -591,8 +577,8 @@ const ReportsContent = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#f5f3ff",
-              color: "#6d28d9",
+              backgroundColor: "var(--surface-purple)",
+              color: "var(--accent-purple)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(109, 40, 217, 0.2)"
             }}
@@ -608,16 +594,16 @@ const ReportsContent = () => {
             gap: "0.75rem"
           }}
         >
-          <h1 style={{ fontSize: "2.1rem", fontWeight: 700, color: "#3b0764" }}>
+          <h1 style={{ fontSize: "2.1rem", fontWeight: 700, color: "var(--accent-purple-deep)" }}>
             Финансовые отчёты
           </h1>
-          <p style={{ color: "#475569", lineHeight: 1.6 }}>
+          <p style={{ color: "var(--text-secondary)", lineHeight: 1.6 }}>
             Анализируйте поступления и расходы за выбранный период.
           </p>
         </header>
 
-        {error ? <p style={{ color: "#b91c1c" }}>{error}</p> : null}
-        {loading ? <p style={{ color: "#64748b" }}>Загружаем данные...</p> : null}
+        {error ? <p style={{ color: "var(--accent-danger)" }}>{error}</p> : null}
+        {loading ? <p style={{ color: "var(--text-muted)" }}>Загружаем данные...</p> : null}
 
         <section
           style={{
@@ -628,46 +614,46 @@ const ReportsContent = () => {
         >
           <article
             style={{
-              backgroundColor: "#ede9fe",
+              backgroundColor: "var(--surface-violet)",
               borderRadius: "1rem",
               padding: "1.5rem",
               boxShadow: "0 16px 35px rgba(129, 140, 248, 0.25)"
             }}
           >
-            <h2 style={{ color: "#312e81", fontWeight: 600, marginBottom: "0.5rem" }}>
+            <h2 style={{ color: "var(--surface-navy)", fontWeight: 600, marginBottom: "0.5rem" }}>
               Приход
             </h2>
-            <strong style={{ fontSize: "1.6rem", color: "#3730a3" }}>
+            <strong style={{ fontSize: "1.6rem", color: "var(--accent-indigo-strong)" }}>
               {currencyFormatter.format(totals.income)}
             </strong>
           </article>
           <article
             style={{
-              backgroundColor: "#fee2e2",
+              backgroundColor: "var(--surface-danger)",
               borderRadius: "1rem",
               padding: "1.5rem",
               boxShadow: "0 16px 35px rgba(248, 113, 113, 0.25)"
             }}
           >
-            <h2 style={{ color: "#991b1b", fontWeight: 600, marginBottom: "0.5rem" }}>
+            <h2 style={{ color: "var(--accent-danger-strong)", fontWeight: 600, marginBottom: "0.5rem" }}>
               Расход
             </h2>
-            <strong style={{ fontSize: "1.6rem", color: "#b91c1c" }}>
+            <strong style={{ fontSize: "1.6rem", color: "var(--accent-danger)" }}>
               {currencyFormatter.format(totals.expense)}
             </strong>
           </article>
           <article
             style={{
-              backgroundColor: "#dcfce7",
+              backgroundColor: "var(--surface-success)",
               borderRadius: "1rem",
               padding: "1.5rem",
               boxShadow: "0 16px 35px rgba(34, 197, 94, 0.25)"
             }}
           >
-            <h2 style={{ color: "#166534", fontWeight: 600, marginBottom: "0.5rem" }}>
+            <h2 style={{ color: "var(--accent-success-strong)", fontWeight: 600, marginBottom: "0.5rem" }}>
               Баланс
             </h2>
-            <strong style={{ fontSize: "1.6rem", color: totals.balance >= 0 ? "#15803d" : "#b91c1c" }}>
+            <strong style={{ fontSize: "1.6rem", color: totals.balance >= 0 ? "var(--accent-success)" : "var(--accent-danger)" }}>
               {currencyFormatter.format(totals.balance)}
             </strong>
           </article>
@@ -689,7 +675,7 @@ const ReportsContent = () => {
               style={{
                 padding: "0.85rem 1rem",
                 borderRadius: "0.75rem",
-                border: "1px solid #d1d5db"
+                border: "1px solid var(--border-muted)"
               }}
             >
               {PERIOD_OPTIONS.map((option) => (
@@ -711,7 +697,7 @@ const ReportsContent = () => {
                   style={{
                     padding: "0.85rem 1rem",
                     borderRadius: "0.75rem",
-                    border: "1px solid #d1d5db"
+                    border: "1px solid var(--border-muted)"
                   }}
                 />
               </label>
@@ -724,7 +710,7 @@ const ReportsContent = () => {
                   style={{
                     padding: "0.85rem 1rem",
                     borderRadius: "0.75rem",
-                    border: "1px solid #d1d5db"
+                    border: "1px solid var(--border-muted)"
                   }}
                 />
               </label>
@@ -738,8 +724,8 @@ const ReportsContent = () => {
               padding: "0.95rem 1.5rem",
               borderRadius: "0.75rem",
               border: "none",
-              backgroundColor: "#7c3aed",
-              color: "#ffffff",
+              backgroundColor: "var(--accent-purple-bright)",
+              color: "var(--surface-primary)",
               fontWeight: 600,
               boxShadow: "0 12px 24px rgba(124, 58, 237, 0.35)",
               cursor: "pointer"
@@ -750,40 +736,40 @@ const ReportsContent = () => {
         </section>
 
         <section style={{ display: "flex", flexDirection: "column", gap: "1.25rem" }}>
-          <h2 style={{ fontSize: "1.4rem", fontWeight: 600, color: "#3b0764" }}>
+          <h2 style={{ fontSize: "1.4rem", fontWeight: 600, color: "var(--accent-purple-deep)" }}>
             Категории
           </h2>
           {categoryRows.length === 0 ? (
-            <p style={{ color: "#64748b" }}>Нет операций за выбранный период.</p>
+            <p style={{ color: "var(--text-muted)" }}>Нет операций за выбранный период.</p>
           ) : (
             <table style={{ width: "100%", borderCollapse: "collapse" }}>
               <thead>
-                <tr style={{ backgroundColor: "#f5f3ff" }}>
-                  <th style={{ textAlign: "left", padding: "0.75rem", color: "#312e81" }}>
+                <tr style={{ backgroundColor: "var(--surface-purple)" }}>
+                  <th style={{ textAlign: "left", padding: "0.75rem", color: "var(--surface-navy)" }}>
                     Категория
                   </th>
-                  <th style={{ textAlign: "right", padding: "0.75rem", color: "#312e81" }}>
+                  <th style={{ textAlign: "right", padding: "0.75rem", color: "var(--surface-navy)" }}>
                     Приход
                   </th>
-                  <th style={{ textAlign: "right", padding: "0.75rem", color: "#312e81" }}>
+                  <th style={{ textAlign: "right", padding: "0.75rem", color: "var(--surface-navy)" }}>
                     Расход
                   </th>
-                  <th style={{ textAlign: "right", padding: "0.75rem", color: "#312e81" }}>
+                  <th style={{ textAlign: "right", padding: "0.75rem", color: "var(--surface-navy)" }}>
                     Итого
                   </th>
                 </tr>
               </thead>
               <tbody>
                 {categoryRows.map((row) => (
-                  <tr key={row.category} style={{ borderBottom: "1px solid #e2e8f0" }}>
-                    <td style={{ padding: "0.75rem", color: "#334155" }}>{row.category}</td>
-                    <td style={{ padding: "0.75rem", textAlign: "right", color: "#15803d" }}>
+                  <tr key={row.category} style={{ borderBottom: "1px solid var(--border-strong)" }}>
+                    <td style={{ padding: "0.75rem", color: "var(--text-secondary-strong)" }}>{row.category}</td>
+                    <td style={{ padding: "0.75rem", textAlign: "right", color: "var(--accent-success)" }}>
                       {currencyFormatter.format(row.income)}
                     </td>
-                    <td style={{ padding: "0.75rem", textAlign: "right", color: "#b91c1c" }}>
+                    <td style={{ padding: "0.75rem", textAlign: "right", color: "var(--accent-danger)" }}>
                       {currencyFormatter.format(row.expense)}
                     </td>
-                    <td style={{ padding: "0.75rem", textAlign: "right", color: "#1f2937" }}>
+                    <td style={{ padding: "0.75rem", textAlign: "right", color: "var(--text-strong)" }}>
                       {currencyFormatter.format(row.total)}
                     </td>
                   </tr>
@@ -802,8 +788,8 @@ const ReportsContent = () => {
             padding: "0.95rem 1.75rem",
             borderRadius: "0.85rem",
             border: "none",
-            backgroundColor: isExporting ? "#7c3aed" : "#5b21b6",
-            color: "#ffffff",
+            backgroundColor: isExporting ? "var(--accent-purple-bright)" : "var(--accent-violet)",
+            color: "var(--surface-primary)",
             fontWeight: 600,
             boxShadow: "0 16px 35px rgba(91, 33, 182, 0.25)",
             cursor: isExporting ? "not-allowed" : "pointer"
@@ -811,8 +797,7 @@ const ReportsContent = () => {
         >
           {isExporting ? "Готовим файл..." : "Экспортировать PDF"}
         </button>
-      </main>
-    </div>
+    </main>
   );
 };
 

--- a/app/settings/categories/page.tsx
+++ b/app/settings/categories/page.tsx
@@ -195,29 +195,15 @@ const CategoriesSettings = () => {
   };
 
   return (
-    <div
+    <main
+      className="page-shell bg-white text-black dark:bg-midnight dark:text-slate-100"
       style={{
-        minHeight: "100vh",
-        backgroundColor: "#eef2ff",
-        padding: "3rem 1.5rem",
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "flex-start"
+        maxWidth: "780px",
+        width: "100%",
+        padding: "2.5rem 2.75rem",
+        gap: "2rem"
       }}
     >
-      <main
-        style={{
-          width: "100%",
-          maxWidth: "780px",
-          backgroundColor: "#ffffff",
-          borderRadius: "20px",
-          padding: "2.5rem 2.75rem",
-          boxShadow: "0 20px 45px rgba(79, 70, 229, 0.14)",
-          display: "flex",
-          flexDirection: "column",
-          gap: "2rem"
-        }}
-      >
         <nav
           style={{
             display: "flex",
@@ -232,8 +218,8 @@ const CategoriesSettings = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#ede9fe",
-              color: "#5b21b6",
+              backgroundColor: "var(--surface-violet)",
+              color: "var(--accent-violet)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(124, 58, 237, 0.2)"
             }}
@@ -245,8 +231,8 @@ const CategoriesSettings = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#e0e7ff",
-              color: "#1d4ed8",
+              backgroundColor: "var(--surface-blue)",
+              color: "var(--accent-blue)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(59, 130, 246, 0.25)"
             }}
@@ -262,16 +248,16 @@ const CategoriesSettings = () => {
             gap: "0.75rem"
           }}
         >
-          <h1 style={{ fontSize: "2rem", fontWeight: 700, color: "#312e81" }}>
+          <h1 style={{ fontSize: "2rem", fontWeight: 700, color: "var(--surface-navy)" }}>
             Управление категориями
           </h1>
-          <p style={{ color: "#475569", lineHeight: 1.6 }}>
+          <p style={{ color: "var(--text-secondary)", lineHeight: 1.6 }}>
             Добавляйте и удаляйте категории прихода и расхода. Все операции сохраняются,
             даже если категорию удалить.
           </p>
         </header>
 
-        {loading ? <p style={{ color: "#64748b" }}>Загружаем категории...</p> : null}
+        {loading ? <p style={{ color: "var(--text-muted)" }}>Загружаем категории...</p> : null}
 
         <section
           style={{
@@ -284,8 +270,8 @@ const CategoriesSettings = () => {
             {
               type: "income" as const,
               title: "Категории прихода",
-              color: "#1d4ed8",
-              background: "#eff6ff",
+              color: "var(--accent-blue)",
+              background: "var(--surface-blue-soft)",
               value: newIncome,
               onChange: setNewIncome,
               categories: incomeCategories
@@ -293,8 +279,8 @@ const CategoriesSettings = () => {
             {
               type: "expense" as const,
               title: "Категории расхода",
-              color: "#b45309",
-              background: "#fff7ed",
+              color: "var(--accent-amber)",
+              background: "var(--surface-amber-soft)",
               value: newExpense,
               onChange: setNewExpense,
               categories: expenseCategories
@@ -332,7 +318,7 @@ const CategoriesSettings = () => {
                       flex: 1,
                       padding: "0.75rem 1rem",
                       borderRadius: "0.75rem",
-                      border: "1px solid #d1d5db"
+                      border: "1px solid var(--border-muted)"
                     }}
                   />
                   <button
@@ -343,8 +329,8 @@ const CategoriesSettings = () => {
                       borderRadius: "0.75rem",
                       border: "none",
                       backgroundColor:
-                        !canManage || pendingType === config.type ? "#9ca3af" : "#2563eb",
-                      color: "#ffffff",
+                        !canManage || pendingType === config.type ? "var(--accent-disabled-strong)" : "var(--accent-primary)",
+                      color: "var(--surface-primary)",
                       fontWeight: 600,
                       cursor: !canManage || pendingType === config.type ? "not-allowed" : "pointer"
                     }}
@@ -355,7 +341,7 @@ const CategoriesSettings = () => {
               </div>
 
               {config.categories.length === 0 ? (
-                <p style={{ color: "#64748b" }}>Категории ещё не добавлены.</p>
+                <p style={{ color: "var(--text-muted)" }}>Категории ещё не добавлены.</p>
               ) : (
                 <ul
                   style={{
@@ -381,10 +367,10 @@ const CategoriesSettings = () => {
                           gap: "0.75rem",
                           padding: "0.6rem 0.9rem",
                           borderRadius: "0.75rem",
-                          backgroundColor: "#ffffff"
+                          backgroundColor: "var(--surface-primary)"
                         }}
                       >
-                        <span style={{ color: "#0f172a" }}>{item}</span>
+                        <span style={{ color: "var(--text-primary)" }}>{item}</span>
                         {canManage ? (
                           <button
                             type="button"
@@ -392,8 +378,8 @@ const CategoriesSettings = () => {
                             disabled={isDeleting}
                             style={{
                               border: "none",
-                              backgroundColor: "#ef4444",
-                              color: "#ffffff",
+                              backgroundColor: "var(--accent-danger-bright)",
+                              color: "var(--surface-primary)",
                               borderRadius: "999px",
                               padding: "0.35rem 0.85rem",
                               fontSize: "0.85rem",
@@ -413,15 +399,14 @@ const CategoriesSettings = () => {
         </section>
 
         {!canManage ? (
-          <p style={{ color: "#64748b" }}>
+          <p style={{ color: "var(--text-muted)" }}>
             Вы вошли как наблюдатель — изменение категорий недоступно.
           </p>
         ) : null}
 
-        {error ? <p style={{ color: "#b91c1c" }}>{error}</p> : null}
-        {message ? <p style={{ color: "#047857" }}>{message}</p> : null}
-      </main>
-    </div>
+        {error ? <p style={{ color: "var(--accent-danger)" }}>{error}</p> : null}
+        {message ? <p style={{ color: "var(--accent-teal-strong)" }}>{message}</p> : null}
+    </main>
   );
 };
 

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useMemo, useState, type FormEvent } from "react";
 import AuthGate from "@/components/AuthGate";
+import ThemeToggle from "@/components/ThemeToggle";
 import { useSession } from "@/components/SessionProvider";
 import { DEFAULT_SETTINGS, SUPPORTED_CURRENCIES } from "@/lib/currency";
 import type { Currency, Settings } from "@/lib/types";
@@ -184,29 +185,15 @@ const SettingsContent = () => {
   };
 
   return (
-    <div
+    <main
+      className="page-shell bg-white text-black dark:bg-midnight dark:text-slate-100"
       style={{
-        minHeight: "100vh",
-        backgroundColor: "#ede9fe",
-        padding: "3rem 1.5rem",
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "flex-start"
+        maxWidth: "820px",
+        width: "100%",
+        padding: "2.5rem 2.75rem",
+        gap: "2.25rem"
       }}
     >
-      <main
-        style={{
-          width: "100%",
-          maxWidth: "820px",
-          backgroundColor: "#ffffff",
-          borderRadius: "20px",
-          padding: "2.5rem 2.75rem",
-          boxShadow: "0 20px 45px rgba(109, 40, 217, 0.15)",
-          display: "flex",
-          flexDirection: "column",
-          gap: "2.25rem"
-        }}
-      >
         <nav
           style={{
             display: "flex",
@@ -221,8 +208,8 @@ const SettingsContent = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#e0e7ff",
-              color: "#1d4ed8",
+              backgroundColor: "var(--surface-blue)",
+              color: "var(--accent-blue)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(59, 130, 246, 0.25)"
             }}
@@ -234,8 +221,8 @@ const SettingsContent = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#ccfbf1",
-              color: "#0f766e",
+              backgroundColor: "var(--surface-teal)",
+              color: "var(--accent-teal)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(45, 212, 191, 0.25)"
             }}
@@ -247,8 +234,8 @@ const SettingsContent = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#eef2ff",
-              color: "#4338ca",
+              backgroundColor: "var(--surface-indigo)",
+              color: "var(--accent-indigo)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(99, 102, 241, 0.2)"
             }}
@@ -260,8 +247,8 @@ const SettingsContent = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#dcfce7",
-              color: "#15803d",
+              backgroundColor: "var(--surface-success)",
+              color: "var(--accent-success)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(34, 197, 94, 0.2)"
             }}
@@ -273,8 +260,8 @@ const SettingsContent = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#fef3c7",
-              color: "#b45309",
+              backgroundColor: "var(--surface-amber)",
+              color: "var(--accent-amber)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(217, 119, 6, 0.2)"
             }}
@@ -286,8 +273,8 @@ const SettingsContent = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#f5f3ff",
-              color: "#6d28d9",
+              backgroundColor: "var(--surface-purple)",
+              color: "var(--accent-purple)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(109, 40, 217, 0.2)"
             }}
@@ -303,15 +290,24 @@ const SettingsContent = () => {
             gap: "0.75rem"
           }}
         >
-          <h1 style={{ fontSize: "2rem", fontWeight: 700, color: "#312e81" }}>
+          <h1 style={{ fontSize: "2rem", fontWeight: 700, color: "var(--surface-navy)" }}>
             Финансовые настройки общины
           </h1>
-          <p style={{ color: "#475569", lineHeight: 1.6 }}>
+          <p style={{ color: "var(--text-secondary)", lineHeight: 1.6 }}>
             Обновляйте базовую валюту и курсы конвертации, чтобы отчёты оставались точными.
           </p>
         </header>
 
-        {loading ? <p style={{ color: "#64748b" }}>Загружаем настройки...</p> : null}
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "flex-end"
+          }}
+        >
+          <ThemeToggle />
+        </div>
+
+        {loading ? <p style={{ color: "var(--text-muted)" }}>Загружаем настройки...</p> : null}
 
         <form
           onSubmit={handleSubmit}
@@ -330,35 +326,35 @@ const SettingsContent = () => {
           >
             <article
               style={{
-                backgroundColor: "#eef2ff",
+                backgroundColor: "var(--surface-indigo)",
                 borderRadius: "1rem",
                 padding: "1.5rem",
                 boxShadow: "0 12px 28px rgba(99, 102, 241, 0.15)"
               }}
             >
-              <h2 style={{ color: "#312e81", fontWeight: 600, marginBottom: "0.5rem" }}>
+              <h2 style={{ color: "var(--surface-navy)", fontWeight: 600, marginBottom: "0.5rem" }}>
                 Базовая валюта
               </h2>
-              <strong style={{ fontSize: "1.5rem", color: "#3730a3" }}>{baseCurrency}</strong>
-              <p style={{ color: "#475569", marginTop: "0.5rem" }}>
+              <strong style={{ fontSize: "1.5rem", color: "var(--accent-indigo-strong)" }}>{baseCurrency}</strong>
+              <p style={{ color: "var(--text-secondary)", marginTop: "0.5rem" }}>
                 Все суммы приводятся к этой валюте для расчётов.
               </p>
             </article>
             <article
               style={{
-                backgroundColor: "#dcfce7",
+                backgroundColor: "var(--surface-success)",
                 borderRadius: "1rem",
                 padding: "1.5rem",
                 boxShadow: "0 12px 28px rgba(34, 197, 94, 0.12)"
               }}
             >
-              <h2 style={{ color: "#166534", fontWeight: 600, marginBottom: "0.5rem" }}>
+              <h2 style={{ color: "var(--accent-success-strong)", fontWeight: 600, marginBottom: "0.5rem" }}>
                 Текущий баланс (пример)
               </h2>
-              <strong style={{ fontSize: "1.5rem", color: "#15803d" }}>
+              <strong style={{ fontSize: "1.5rem", color: "var(--accent-success)" }}>
                 {baseFormatter.format(1_000_000)}
               </strong>
-              <p style={{ color: "#475569", marginTop: "0.5rem" }}>
+              <p style={{ color: "var(--text-secondary)", marginTop: "0.5rem" }}>
                 Для проверки отображения формата валюты.
               </p>
             </article>
@@ -376,7 +372,7 @@ const SettingsContent = () => {
                 key={code}
                 style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}
               >
-                <span style={{ fontWeight: 600, color: "#1f2937" }}>
+                <span style={{ fontWeight: 600, color: "var(--text-strong)" }}>
                   {code} за 1 {baseCurrency}
                 </span>
                 <input
@@ -394,7 +390,7 @@ const SettingsContent = () => {
                   style={{
                     padding: "0.85rem 1rem",
                     borderRadius: "0.75rem",
-                    border: "1px solid #d1d5db"
+                    border: "1px solid var(--border-muted)"
                   }}
                 />
               </label>
@@ -408,8 +404,8 @@ const SettingsContent = () => {
               padding: "0.95rem 1.5rem",
               borderRadius: "0.85rem",
               border: "none",
-              backgroundColor: saving || !canManage ? "#94a3b8" : "#6d28d9",
-              color: "#ffffff",
+              backgroundColor: saving || !canManage ? "var(--accent-disabled)" : "var(--accent-purple)",
+              color: "var(--surface-primary)",
               fontWeight: 600,
               boxShadow: "0 12px 24px rgba(109, 40, 217, 0.25)",
               cursor: !canManage || saving ? "not-allowed" : "pointer"
@@ -434,15 +430,15 @@ const SettingsContent = () => {
               gap: "0.5rem",
               padding: "1.5rem",
               borderRadius: "1rem",
-              backgroundColor: "#eef2ff",
+              backgroundColor: "var(--surface-indigo)",
               textDecoration: "none",
               boxShadow: "0 12px 24px rgba(79, 70, 229, 0.15)"
             }}
           >
-            <strong style={{ color: "#3730a3", fontSize: "1.1rem" }}>
+            <strong style={{ color: "var(--accent-indigo-strong)", fontSize: "1.1rem" }}>
               Категории
             </strong>
-            <span style={{ color: "#475569", lineHeight: 1.5 }}>
+            <span style={{ color: "var(--text-secondary)", lineHeight: 1.5 }}>
               Добавляйте и удаляйте категории прихода и расхода в отдельном разделе.
             </span>
           </Link>
@@ -455,30 +451,29 @@ const SettingsContent = () => {
               gap: "0.5rem",
               padding: "1.5rem",
               borderRadius: "1rem",
-              backgroundColor: "#ecfeff",
+              backgroundColor: "var(--surface-cyan)",
               textDecoration: "none",
               boxShadow: "0 12px 24px rgba(13, 148, 136, 0.15)"
             }}
           >
-            <strong style={{ color: "#0f766e", fontSize: "1.1rem" }}>
+            <strong style={{ color: "var(--accent-teal)", fontSize: "1.1rem" }}>
               Кошельки
             </strong>
-            <span style={{ color: "#475569", lineHeight: 1.5 }}>
+            <span style={{ color: "var(--text-secondary)", lineHeight: 1.5 }}>
               Управляйте списком кошельков, не затрагивая связанные операции.
             </span>
           </Link>
         </section>
 
         {!canManage ? (
-          <p style={{ color: "#64748b" }}>
+          <p style={{ color: "var(--text-muted)" }}>
             Вы вошли как наблюдатель — редактирование курсов недоступно.
           </p>
         ) : null}
 
-        {error ? <p style={{ color: "#b91c1c" }}>{error}</p> : null}
-        {message ? <p style={{ color: "#15803d" }}>{message}</p> : null}
-      </main>
-    </div>
+        {error ? <p style={{ color: "var(--accent-danger)" }}>{error}</p> : null}
+        {message ? <p style={{ color: "var(--accent-success)" }}>{message}</p> : null}
+    </main>
   );
 };
 

--- a/app/settings/wallets/page.tsx
+++ b/app/settings/wallets/page.tsx
@@ -174,29 +174,15 @@ const WalletSettings = () => {
   };
 
   return (
-    <div
+    <main
+      className="page-shell bg-white text-black dark:bg-midnight dark:text-slate-100"
       style={{
-        minHeight: "100vh",
-        backgroundColor: "#ecfeff",
-        padding: "3rem 1.5rem",
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "flex-start"
+        maxWidth: "760px",
+        width: "100%",
+        padding: "2.5rem 2.75rem",
+        gap: "2rem"
       }}
     >
-      <main
-        style={{
-          width: "100%",
-          maxWidth: "760px",
-          backgroundColor: "#ffffff",
-          borderRadius: "20px",
-          padding: "2.5rem 2.75rem",
-          boxShadow: "0 20px 45px rgba(13, 148, 136, 0.15)",
-          display: "flex",
-          flexDirection: "column",
-          gap: "2rem"
-        }}
-      >
         <nav
           style={{
             display: "flex",
@@ -211,8 +197,8 @@ const WalletSettings = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#ccfbf1",
-              color: "#0f766e",
+              backgroundColor: "var(--surface-teal)",
+              color: "var(--accent-teal)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(45, 212, 191, 0.25)"
             }}
@@ -224,8 +210,8 @@ const WalletSettings = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#e0e7ff",
-              color: "#1d4ed8",
+              backgroundColor: "var(--surface-blue)",
+              color: "var(--accent-blue)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(59, 130, 246, 0.25)"
             }}
@@ -241,16 +227,16 @@ const WalletSettings = () => {
             gap: "0.75rem"
           }}
         >
-          <h1 style={{ fontSize: "2rem", fontWeight: 700, color: "#0f172a" }}>
+          <h1 style={{ fontSize: "2rem", fontWeight: 700, color: "var(--text-primary)" }}>
             Управление кошельками
           </h1>
-          <p style={{ color: "#475569", lineHeight: 1.6 }}>
+          <p style={{ color: "var(--text-secondary)", lineHeight: 1.6 }}>
             Добавляйте и удаляйте кошельки. История операций сохраняется, даже если
             кошелёк удалён из списка.
           </p>
         </header>
 
-        {loading ? <p style={{ color: "#64748b" }}>Загружаем список...</p> : null}
+        {loading ? <p style={{ color: "var(--text-muted)" }}>Загружаем список...</p> : null}
 
         <form
           onSubmit={handleAdd}
@@ -275,7 +261,7 @@ const WalletSettings = () => {
               minWidth: "220px",
               padding: "0.8rem 1rem",
               borderRadius: "0.75rem",
-              border: "1px solid #d1d5db"
+              border: "1px solid var(--border-muted)"
             }}
           />
           <button
@@ -285,8 +271,8 @@ const WalletSettings = () => {
               padding: "0.8rem 1.4rem",
               borderRadius: "0.75rem",
               border: "none",
-              backgroundColor: !canManage || saving ? "#9ca3af" : "#0f766e",
-              color: "#ffffff",
+              backgroundColor: !canManage || saving ? "var(--accent-disabled-strong)" : "var(--accent-teal)",
+              color: "var(--surface-primary)",
               fontWeight: 600,
               cursor: !canManage || saving ? "not-allowed" : "pointer"
             }}
@@ -296,7 +282,7 @@ const WalletSettings = () => {
         </form>
 
         {wallets.length === 0 ? (
-          <p style={{ color: "#64748b" }}>
+          <p style={{ color: "var(--text-muted)" }}>
             Список пуст. Добавьте первый кошелёк, чтобы использовать его в операциях.
           </p>
         ) : (
@@ -323,11 +309,11 @@ const WalletSettings = () => {
                     gap: "0.75rem",
                     padding: "0.75rem 1rem",
                     borderRadius: "0.85rem",
-                    backgroundColor: "#f0fdfa",
-                    border: "1px solid #99f6e4"
+                    backgroundColor: "var(--surface-teal-bright)",
+                    border: "1px solid var(--surface-teal-strong)"
                   }}
                 >
-                  <span style={{ color: "#0f172a", fontWeight: 500 }}>{wallet}</span>
+                  <span style={{ color: "var(--text-primary)", fontWeight: 500 }}>{wallet}</span>
                   {canManage ? (
                     <button
                       type="button"
@@ -335,8 +321,8 @@ const WalletSettings = () => {
                       disabled={isDeleting}
                       style={{
                         border: "none",
-                        backgroundColor: "#ef4444",
-                        color: "#ffffff",
+                        backgroundColor: "var(--accent-danger-bright)",
+                        color: "var(--surface-primary)",
                         borderRadius: "999px",
                         padding: "0.35rem 0.85rem",
                         fontSize: "0.85rem",
@@ -353,15 +339,14 @@ const WalletSettings = () => {
         )}
 
         {!canManage ? (
-          <p style={{ color: "#64748b" }}>
+          <p style={{ color: "var(--text-muted)" }}>
             Вы вошли как наблюдатель — изменение списка кошельков недоступно.
           </p>
         ) : null}
 
-        {error ? <p style={{ color: "#b91c1c" }}>{error}</p> : null}
-        {message ? <p style={{ color: "#047857" }}>{message}</p> : null}
-      </main>
-    </div>
+        {error ? <p style={{ color: "var(--accent-danger)" }}>{error}</p> : null}
+        {message ? <p style={{ color: "var(--accent-teal-strong)" }}>{message}</p> : null}
+    </main>
   );
 };
 

--- a/app/wallets/page.tsx
+++ b/app/wallets/page.tsx
@@ -205,29 +205,15 @@ const WalletsContent = () => {
     [summaries]
   );
   return (
-    <div
+    <main
+      className="page-shell bg-white text-black dark:bg-midnight dark:text-slate-100"
       style={{
-        minHeight: "100vh",
-        backgroundColor: "#ecfeff",
-        padding: "3rem 1.5rem",
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "flex-start"
+        maxWidth: "880px",
+        width: "100%",
+        padding: "2.5rem 2.75rem",
+        gap: "2.5rem"
       }}
     >
-      <main
-        style={{
-          width: "100%",
-          maxWidth: "880px",
-          backgroundColor: "#ffffff",
-          borderRadius: "20px",
-          padding: "2.5rem 2.75rem",
-          boxShadow: "0 20px 45px rgba(13, 148, 136, 0.15)",
-          display: "flex",
-          flexDirection: "column",
-          gap: "2.5rem"
-        }}
-      >
         <nav
           style={{
             display: "flex",
@@ -242,8 +228,8 @@ const WalletsContent = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#e0e7ff",
-              color: "#1d4ed8",
+              backgroundColor: "var(--surface-blue)",
+              color: "var(--accent-blue)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(59, 130, 246, 0.25)"
             }}
@@ -255,8 +241,8 @@ const WalletsContent = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#99f6e4",
-              color: "#047857",
+              backgroundColor: "var(--surface-teal-strong)",
+              color: "var(--accent-teal-strong)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(16, 185, 129, 0.25)"
             }}
@@ -268,8 +254,8 @@ const WalletsContent = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#eef2ff",
-              color: "#4338ca",
+              backgroundColor: "var(--surface-indigo)",
+              color: "var(--accent-indigo)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(99, 102, 241, 0.2)"
             }}
@@ -281,8 +267,8 @@ const WalletsContent = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#dcfce7",
-              color: "#15803d",
+              backgroundColor: "var(--surface-success)",
+              color: "var(--accent-success)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(34, 197, 94, 0.2)"
             }}
@@ -294,8 +280,8 @@ const WalletsContent = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#fef3c7",
-              color: "#b45309",
+              backgroundColor: "var(--surface-amber)",
+              color: "var(--accent-amber)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(217, 119, 6, 0.2)"
             }}
@@ -307,8 +293,8 @@ const WalletsContent = () => {
             style={{
               padding: "0.6rem 1.4rem",
               borderRadius: "999px",
-              backgroundColor: "#f5f3ff",
-              color: "#6d28d9",
+              backgroundColor: "var(--surface-purple)",
+              color: "var(--accent-purple)",
               fontWeight: 600,
               boxShadow: "0 4px 12px rgba(109, 40, 217, 0.2)"
             }}
@@ -324,16 +310,16 @@ const WalletsContent = () => {
             gap: "0.75rem"
           }}
         >
-          <h1 style={{ fontSize: "2rem", fontWeight: 700, color: "#0f172a" }}>
+          <h1 style={{ fontSize: "2rem", fontWeight: 700, color: "var(--text-primary)" }}>
             Состояние кошельков
           </h1>
-          <p style={{ color: "#475569", lineHeight: 1.6 }}>
+          <p style={{ color: "var(--text-secondary)", lineHeight: 1.6 }}>
             Анализируйте балансы по каждому кошельку с учётом долгов и целевых средств.
           </p>
         </header>
 
-        {loading ? <p style={{ color: "#64748b" }}>Загружаем данные...</p> : null}
-        {error ? <p style={{ color: "#b91c1c" }}>{error}</p> : null}
+        {loading ? <p style={{ color: "var(--text-muted)" }}>Загружаем данные...</p> : null}
+        {error ? <p style={{ color: "var(--accent-danger)" }}>{error}</p> : null}
 
         <section style={{ display: "flex", flexDirection: "column", gap: "1.25rem" }}>
           <div
@@ -345,24 +331,24 @@ const WalletsContent = () => {
               flexWrap: "wrap"
             }}
           >
-            <h2 style={{ fontSize: "1.4rem", fontWeight: 600, color: "#0f172a" }}>
+            <h2 style={{ fontSize: "1.4rem", fontWeight: 600, color: "var(--text-primary)" }}>
               Активные кошельки
             </h2>
           </div>
 
-          <p style={{ color: "#475569", margin: 0 }}>
+          <p style={{ color: "var(--text-secondary)", margin: 0 }}>
             Просматривайте активные кошельки и их остатки. Добавление и удаление доступно в
             отдельном разделе.
           </p>
 
-          <p style={{ color: "#64748b", margin: 0 }}>
+          <p style={{ color: "var(--text-muted)", margin: 0 }}>
             {wallets.length === 0
               ? "Пока нет активных кошельков — бухгалтер может добавить их в разделе настроек."
               : `Сейчас активных кошельков: ${wallets.length}.`}
           </p>
 
           {!canManage ? (
-            <p style={{ color: "#64748b" }}>
+            <p style={{ color: "var(--text-muted)" }}>
               Управление списком кошельков доступно бухгалтеру.
             </p>
           ) : null}
@@ -376,7 +362,7 @@ const WalletsContent = () => {
           }}
         >
           {summaries.length === 0 ? (
-            <p style={{ color: "#64748b", gridColumn: "1 / -1" }}>
+            <p style={{ color: "var(--text-muted)", gridColumn: "1 / -1" }}>
               Пока нет кошельков или связанных операций.
             </p>
           ) : (
@@ -384,22 +370,22 @@ const WalletsContent = () => {
               <article
                 key={summary.wallet}
                 style={{
-                  backgroundColor: summary.active ? "#f8fafc" : "#f1f5f9",
+                  backgroundColor: summary.active ? "var(--surface-subtle)" : "var(--surface-muted)",
                   borderRadius: "1rem",
                   padding: "1.5rem",
                   boxShadow: summary.active
                     ? "0 12px 24px rgba(13, 148, 136, 0.12)"
                     : "0 8px 18px rgba(100, 116, 139, 0.12)",
-                  border: summary.active ? "1px solid transparent" : "1px dashed #94a3b8",
+                  border: summary.active ? "1px solid transparent" : "1px dashed var(--accent-disabled)",
                   display: "flex",
                   flexDirection: "column",
                   gap: "0.6rem"
                 }}
               >
                 <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem" }}>
-                  <h2 style={{ color: "#0f172a", fontWeight: 600 }}>{summary.wallet}</h2>
+                  <h2 style={{ color: "var(--text-primary)", fontWeight: 600 }}>{summary.wallet}</h2>
                   {!summary.active ? (
-                    <span style={{ color: "#b45309", fontSize: "0.85rem" }}>
+                    <span style={{ color: "var(--accent-amber)", fontSize: "0.85rem" }}>
                       Кошелёк удалён — операции и остатки сохранены
                     </span>
                   ) : null}
@@ -407,7 +393,7 @@ const WalletsContent = () => {
                 <strong
                   style={{
                     fontSize: "1.5rem",
-                    color: summary.actualAmount >= 0 ? "#047857" : "#b91c1c"
+                    color: summary.actualAmount >= 0 ? "var(--accent-teal-strong)" : "var(--accent-danger)"
                   }}
                 >
                   {currencyFormatter.format(summary.actualAmount)}
@@ -418,19 +404,18 @@ const WalletsContent = () => {
         </section>
 
         {summaries.length > 0 && hasArchivedWallets ? (
-          <p style={{ color: "#b45309" }}>
+          <p style={{ color: "var(--accent-amber)" }}>
             Удалённые кошельки помечены отдельно — связанные операции и балансы остаются в
             отчётах.
           </p>
         ) : null}
 
         {!hasActivity ? (
-          <p style={{ color: "#64748b" }}>
+          <p style={{ color: "var(--text-muted)" }}>
             Пока нет операций, влияющих на кошельки.
           </p>
         ) : null}
-      </main>
-    </div>
+    </main>
   );
 };
 

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTheme } from "next-themes";
+
+const ThemeToggle = () => {
+  const { resolvedTheme, setTheme, theme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const mode = theme === "system" ? resolvedTheme : theme;
+  const isDark = mode === "dark";
+
+  if (!mounted) {
+    return null;
+  }
+
+  return (
+    <button
+      type="button"
+      className="theme-toggle"
+      data-mode={isDark ? "dark" : "light"}
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      aria-label={isDark ? "Включить светлую тему" : "Включить тёмную тему"}
+      title={isDark ? "Светлая тема" : "Тёмная тема"}
+    >
+      <span className="theme-toggle__track">
+        <span className="theme-toggle__thumb" />
+      </span>
+      <span className="theme-toggle__label">{isDark ? "Тёмная тема" : "Светлая тема"}</span>
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/lib/next-themes.tsx
+++ b/lib/next-themes.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode
+} from "react";
+
+export type Theme = "light" | "dark" | "system";
+
+type ResolvedTheme = "light" | "dark";
+
+type ThemeContextValue = {
+  theme: Theme;
+  resolvedTheme: ResolvedTheme;
+  setTheme: (value: Theme) => void;
+  toggleTheme: () => void;
+};
+
+const noop = () => {
+  // noop
+};
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: "light",
+  resolvedTheme: "light",
+  setTheme: noop,
+  toggleTheme: noop
+});
+
+type ThemeProviderProps = {
+  attribute?: "class" | "data-theme";
+  children: ReactNode;
+  defaultTheme?: Theme;
+  enableSystem?: boolean;
+  storageKey?: string;
+};
+
+const prefersDarkScheme = "(prefers-color-scheme: dark)";
+
+const resolveSystemTheme = () =>
+  typeof window !== "undefined" && window.matchMedia(prefersDarkScheme).matches
+    ? "dark"
+    : "light";
+
+const setHtmlAttribute = (attribute: string, value: ResolvedTheme) => {
+  const root = document.documentElement;
+
+  if (attribute === "class") {
+    root.classList.remove("light", "dark");
+    root.classList.add(value);
+    return;
+  }
+
+  root.setAttribute(attribute, value);
+};
+
+export const ThemeProvider = ({
+  attribute = "class",
+  children,
+  defaultTheme = "system",
+  enableSystem = true,
+  storageKey = "theme"
+}: ThemeProviderProps) => {
+  const [theme, setThemeState] = useState<Theme>(defaultTheme);
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(
+    defaultTheme === "dark" ? "dark" : "light"
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const stored = window.localStorage.getItem(storageKey) as Theme | null;
+
+    if (stored === "light" || stored === "dark" || stored === "system") {
+      setThemeState(stored);
+      return;
+    }
+
+    setThemeState(defaultTheme);
+  }, [defaultTheme, storageKey]);
+
+  const updateTheme = useCallback(
+    (value: Theme) => {
+      setThemeState(value);
+
+      if (typeof window === "undefined") {
+        return;
+      }
+
+      if (value === "system") {
+        window.localStorage.removeItem(storageKey);
+        return;
+      }
+
+      window.localStorage.setItem(storageKey, value);
+    },
+    [storageKey]
+  );
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    const resolved =
+      theme === "system" && enableSystem ? resolveSystemTheme() : theme === "dark" ? "dark" : "light";
+
+    setHtmlAttribute(attribute, resolved);
+    setResolvedTheme(resolved);
+
+    if (!enableSystem || theme !== "system") {
+      return;
+    }
+
+    const media = window.matchMedia(prefersDarkScheme);
+
+    const listener = () => {
+      const systemTheme = resolveSystemTheme();
+      setHtmlAttribute(attribute, systemTheme);
+      setResolvedTheme(systemTheme);
+    };
+
+    media.addEventListener("change", listener);
+
+    return () => {
+      media.removeEventListener("change", listener);
+    };
+  }, [attribute, enableSystem, theme]);
+
+  const toggleTheme = useCallback(() => {
+    updateTheme(resolvedTheme === "dark" ? "light" : "dark");
+  }, [resolvedTheme, updateTheme]);
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({
+      theme,
+      resolvedTheme,
+      setTheme: updateTheme,
+      toggleTheme
+    }),
+    [resolvedTheme, theme, toggleTheme, updateTheme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export const useTheme = () => useContext(ThemeContext);
+
+export default ThemeProvider;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,9 @@
     "paths": {
       "@/*": [
         "./*"
+      ],
+      "next-themes": [
+        "./lib/next-themes"
       ]
     },
     "plugins": [


### PR DESCRIPTION
## Summary
- implement a local next-themes compatible provider and wrap the root layout so every page reacts to light or dark mode
- introduce CSS variables, a reusable page-shell, and utility classes to keep backgrounds and text synchronized with the active theme
- expose a settings toggle for switching themes and update each major view to consume the shared palette

## Testing
- npm run lint *(fails: `next` command not available because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d179e219a48331b9487d1652e95060