### PR TITLE
Unify layout across tabs and tidy settings forms

### DIFF
--- a/app/debts/page.tsx
+++ b/app/debts/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import Link from "next/link";
 import { useEffect, useMemo, useState, type FormEvent } from "react";
 import AuthGate from "@/components/AuthGate";
+import PageContainer from "@/components/PageContainer";
 import { useSession } from "@/components/SessionProvider";
 import {
   convertToBase,
@@ -291,104 +291,7 @@ const DebtsContent = () => {
   };
 
   return (
-    <main
-      className="page-shell bg-white text-black dark:bg-midnight dark:text-slate-100"
-      style={{
-        width: "min(720px, 100%)",
-        padding: "2.5rem 2rem",
-        boxShadow: "var(--shadow-soft)",
-        gap: "2rem"
-      }}
-    >
-      <nav
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "flex-start",
-          gap: "1rem",
-          flexWrap: "wrap"
-        }}
-      >
-        <Link
-          href="/"
-          style={{
-            padding: "0.6rem 1.4rem",
-            borderRadius: "999px",
-            backgroundColor: "var(--surface-blue)",
-            color: "var(--accent-blue)",
-            fontWeight: 600,
-            boxShadow: "0 4px 12px rgba(59, 130, 246, 0.25)"
-          }}
-        >
-          Главная
-        </Link>
-        <Link
-          href="/wallets"
-          style={{
-            padding: "0.6rem 1.4rem",
-            borderRadius: "999px",
-            backgroundColor: "var(--surface-teal)",
-            color: "var(--accent-teal)",
-            fontWeight: 600,
-            boxShadow: "0 4px 12px rgba(45, 212, 191, 0.25)"
-          }}
-        >
-          Кошельки
-        </Link>
-        <Link
-          href="/debts"
-          style={{
-            padding: "0.6rem 1.4rem",
-            borderRadius: "999px",
-            backgroundColor: "var(--surface-indigo)",
-            color: "var(--accent-indigo)",
-            fontWeight: 600,
-            boxShadow: "0 4px 12px rgba(99, 102, 241, 0.2)"
-          }}
-        >
-          Долги
-        </Link>
-        <Link
-          href="/planning"
-          style={{
-            padding: "0.6rem 1.4rem",
-            borderRadius: "999px",
-            backgroundColor: "var(--surface-success)",
-            color: "var(--accent-success)",
-            fontWeight: 600,
-            boxShadow: "0 4px 12px rgba(34, 197, 94, 0.2)"
-          }}
-        >
-          Планирование
-        </Link>
-        <Link
-          href="/reports"
-          style={{
-            padding: "0.6rem 1.4rem",
-            borderRadius: "999px",
-            backgroundColor: "var(--surface-amber)",
-            color: "var(--accent-amber)",
-            fontWeight: 600,
-            boxShadow: "0 4px 12px rgba(217, 119, 6, 0.2)"
-          }}
-        >
-          Отчёты
-        </Link>
-        <Link
-          href="/settings"
-          style={{
-            padding: "0.6rem 1.4rem",
-            borderRadius: "999px",
-            backgroundColor: "var(--surface-purple)",
-            color: "var(--accent-purple)",
-            fontWeight: 600,
-            boxShadow: "0 4px 12px rgba(109, 40, 217, 0.2)"
-          }}
-        >
-          Настройки
-        </Link>
-      </nav>
-
+    <PageContainer activeTab="debts">
       <header style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
         <h1 style={{ fontSize: "1.85rem", fontWeight: 700, color: "var(--text-primary)" }}>
           Управление долгами
@@ -659,24 +562,13 @@ const DebtsContent = () => {
           </ul>
         )}
       </section>
-    </main>
+    </PageContainer>
   );
 };
 
 const DebtsPage = () => (
   <AuthGate>
-    <div
-      style={{
-        minHeight: "100vh",
-        backgroundColor: "var(--surface-muted)",
-        padding: "3rem 1.5rem",
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "flex-start"
-      }}
-    >
-      <DebtsContent />
-    </div>
+    <DebtsContent />
   </AuthGate>
 );
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -241,6 +241,117 @@ button {
   color: var(--text-secondary);
 }
 
+/* Tailwind-inspired utility classes used for layout adjustments */
+.flex {
+  display: flex;
+}
+
+.inline-flex {
+  display: inline-flex;
+}
+
+.flex-col {
+  flex-direction: column;
+}
+
+.flex-wrap {
+  flex-wrap: wrap;
+}
+
+.items-center {
+  align-items: center;
+}
+
+.justify-center {
+  justify-content: center;
+}
+
+.gap-2 {
+  gap: 0.5rem;
+}
+
+.gap-3 {
+  gap: 0.75rem;
+}
+
+.gap-4 {
+  gap: 1rem;
+}
+
+.gap-10 {
+  gap: 2.5rem;
+}
+
+.w-full {
+  width: 100%;
+}
+
+.flex-1 {
+  flex: 1 1 0%;
+}
+
+.min-w-0 {
+  min-width: 0;
+}
+
+.px-4 {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.px-5 {
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
+}
+
+.py-2 {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
+.py-2\.5 {
+  padding-top: 0.625rem;
+  padding-bottom: 0.625rem;
+}
+
+.py-3 {
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+}
+
+.rounded-full {
+  border-radius: 9999px;
+}
+
+.rounded-xl {
+  border-radius: 0.75rem;
+}
+
+.text-sm {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
+.font-semibold {
+  font-weight: 600;
+}
+
+.border {
+  border: 1px solid var(--border-muted);
+}
+
+.whitespace-nowrap {
+  white-space: nowrap;
+}
+
+.transition-colors {
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tab-pill {
+  box-shadow: var(--shadow-soft);
+}
+
 @media (max-width: 900px) {
   body {
     padding: 2rem 1rem 3rem;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
 import AuthGate from "@/components/AuthGate";
+import PageContainer from "@/components/PageContainer";
 import { useSession } from "@/components/SessionProvider";
 import {
   convertToBase,
@@ -424,97 +424,8 @@ const Dashboard = () => {
     }
   };
   return (
-    <main className="page-shell bg-white text-black dark:bg-midnight dark:text-slate-100">
-        <nav
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "flex-start",
-            gap: "1rem",
-            flexWrap: "wrap"
-          }}
-        >
-          <Link
-            href="/"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-blue)",
-              color: "var(--accent-blue)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(59, 130, 246, 0.25)"
-            }}
-          >
-            Главная
-          </Link>
-          <Link
-            href="/wallets"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-teal)",
-              color: "var(--accent-teal)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(45, 212, 191, 0.25)"
-            }}
-          >
-            Кошельки
-          </Link>
-          <Link
-            href="/debts"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-indigo)",
-              color: "var(--accent-indigo)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(99, 102, 241, 0.2)"
-            }}
-          >
-            Долги
-          </Link>
-          <Link
-            href="/planning"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-success)",
-              color: "var(--accent-success)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(34, 197, 94, 0.2)"
-            }}
-          >
-            Планирование
-          </Link>
-          <Link
-            href="/reports"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-amber)",
-              color: "var(--accent-amber)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(217, 119, 6, 0.2)"
-            }}
-          >
-            Отчёты
-          </Link>
-          <Link
-            href="/settings"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-purple)",
-              color: "var(--accent-purple)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(109, 40, 217, 0.2)"
-            }}
-          >
-            Настройки
-          </Link>
-        </nav>
-
-        <header
+    <PageContainer activeTab="home">
+      <header
           style={{
             display: "flex",
             flexDirection: "column",
@@ -804,7 +715,7 @@ const Dashboard = () => {
             </ul>
           )}
         </section>
-    </main>
+    </PageContainer>
   );
 };
 

--- a/app/planning/page.tsx
+++ b/app/planning/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
 import AuthGate from "@/components/AuthGate";
+import PageContainer from "@/components/PageContainer";
 import { useSession } from "@/components/SessionProvider";
 import { convertFromBase, DEFAULT_SETTINGS, SUPPORTED_CURRENCIES } from "@/lib/currency";
 import type { Currency, Goal, Settings } from "@/lib/types";
@@ -245,105 +245,8 @@ const PlanningContent = () => {
   };
 
   return (
-    <main
-      className="page-shell bg-white text-black dark:bg-midnight dark:text-slate-100"
-      style={{
-        maxWidth: "840px",
-        width: "100%",
-        padding: "2.5rem 2.75rem",
-        gap: "2.25rem"
-      }}
-    >
-        <nav
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "flex-start",
-            gap: "1rem",
-            flexWrap: "wrap"
-          }}
-        >
-          <Link
-            href="/"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-blue)",
-              color: "var(--accent-blue)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(59, 130, 246, 0.25)"
-            }}
-          >
-            Главная
-          </Link>
-          <Link
-            href="/wallets"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-teal)",
-              color: "var(--accent-teal)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(45, 212, 191, 0.25)"
-            }}
-          >
-            Кошельки
-          </Link>
-          <Link
-            href="/debts"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-indigo)",
-              color: "var(--accent-indigo)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(99, 102, 241, 0.2)"
-            }}
-          >
-            Долги
-          </Link>
-          <Link
-            href="/planning"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-success)",
-              color: "var(--accent-success)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(34, 197, 94, 0.2)"
-            }}
-          >
-            Планирование
-          </Link>
-          <Link
-            href="/reports"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-amber)",
-              color: "var(--accent-amber)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(217, 119, 6, 0.2)"
-            }}
-          >
-            Отчёты
-          </Link>
-          <Link
-            href="/settings"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-purple)",
-              color: "var(--accent-purple)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(109, 40, 217, 0.2)"
-            }}
-          >
-            Настройки
-          </Link>
-        </nav>
-
-        <header
+    <PageContainer activeTab="planning">
+      <header
           style={{
             display: "flex",
             flexDirection: "column",
@@ -592,7 +495,7 @@ const PlanningContent = () => {
             </ul>
           )}
         </section>
-    </main>
+    </PageContainer>
   );
 };
 

--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import AuthGate from "@/components/AuthGate";
+import PageContainer from "@/components/PageContainer";
 import { useSession } from "@/components/SessionProvider";
 import { convertToBase, DEFAULT_SETTINGS } from "@/lib/currency";
 import type { Operation, Settings } from "@/lib/types";
@@ -489,105 +489,8 @@ const ReportsContent = () => {
 
 
   return (
-    <main
-      className="page-shell bg-white text-black dark:bg-midnight dark:text-slate-100"
-      style={{
-        maxWidth: "900px",
-        width: "100%",
-        padding: "2.75rem",
-        gap: "2.5rem"
-      }}
-    >
-        <nav
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "flex-start",
-            gap: "1rem",
-            flexWrap: "wrap"
-          }}
-        >
-          <Link
-            href="/"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-blue)",
-              color: "var(--accent-blue)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(59, 130, 246, 0.25)"
-            }}
-          >
-            Главная
-          </Link>
-          <Link
-            href="/wallets"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-teal)",
-              color: "var(--accent-teal)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(45, 212, 191, 0.25)"
-            }}
-          >
-            Кошельки
-          </Link>
-          <Link
-            href="/debts"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-indigo)",
-              color: "var(--accent-indigo)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(99, 102, 241, 0.2)"
-            }}
-          >
-            Долги
-          </Link>
-          <Link
-            href="/planning"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-success)",
-              color: "var(--accent-success)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(34, 197, 94, 0.2)"
-            }}
-          >
-            Планирование
-          </Link>
-          <Link
-            href="/reports"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-amber)",
-              color: "var(--accent-amber)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(217, 119, 6, 0.2)"
-            }}
-          >
-            Отчёты
-          </Link>
-          <Link
-            href="/settings"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-purple)",
-              color: "var(--accent-purple)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(109, 40, 217, 0.2)"
-            }}
-          >
-            Настройки
-          </Link>
-        </nav>
-
-        <header
+    <PageContainer activeTab="reports">
+      <header
           style={{
             display: "flex",
             flexDirection: "column",
@@ -797,7 +700,7 @@ const ReportsContent = () => {
         >
           {isExporting ? "Готовим файл..." : "Экспортировать PDF"}
         </button>
-    </main>
+    </PageContainer>
   );
 };
 

--- a/app/settings/categories/page.tsx
+++ b/app/settings/categories/page.tsx
@@ -302,7 +302,7 @@ const CategoriesSettings = () => {
                 <h2 style={{ color: config.color, fontWeight: 600 }}>{config.title}</h2>
                 <form
                   onSubmit={(event) => handleAdd(event, config.type)}
-                  style={{ display: "flex", gap: "0.5rem" }}
+                  className="flex items-center gap-3"
                 >
                   <input
                     type="text"
@@ -314,24 +314,19 @@ const CategoriesSettings = () => {
                     }}
                     placeholder="Новая категория"
                     disabled={!canManage || pendingType === config.type}
-                    style={{
-                      flex: 1,
-                      padding: "0.75rem 1rem",
-                      borderRadius: "0.75rem",
-                      border: "1px solid var(--border-muted)"
-                    }}
+                    className="flex-1 min-w-0 rounded-xl border px-4 py-3"
                   />
                   <button
                     type="submit"
                     disabled={!canManage || pendingType === config.type}
+                    className="inline-flex items-center justify-center rounded-xl px-5 py-3 font-semibold whitespace-nowrap transition-colors"
                     style={{
-                      padding: "0.75rem 1.25rem",
-                      borderRadius: "0.75rem",
-                      border: "none",
                       backgroundColor:
-                        !canManage || pendingType === config.type ? "var(--accent-disabled-strong)" : "var(--accent-primary)",
+                        !canManage || pendingType === config.type
+                          ? "var(--accent-disabled-strong)"
+                          : "var(--accent-primary)",
                       color: "var(--surface-primary)",
-                      fontWeight: 600,
+                      boxShadow: "0 10px 18px rgba(37, 99, 235, 0.2)",
                       cursor: !canManage || pendingType === config.type ? "not-allowed" : "pointer"
                     }}
                   >

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useMemo, useState, type FormEvent } from "react";
 import AuthGate from "@/components/AuthGate";
+import PageContainer from "@/components/PageContainer";
 import ThemeToggle from "@/components/ThemeToggle";
 import { useSession } from "@/components/SessionProvider";
 import { DEFAULT_SETTINGS, SUPPORTED_CURRENCIES } from "@/lib/currency";
@@ -185,105 +186,8 @@ const SettingsContent = () => {
   };
 
   return (
-    <main
-      className="page-shell bg-white text-black dark:bg-midnight dark:text-slate-100"
-      style={{
-        maxWidth: "820px",
-        width: "100%",
-        padding: "2.5rem 2.75rem",
-        gap: "2.25rem"
-      }}
-    >
-        <nav
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "flex-start",
-            gap: "1rem",
-            flexWrap: "wrap"
-          }}
-        >
-          <Link
-            href="/"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-blue)",
-              color: "var(--accent-blue)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(59, 130, 246, 0.25)"
-            }}
-          >
-            Главная
-          </Link>
-          <Link
-            href="/wallets"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-teal)",
-              color: "var(--accent-teal)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(45, 212, 191, 0.25)"
-            }}
-          >
-            Кошельки
-          </Link>
-          <Link
-            href="/debts"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-indigo)",
-              color: "var(--accent-indigo)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(99, 102, 241, 0.2)"
-            }}
-          >
-            Долги
-          </Link>
-          <Link
-            href="/planning"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-success)",
-              color: "var(--accent-success)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(34, 197, 94, 0.2)"
-            }}
-          >
-            Планирование
-          </Link>
-          <Link
-            href="/reports"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-amber)",
-              color: "var(--accent-amber)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(217, 119, 6, 0.2)"
-            }}
-          >
-            Отчёты
-          </Link>
-          <Link
-            href="/settings"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-purple)",
-              color: "var(--accent-purple)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(109, 40, 217, 0.2)"
-            }}
-          >
-            Настройки
-          </Link>
-        </nav>
-
-        <header
+    <PageContainer activeTab="settings">
+      <header
           style={{
             display: "flex",
             flexDirection: "column",
@@ -473,7 +377,7 @@ const SettingsContent = () => {
 
         {error ? <p style={{ color: "var(--accent-danger)" }}>{error}</p> : null}
         {message ? <p style={{ color: "var(--accent-success)" }}>{message}</p> : null}
-    </main>
+    </PageContainer>
   );
 };
 

--- a/app/settings/wallets/page.tsx
+++ b/app/settings/wallets/page.tsx
@@ -238,14 +238,7 @@ const WalletSettings = () => {
 
         {loading ? <p style={{ color: "var(--text-muted)" }}>Загружаем список...</p> : null}
 
-        <form
-          onSubmit={handleAdd}
-          style={{
-            display: "flex",
-            gap: "0.75rem",
-            flexWrap: "wrap"
-          }}
-        >
+        <form onSubmit={handleAdd} className="flex items-center gap-3">
           <input
             type="text"
             value={newWallet}
@@ -256,24 +249,17 @@ const WalletSettings = () => {
             }}
             disabled={!canManage || saving}
             placeholder="Название кошелька"
-            style={{
-              flex: 1,
-              minWidth: "220px",
-              padding: "0.8rem 1rem",
-              borderRadius: "0.75rem",
-              border: "1px solid var(--border-muted)"
-            }}
+            className="flex-1 min-w-0 rounded-xl border px-4 py-3"
+            style={{ minWidth: "220px" }}
           />
           <button
             type="submit"
             disabled={!canManage || saving}
+            className="inline-flex items-center justify-center rounded-xl px-5 py-3 font-semibold whitespace-nowrap transition-colors"
             style={{
-              padding: "0.8rem 1.4rem",
-              borderRadius: "0.75rem",
-              border: "none",
               backgroundColor: !canManage || saving ? "var(--accent-disabled-strong)" : "var(--accent-teal)",
               color: "var(--surface-primary)",
-              fontWeight: 600,
+              boxShadow: "0 10px 18px rgba(13, 148, 136, 0.25)",
               cursor: !canManage || saving ? "not-allowed" : "pointer"
             }}
           >

--- a/app/wallets/page.tsx
+++ b/app/wallets/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import AuthGate from "@/components/AuthGate";
+import PageContainer from "@/components/PageContainer";
 import { useSession } from "@/components/SessionProvider";
 import { convertToBase, DEFAULT_SETTINGS } from "@/lib/currency";
 import { type Debt, type Goal, type Operation, type Settings, type Wallet } from "@/lib/types";
@@ -205,105 +205,8 @@ const WalletsContent = () => {
     [summaries]
   );
   return (
-    <main
-      className="page-shell bg-white text-black dark:bg-midnight dark:text-slate-100"
-      style={{
-        maxWidth: "880px",
-        width: "100%",
-        padding: "2.5rem 2.75rem",
-        gap: "2.5rem"
-      }}
-    >
-        <nav
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "flex-start",
-            gap: "1rem",
-            flexWrap: "wrap"
-          }}
-        >
-          <Link
-            href="/"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-blue)",
-              color: "var(--accent-blue)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(59, 130, 246, 0.25)"
-            }}
-          >
-            Главная
-          </Link>
-          <Link
-            href="/wallets"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-teal-strong)",
-              color: "var(--accent-teal-strong)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(16, 185, 129, 0.25)"
-            }}
-          >
-            Кошельки
-          </Link>
-          <Link
-            href="/debts"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-indigo)",
-              color: "var(--accent-indigo)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(99, 102, 241, 0.2)"
-            }}
-          >
-            Долги
-          </Link>
-          <Link
-            href="/planning"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-success)",
-              color: "var(--accent-success)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(34, 197, 94, 0.2)"
-            }}
-          >
-            Планирование
-          </Link>
-          <Link
-            href="/reports"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-amber)",
-              color: "var(--accent-amber)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(217, 119, 6, 0.2)"
-            }}
-          >
-            Отчёты
-          </Link>
-          <Link
-            href="/settings"
-            style={{
-              padding: "0.6rem 1.4rem",
-              borderRadius: "999px",
-              backgroundColor: "var(--surface-purple)",
-              color: "var(--accent-purple)",
-              fontWeight: 600,
-              boxShadow: "0 4px 12px rgba(109, 40, 217, 0.2)"
-            }}
-          >
-            Настройки
-          </Link>
-        </nav>
-
-        <header
+    <PageContainer activeTab="wallets">
+      <header
           style={{
             display: "flex",
             flexDirection: "column",
@@ -415,7 +318,7 @@ const WalletsContent = () => {
             Пока нет операций, влияющих на кошельки.
           </p>
         ) : null}
-    </main>
+    </PageContainer>
   );
 };
 

--- a/components/AppNavigation.tsx
+++ b/components/AppNavigation.tsx
@@ -1,0 +1,126 @@
+import Link from "next/link";
+
+export type AppTabKey =
+  | "home"
+  | "wallets"
+  | "debts"
+  | "planning"
+  | "reports"
+  | "settings";
+
+type TabConfig = {
+  key: AppTabKey;
+  href: string;
+  label: string;
+  palette: {
+    bg: string;
+    text: string;
+    activeBg: string;
+    activeText: string;
+    shadow: string;
+  };
+};
+
+const TABS: TabConfig[] = [
+  {
+    key: "home",
+    href: "/",
+    label: "Главная",
+    palette: {
+      bg: "var(--surface-blue)",
+      text: "var(--accent-blue)",
+      activeBg: "var(--accent-blue)",
+      activeText: "var(--surface-primary)",
+      shadow: "0 4px 12px rgba(59, 130, 246, 0.25)"
+    }
+  },
+  {
+    key: "debts",
+    href: "/debts",
+    label: "Долги",
+    palette: {
+      bg: "var(--surface-indigo)",
+      text: "var(--accent-indigo)",
+      activeBg: "var(--accent-indigo)",
+      activeText: "var(--surface-primary)",
+      shadow: "0 4px 12px rgba(99, 102, 241, 0.2)"
+    }
+  },
+  {
+    key: "wallets",
+    href: "/wallets",
+    label: "Кошельки",
+    palette: {
+      bg: "var(--surface-teal)",
+      text: "var(--accent-teal)",
+      activeBg: "var(--accent-teal)",
+      activeText: "var(--surface-primary)",
+      shadow: "0 4px 12px rgba(45, 212, 191, 0.25)"
+    }
+  },
+  {
+    key: "planning",
+    href: "/planning",
+    label: "Планирование",
+    palette: {
+      bg: "var(--surface-success)",
+      text: "var(--accent-success)",
+      activeBg: "var(--accent-success)",
+      activeText: "var(--surface-primary)",
+      shadow: "0 4px 12px rgba(34, 197, 94, 0.2)"
+    }
+  },
+  {
+    key: "reports",
+    href: "/reports",
+    label: "Отчёты",
+    palette: {
+      bg: "var(--surface-amber)",
+      text: "var(--accent-amber)",
+      activeBg: "var(--accent-amber)",
+      activeText: "var(--surface-primary)",
+      shadow: "0 4px 12px rgba(217, 119, 6, 0.2)"
+    }
+  },
+  {
+    key: "settings",
+    href: "/settings",
+    label: "Настройки",
+    palette: {
+      bg: "var(--surface-purple)",
+      text: "var(--accent-purple)",
+      activeBg: "var(--accent-purple)",
+      activeText: "var(--surface-primary)",
+      shadow: "0 4px 12px rgba(109, 40, 217, 0.2)"
+    }
+  }
+];
+
+type AppNavigationProps = {
+  activeTab: AppTabKey;
+};
+
+const AppNavigation = ({ activeTab }: AppNavigationProps) => (
+  <nav className="flex flex-wrap items-center gap-3">
+    {TABS.map((tab) => {
+      const isActive = tab.key === activeTab;
+
+      return (
+        <Link
+          key={tab.key}
+          href={tab.href}
+          className="tab-pill inline-flex items-center justify-center rounded-full px-5 py-2.5 text-sm font-semibold transition-colors"
+          style={{
+            backgroundColor: isActive ? tab.palette.activeBg : tab.palette.bg,
+            color: isActive ? tab.palette.activeText : tab.palette.text,
+            boxShadow: tab.palette.shadow
+          }}
+        >
+          {tab.label}
+        </Link>
+      );
+    })}
+  </nav>
+);
+
+export default AppNavigation;

--- a/components/PageContainer.tsx
+++ b/components/PageContainer.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react";
+
+import AppNavigation, { type AppTabKey } from "@/components/AppNavigation";
+
+type PageContainerProps = {
+  activeTab: AppTabKey;
+  children: ReactNode;
+};
+
+const PageContainer = ({ activeTab, children }: PageContainerProps) => (
+  <main className="page-shell bg-white text-black dark:bg-midnight dark:text-slate-100">
+    <div className="flex w-full flex-col gap-10">
+      <AppNavigation activeTab={activeTab} />
+      {children}
+    </div>
+  </main>
+);
+
+export default PageContainer;


### PR DESCRIPTION
## Summary
- add a shared PageContainer with unified navigation for the main tabs
- introduce Tailwind-inspired utility classes and AppNavigation to remove inline layout styles
- align the category and wallet settings forms so inputs and actions sit on a single line with consistent spacing

## Testing
- `npm run lint` *(fails: `next` command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d18060809483319e108b16d27a82a7