### PR TITLE
Add automated exchange rate updates

### DIFF
--- a/app/api/rates/route.ts
+++ b/app/api/rates/route.ts
@@ -1,0 +1,138 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+
+const CURRENCIES = ["USD", "EUR", "RUB", "GEL"] as const;
+
+type Currency = (typeof CURRENCIES)[number];
+
+type RatesResponse = {
+  ok: boolean;
+  skipped?: boolean;
+  count?: number;
+  rows: Array<{
+    baseCurrency: Currency;
+    targetCurrency: Currency;
+    rate: number;
+    date: Date;
+  }>;
+};
+
+async function fetchWithTimeout(url: string, ms = 10000) {
+  const ctrl = new AbortController();
+  const id = setTimeout(() => ctrl.abort(), ms);
+
+  try {
+    return await fetch(url, { signal: ctrl.signal, cache: "no-store" });
+  } finally {
+    clearTimeout(id);
+  }
+}
+
+export const revalidate = 0;
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const force = searchParams.get("force") === "1";
+
+    if (!force) {
+      const latest = await prisma.exchangeRate.findFirst({
+        orderBy: { date: "desc" },
+        select: { date: true },
+      });
+
+      if (latest) {
+        const ageMs = Date.now() - new Date(latest.date).getTime();
+
+        if (ageMs < 24 * 60 * 60 * 1000) {
+          const rows = await prisma.exchangeRate.findMany({
+            orderBy: [
+              { baseCurrency: "asc" },
+              { targetCurrency: "asc" },
+            ],
+          });
+
+          return NextResponse.json({ ok: true, skipped: true, rows } satisfies RatesResponse);
+        }
+      }
+    }
+
+    const updates: Array<{ base: Currency; target: Currency; rate: number }> = [];
+
+    for (const base of CURRENCIES) {
+      const symbols = CURRENCIES.filter((currency) => currency !== base).join(",");
+      const url = `https://api.exchangerate.host/latest?base=${base}&symbols=${symbols}`;
+      const response = await fetchWithTimeout(url, 10000);
+
+      if (!response.ok) {
+        return NextResponse.json(
+          {
+            ok: false,
+            reason: `Upstream error ${response.status} ${response.statusText}`,
+            base,
+          },
+          { status: 502 }
+        );
+      }
+
+      const data = (await response.json()) as { rates?: Record<string, unknown> } | null;
+      const rates = data?.rates ?? {};
+
+      for (const [target, value] of Object.entries(rates)) {
+        if (!CURRENCIES.includes(target as Currency)) {
+          continue;
+        }
+
+        const numeric = Number(value);
+
+        if (!Number.isFinite(numeric)) {
+          continue;
+        }
+
+        updates.push({ base, target: target as Currency, rate: numeric });
+      }
+    }
+
+    if (updates.length === 0) {
+      return NextResponse.json(
+        { ok: false, reason: "No rates received from upstream" },
+        { status: 502 }
+      );
+    }
+
+    const now = new Date();
+
+    await prisma.$transaction(
+      updates.map((update) =>
+        prisma.exchangeRate.upsert({
+          where: {
+            baseCurrency_targetCurrency: {
+              baseCurrency: update.base,
+              targetCurrency: update.target,
+            },
+          },
+          update: { rate: update.rate, date: now },
+          create: {
+            baseCurrency: update.base,
+            targetCurrency: update.target,
+            rate: update.rate,
+            date: now,
+          },
+        })
+      )
+    );
+
+    const rows = await prisma.exchangeRate.findMany({
+      orderBy: [
+        { baseCurrency: "asc" },
+        { targetCurrency: "asc" },
+      ],
+    });
+
+    return NextResponse.json({ ok: true, count: updates.length, rows } satisfies RatesResponse);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+
+    return NextResponse.json({ ok: false, reason }, { status: 500 });
+  }
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,13 +1,20 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import AuthGate from "@/components/AuthGate";
 import PageContainer from "@/components/PageContainer";
 import ThemeToggle from "@/components/ThemeToggle";
 import { useSession } from "@/components/SessionProvider";
 import { DEFAULT_SETTINGS, SUPPORTED_CURRENCIES } from "@/lib/currency";
 import type { Currency, Settings } from "@/lib/types";
+
+type RateRow = {
+  baseCurrency: Currency;
+  targetCurrency: Currency;
+  rate: number;
+  date: string;
+};
 
 const isSettings = (value: unknown): value is Settings => {
   if (!value || typeof value !== "object") {
@@ -24,22 +31,38 @@ const isSettings = (value: unknown): value is Settings => {
   );
 };
 
-const buildRatesState = (settings: Settings) =>
-  SUPPORTED_CURRENCIES.reduce<Record<Currency, string>>((acc, code) => {
-    if (code === settings.baseCurrency) {
-      acc[code] = "1";
-      return acc;
-    }
+const isRateRow = (value: unknown): value is RateRow => {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
 
-    const rawRate = settings.rates[code];
-    const normalized =
-      typeof rawRate === "number" && Number.isFinite(rawRate) && rawRate > 0
-        ? 1 / rawRate
-        : 1;
+  const row = value as Partial<RateRow>;
 
-    acc[code] = Number(normalized.toFixed(6)).toString();
-    return acc;
-  }, {} as Record<Currency, string>);
+  return (
+    typeof row.baseCurrency === "string" &&
+    SUPPORTED_CURRENCIES.includes(row.baseCurrency as Currency) &&
+    typeof row.targetCurrency === "string" &&
+    SUPPORTED_CURRENCIES.includes(row.targetCurrency as Currency) &&
+    typeof row.rate === "number" &&
+    Number.isFinite(row.rate) &&
+    typeof row.date === "string"
+  );
+};
+
+const isRatesResponse = (value: unknown): value is {
+  rows: RateRow[];
+  skipped?: boolean;
+  count?: number;
+  reason?: string;
+} => {
+  if (!value || typeof value !== "object" || !("rows" in value)) {
+    return false;
+  }
+
+  const rows = (value as { rows?: unknown }).rows;
+
+  return Array.isArray(rows) && rows.every(isRateRow);
+};
 
 const SettingsContent = () => {
   const { user, refresh } = useSession();
@@ -51,24 +74,25 @@ const SettingsContent = () => {
   const canManage = user.role === "accountant";
 
   const [settings, setSettings] = useState<Settings>(DEFAULT_SETTINGS);
-  const [rates, setRates] = useState<Record<Currency, string>>(() =>
-    buildRatesState(DEFAULT_SETTINGS)
-  );
-  const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [loadingSettings, setLoadingSettings] = useState(true);
+  const [settingsError, setSettingsError] = useState<string | null>(null);
+
+  const [rates, setRates] = useState<RateRow[]>([]);
+  const [ratesLoading, setRatesLoading] = useState(true);
+  const [ratesError, setRatesError] = useState<string | null>(null);
+  const [forceUpdating, setForceUpdating] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
 
   useEffect(() => {
     const loadSettings = async () => {
-      setLoading(true);
-      setError(null);
+      setLoadingSettings(true);
+      setSettingsError(null);
 
       try {
         const response = await fetch("/api/settings");
 
         if (response.status === 401) {
-          setError("Сессия истекла, войдите заново.");
+          setSettingsError("Сессия истекла, войдите заново.");
           await refresh();
           return;
         }
@@ -84,299 +108,280 @@ const SettingsContent = () => {
         }
 
         setSettings(data);
-        setRates(buildRatesState(data));
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Произошла ошибка");
+        setSettingsError(err instanceof Error ? err.message : "Произошла ошибка");
       } finally {
-        setLoading(false);
+        setLoadingSettings(false);
       }
     };
 
     void loadSettings();
   }, [refresh]);
 
+  const loadRates = useCallback(
+    async (force = false) => {
+      if (force && !canManage) {
+        return;
+      }
+
+      if (force) {
+        setForceUpdating(true);
+        setMessage(null);
+      } else {
+        setRatesLoading(true);
+      }
+
+      setRatesError(null);
+
+      try {
+        const response = await fetch(force ? "/api/rates?force=1" : "/api/rates", {
+          cache: "no-store",
+        });
+
+        const data = await response.json().catch(() => null);
+
+        if (!response.ok || !isRatesResponse(data)) {
+          const reason =
+            data &&
+            typeof data === "object" &&
+            "reason" in data &&
+            typeof (data as { reason?: unknown }).reason === "string"
+              ? (data as { reason: string }).reason
+              : undefined;
+
+          throw new Error(reason ?? "Не удалось загрузить курсы");
+        }
+
+        setRates(data.rows);
+
+        if (force) {
+          setMessage(
+            data.skipped
+              ? "Курсы уже были актуальны за последние 24 часа."
+              : `Обновлено ${data.count ?? data.rows.length} курсов.`
+          );
+        }
+      } catch (err) {
+        setRatesError(
+          err instanceof Error ? err.message : "Не удалось загрузить курсы"
+        );
+      } finally {
+        if (force) {
+          setForceUpdating(false);
+        } else {
+          setRatesLoading(false);
+        }
+      }
+    },
+    [canManage]
+  );
+
+  useEffect(() => {
+    void loadRates();
+  }, [loadRates]);
+
   const baseCurrency = settings.baseCurrency;
   const baseFormatter = useMemo(
     () =>
       new Intl.NumberFormat("ru-RU", {
         style: "currency",
-        currency: baseCurrency
+        currency: baseCurrency,
       }),
     [baseCurrency]
   );
 
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    setError(null);
-    setMessage(null);
-
-    if (!canManage) {
-      setError("Недостаточно прав для изменения курсов");
-      return;
-    }
-
-    setSaving(true);
-
-    const payloadRates: Partial<Record<Currency, number>> = {};
-
-    for (const currency of SUPPORTED_CURRENCIES) {
-      if (currency === baseCurrency) {
-        continue;
-      }
-
-      const value = rates[currency];
-      const numeric = Number(value);
-
-      if (!Number.isFinite(numeric) || numeric <= 0) {
-        setError(
-          `Введите положительный курс (количество ${currency} за 1 ${baseCurrency})`
-        );
-        setSaving(false);
-        return;
-      }
-
-      payloadRates[currency] = 1 / numeric;
-    }
-
-    try {
-      const response = await fetch("/api/settings", {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json"
-        },
-        body: JSON.stringify({ rates: payloadRates })
-      });
-
-      const data = await response.json().catch(() => null);
-
-      if (response.status === 401) {
-        setError("Сессия истекла, войдите заново.");
-        await refresh();
-        return;
-      }
-
-      if (response.status === 403) {
-        setError("Недостаточно прав для изменения курсов");
-        return;
-      }
-
-      if (
-        !response.ok ||
-        !isSettings(data)
-      ) {
-        const errorMessage =
-          data &&
-          typeof data === "object" &&
-          "error" in data &&
-          typeof (data as { error?: unknown }).error === "string"
-            ? (data as { error?: string }).error
-            : undefined;
-
-        throw new Error(errorMessage ?? "Не удалось сохранить настройки");
-      }
-
-      setSettings(data);
-      setRates(buildRatesState(data));
-      setMessage("Курсы успешно обновлены");
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Произошла ошибка");
-    } finally {
-      setSaving(false);
-    }
-  };
-
   return (
     <PageContainer activeTab="settings">
       <header
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "0.75rem",
+        }}
+      >
+        <h1 style={{ fontSize: "2rem", fontWeight: 700, color: "var(--surface-navy)" }}>
+          Финансовые настройки общины
+        </h1>
+        <p style={{ color: "var(--text-secondary)", lineHeight: 1.6 }}>
+          Обновляйте базовую валюту и курсы конвертации, чтобы отчёты оставались точными.
+        </p>
+      </header>
+
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "flex-end",
+        }}
+      >
+        <ThemeToggle />
+      </div>
+
+      {loadingSettings ? (
+        <p style={{ color: "var(--text-muted)" }}>Загружаем настройки...</p>
+      ) : null}
+
+      <section
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+          gap: "1.5rem",
+        }}
+      >
+        <article
           style={{
-            display: "flex",
-            flexDirection: "column",
-            gap: "0.75rem"
+            backgroundColor: "var(--surface-indigo)",
+            borderRadius: "1rem",
+            padding: "1.5rem",
+            boxShadow: "0 12px 28px rgba(99, 102, 241, 0.15)",
           }}
         >
-          <h1 style={{ fontSize: "2rem", fontWeight: 700, color: "var(--surface-navy)" }}>
-            Финансовые настройки общины
-          </h1>
-          <p style={{ color: "var(--text-secondary)", lineHeight: 1.6 }}>
-            Обновляйте базовую валюту и курсы конвертации, чтобы отчёты оставались точными.
+          <h2 style={{ color: "var(--surface-navy)", fontWeight: 600, marginBottom: "0.5rem" }}>
+            Базовая валюта
+          </h2>
+          <strong style={{ fontSize: "1.5rem", color: "var(--accent-indigo-strong)" }}>
+            {baseCurrency}
+          </strong>
+          <p style={{ color: "var(--text-secondary)", marginTop: "0.5rem" }}>
+            Все суммы приводятся к этой валюте для расчётов.
           </p>
-        </header>
-
-        <div
+        </article>
+        <article
           style={{
-            display: "flex",
-            justifyContent: "flex-end"
+            backgroundColor: "var(--surface-success)",
+            borderRadius: "1rem",
+            padding: "1.5rem",
+            boxShadow: "0 12px 28px rgba(34, 197, 94, 0.12)",
           }}
         >
-          <ThemeToggle />
-        </div>
+          <h2 style={{ color: "var(--accent-success-strong)", fontWeight: 600, marginBottom: "0.5rem" }}>
+            Текущий баланс (пример)
+          </h2>
+          <strong style={{ fontSize: "1.5rem", color: "var(--accent-success)" }}>
+            {baseFormatter.format(1_000_000)}
+          </strong>
+          <p style={{ color: "var(--text-secondary)", marginTop: "0.5rem" }}>
+            Для проверки отображения формата валюты.
+          </p>
+        </article>
+      </section>
 
-        {loading ? <p style={{ color: "var(--text-muted)" }}>Загружаем настройки...</p> : null}
-
-        <form
-          onSubmit={handleSubmit}
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            gap: "1.5rem"
-          }}
-        >
-          <section
-            style={{
-              display: "grid",
-              gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
-              gap: "1.5rem"
-            }}
-          >
-            <article
-              style={{
-                backgroundColor: "var(--surface-indigo)",
-                borderRadius: "1rem",
-                padding: "1.5rem",
-                boxShadow: "0 12px 28px rgba(99, 102, 241, 0.15)"
-              }}
-            >
-              <h2 style={{ color: "var(--surface-navy)", fontWeight: 600, marginBottom: "0.5rem" }}>
-                Базовая валюта
-              </h2>
-              <strong style={{ fontSize: "1.5rem", color: "var(--accent-indigo-strong)" }}>{baseCurrency}</strong>
-              <p style={{ color: "var(--text-secondary)", marginTop: "0.5rem" }}>
-                Все суммы приводятся к этой валюте для расчётов.
-              </p>
-            </article>
-            <article
-              style={{
-                backgroundColor: "var(--surface-success)",
-                borderRadius: "1rem",
-                padding: "1.5rem",
-                boxShadow: "0 12px 28px rgba(34, 197, 94, 0.12)"
-              }}
-            >
-              <h2 style={{ color: "var(--accent-success-strong)", fontWeight: 600, marginBottom: "0.5rem" }}>
-                Текущий баланс (пример)
-              </h2>
-              <strong style={{ fontSize: "1.5rem", color: "var(--accent-success)" }}>
-                {baseFormatter.format(1_000_000)}
-              </strong>
-              <p style={{ color: "var(--text-secondary)", marginTop: "0.5rem" }}>
-                Для проверки отображения формата валюты.
-              </p>
-            </article>
-          </section>
-
-          <section
-            style={{
-              display: "grid",
-              gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
-              gap: "1.25rem"
-            }}
-          >
-            {SUPPORTED_CURRENCIES.filter((code) => code !== baseCurrency).map((code) => (
-              <label
-                key={code}
-                style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}
-              >
-                <span style={{ fontWeight: 600, color: "var(--text-strong)" }}>
-                  {code} за 1 {baseCurrency}
-                </span>
-                <input
-                  type="number"
-                  min="0"
-                  step="0.000001"
-                  value={rates[code] ?? "1"}
-                  onChange={(event) =>
-                    setRates((prev) => ({
-                      ...prev,
-                      [code]: event.target.value
-                    }))
-                  }
-                  disabled={!canManage || saving}
-                  style={{
-                    padding: "0.85rem 1rem",
-                    borderRadius: "0.75rem",
-                    border: "1px solid var(--border-muted)"
-                  }}
-                />
-              </label>
-            ))}
-          </section>
-
+      <div className="rounded-2xl bg-white p-6 shadow-sm dark:bg-gray-900">
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+          <h2 className="text-xl font-semibold">Курсы валют (авто)</h2>
           <button
-            type="submit"
-            disabled={!canManage || saving}
-            style={{
-              padding: "0.95rem 1.5rem",
-              borderRadius: "0.85rem",
-              border: "none",
-              backgroundColor: saving || !canManage ? "var(--accent-disabled)" : "var(--accent-purple)",
-              color: "var(--surface-primary)",
-              fontWeight: 600,
-              boxShadow: "0 12px 24px rgba(109, 40, 217, 0.25)",
-              cursor: !canManage || saving ? "not-allowed" : "pointer"
-            }}
+            type="button"
+            onClick={() => void loadRates(true)}
+            disabled={!canManage || forceUpdating}
+            className="rounded-xl bg-gray-900 px-3 py-2 text-sm font-medium text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-white dark:text-gray-900"
           >
-            {saving ? "Сохраняем..." : "Сохранить курсы"}
+            {forceUpdating ? "Обновляем..." : "Обновить сейчас"}
           </button>
-        </form>
+        </div>
+        <p className="mb-4 text-sm text-gray-500 dark:text-gray-400">
+          Обновляется ежедневно по расписанию. Можно принудительно обновить кнопкой.
+        </p>
+        {message ? (
+          <p className="mb-4 text-sm text-emerald-600 dark:text-emerald-400">{message}</p>
+        ) : null}
+        {ratesError ? (
+          <p className="mb-4 text-sm text-rose-600 dark:text-rose-400">{ratesError}</p>
+        ) : null}
+        <div className="overflow-x-auto rounded-xl border border-gray-200 dark:border-gray-700">
+          {ratesLoading ? (
+            <p className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">
+              Загружаем курсы...
+            </p>
+          ) : rates.length === 0 ? (
+            <p className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">
+              Курсы ещё не загружены. Нажмите «Обновить сейчас».
+            </p>
+          ) : (
+            <table className="min-w-full text-sm">
+              <thead className="bg-gray-50 dark:bg-gray-800">
+                <tr>
+                  <th className="px-4 py-2 text-left">Базовая</th>
+                  <th className="px-4 py-2 text-left">Целевая</th>
+                  <th className="px-4 py-2 text-left">Курс</th>
+                  <th className="px-4 py-2 text-left">Обновлено</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rates.map((rate) => (
+                  <tr
+                    key={`${rate.baseCurrency}-${rate.targetCurrency}`}
+                    className="border-t border-gray-100 dark:border-gray-800"
+                  >
+                    <td className="px-4 py-2">{rate.baseCurrency}</td>
+                    <td className="px-4 py-2">{rate.targetCurrency}</td>
+                    <td className="px-4 py-2">{rate.rate.toFixed(6)}</td>
+                    <td className="px-4 py-2">{new Date(rate.date).toLocaleString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
 
-        <section
+      <section
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+          gap: "1.25rem",
+        }}
+      >
+        <Link
+          href="/settings/categories"
           style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
-            gap: "1.25rem"
+            display: "flex",
+            flexDirection: "column",
+            gap: "0.5rem",
+            padding: "1.5rem",
+            borderRadius: "1rem",
+            backgroundColor: "var(--surface-indigo)",
+            textDecoration: "none",
+            boxShadow: "0 12px 24px rgba(79, 70, 229, 0.15)",
           }}
         >
-          <Link
-            href="/settings/categories"
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              gap: "0.5rem",
-              padding: "1.5rem",
-              borderRadius: "1rem",
-              backgroundColor: "var(--surface-indigo)",
-              textDecoration: "none",
-              boxShadow: "0 12px 24px rgba(79, 70, 229, 0.15)"
-            }}
-          >
-            <strong style={{ color: "var(--accent-indigo-strong)", fontSize: "1.1rem" }}>
-              Категории
-            </strong>
-            <span style={{ color: "var(--text-secondary)", lineHeight: 1.5 }}>
-              Добавляйте и удаляйте категории прихода и расхода в отдельном разделе.
-            </span>
-          </Link>
+          <strong style={{ color: "var(--accent-indigo-strong)", fontSize: "1.1rem" }}>
+            Категории
+          </strong>
+          <span style={{ color: "var(--text-secondary)", lineHeight: 1.5 }}>
+            Добавляйте и удаляйте категории прихода и расхода в отдельном разделе.
+          </span>
+        </Link>
 
-          <Link
-            href="/settings/wallets"
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              gap: "0.5rem",
-              padding: "1.5rem",
-              borderRadius: "1rem",
-              backgroundColor: "var(--surface-cyan)",
-              textDecoration: "none",
-              boxShadow: "0 12px 24px rgba(13, 148, 136, 0.15)"
-            }}
-          >
-            <strong style={{ color: "var(--accent-teal)", fontSize: "1.1rem" }}>
-              Кошельки
-            </strong>
-            <span style={{ color: "var(--text-secondary)", lineHeight: 1.5 }}>
-              Управляйте списком кошельков, не затрагивая связанные операции.
-            </span>
-          </Link>
-        </section>
+        <Link
+          href="/settings/wallets"
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "0.5rem",
+            padding: "1.5rem",
+            borderRadius: "1rem",
+            backgroundColor: "var(--surface-cyan)",
+            textDecoration: "none",
+            boxShadow: "0 12px 24px rgba(13, 148, 136, 0.15)",
+          }}
+        >
+          <strong style={{ color: "var(--accent-teal)", fontSize: "1.1rem" }}>
+            Кошельки
+          </strong>
+          <span style={{ color: "var(--text-secondary)", lineHeight: 1.5 }}>
+            Управляйте списком кошельков, не затрагивая связанные операции.
+          </span>
+        </Link>
+      </section>
 
-        {!canManage ? (
-          <p style={{ color: "var(--text-muted)" }}>
-            Вы вошли как наблюдатель — редактирование курсов недоступно.
-          </p>
-        ) : null}
+      {!canManage ? (
+        <p style={{ color: "var(--text-muted)" }}>
+          Вы вошли как наблюдатель — принудительное обновление недоступно.
+        </p>
+      ) : null}
 
-        {error ? <p style={{ color: "var(--accent-danger)" }}>{error}</p> : null}
-        {message ? <p style={{ color: "var(--accent-success)" }}>{message}</p> : null}
+      {settingsError ? (
+        <p style={{ color: "var(--accent-danger)" }}>{settingsError}</p>
+      ) : null}
     </PageContainer>
   );
 };

--- a/lib/settingsService.ts
+++ b/lib/settingsService.ts
@@ -6,20 +6,21 @@ const isValidRate = (value: unknown): value is number =>
   typeof value === "number" && Number.isFinite(value) && value > 0;
 
 export const loadSettings = async (): Promise<Settings> => {
-  const [settingsRow, rateRows] = await Promise.all([
-    prisma.settings.findFirst({ orderBy: { id: "desc" } }),
-    prisma.currencyRate.findMany()
-  ]);
+  const settingsRow = await prisma.settings.findFirst({ orderBy: { id: "desc" } });
 
   const baseCurrency = sanitizeCurrency(
     settingsRow?.base_currency,
     DEFAULT_SETTINGS.baseCurrency
   );
 
+  const rateRows = await prisma.exchangeRate.findMany({
+    where: { targetCurrency: baseCurrency },
+  });
+
   const rates: Settings["rates"] = { ...DEFAULT_SETTINGS.rates };
 
   for (const rate of rateRows) {
-    const currency = rate.currency as Currency;
+    const currency = rate.baseCurrency as Currency;
 
     if (!SUPPORTED_CURRENCIES.includes(currency)) {
       continue;
@@ -46,15 +47,26 @@ export const applyRatesUpdate = async (
   ratesUpdate: Partial<Record<Currency, number>>
 ): Promise<Settings> => {
   const settings = await loadSettings();
-  const operations: Promise<unknown>[] = [];
+  const now = new Date();
+  const operations: Parameters<typeof prisma.$transaction>[0] = [];
 
   for (const currency of SUPPORTED_CURRENCIES) {
     if (currency === settings.baseCurrency) {
       operations.push(
-        prisma.currencyRate.upsert({
-          where: { currency },
-          update: { rate: 1 },
-          create: { currency, rate: 1 }
+        prisma.exchangeRate.upsert({
+          where: {
+            baseCurrency_targetCurrency: {
+              baseCurrency: currency,
+              targetCurrency: settings.baseCurrency,
+            },
+          },
+          update: { rate: 1, date: now },
+          create: {
+            baseCurrency: currency,
+            targetCurrency: settings.baseCurrency,
+            rate: 1,
+            date: now,
+          },
         })
       );
       continue;
@@ -62,20 +74,50 @@ export const applyRatesUpdate = async (
 
     const newRate = ratesUpdate[currency];
 
-    if (newRate === undefined) {
+    if (newRate === undefined || !isValidRate(newRate)) {
       continue;
     }
 
     operations.push(
-      prisma.currencyRate.upsert({
-        where: { currency },
-        update: { rate: newRate },
-        create: { currency, rate: newRate }
+      prisma.exchangeRate.upsert({
+        where: {
+          baseCurrency_targetCurrency: {
+            baseCurrency: currency,
+            targetCurrency: settings.baseCurrency,
+          },
+        },
+        update: { rate: newRate, date: now },
+        create: {
+          baseCurrency: currency,
+          targetCurrency: settings.baseCurrency,
+          rate: newRate,
+          date: now,
+        },
+      })
+    );
+
+    operations.push(
+      prisma.exchangeRate.upsert({
+        where: {
+          baseCurrency_targetCurrency: {
+            baseCurrency: settings.baseCurrency,
+            targetCurrency: currency,
+          },
+        },
+        update: { rate: 1 / newRate, date: now },
+        create: {
+          baseCurrency: settings.baseCurrency,
+          targetCurrency: currency,
+          rate: 1 / newRate,
+          date: now,
+        },
       })
     );
   }
 
-  await Promise.all(operations);
+  if (operations.length > 0) {
+    await prisma.$transaction(operations);
+  }
 
   return loadSettings();
 };

--- a/prisma/migrations/20241005000000_add_exchange_rates/migration.sql
+++ b/prisma/migrations/20241005000000_add_exchange_rates/migration.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS "exchange_rates" (
+  "id" SERIAL PRIMARY KEY,
+  "base_currency" TEXT NOT NULL,
+  "target_currency" TEXT NOT NULL,
+  "rate" DOUBLE PRECISION NOT NULL,
+  "date" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "baseCurrency_targetCurrency" UNIQUE ("base_currency", "target_currency")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -87,3 +87,14 @@ model CurrencyRate {
 
   @@map("currency_rates")
 }
+
+model ExchangeRate {
+  id             Int      @id @default(autoincrement()) @db.Integer
+  baseCurrency   String   @map("base_currency") @db.Text
+  targetCurrency String   @map("target_currency") @db.Text
+  rate           Float    @db.DoublePrecision
+  date           DateTime @default(now()) @db.Timestamptz(6)
+
+  @@unique([baseCurrency, targetCurrency], name: "baseCurrency_targetCurrency")
+  @@map("exchange_rates")
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, Prisma } from "@prisma/client";
+import { PrismaClient } from "@prisma/client";
 import seedData from "./seed-data.json" assert { type: "json" };
 
 const prisma = new PrismaClient();
@@ -38,15 +38,26 @@ const main = async () => {
     await prisma.settings.create({ data: { base_currency: baseCurrency } });
   }
 
-  await Promise.all(
-    currencies.map((currency) =>
-      prisma.currencyRate.upsert({
-        where: { currency },
-        update: { rate: 1 },
-        create: { currency, rate: new Prisma.Decimal(1) },
-      })
-    )
+  const now = new Date();
+  const pairs = currencies.flatMap((base) =>
+    currencies
+      .filter((target) => target !== base)
+      .map((target) => ({ baseCurrency: base, targetCurrency: target }))
   );
+
+  if (pairs.length > 0) {
+    await prisma.$transaction(
+      pairs.map(({ baseCurrency, targetCurrency }) =>
+        prisma.exchangeRate.upsert({
+          where: {
+            baseCurrency_targetCurrency: { baseCurrency, targetCurrency },
+          },
+          update: { rate: 1, date: now },
+          create: { baseCurrency, targetCurrency, rate: 1, date: now },
+        })
+      )
+    );
+  }
 };
 
 main()

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "next build",
-  "outputDirectory": ".next",
-  "framework": "nextjs"
+  "crons": [
+    { "path": "/api/rates", "schedule": "0 0 * * *" }
+  ]
 }


### PR DESCRIPTION
## Summary
- add an `ExchangeRate` table with a daily cron hitting a new `/api/rates` endpoint
- implement exchangerate.host syncing and reuse the stored pairs in the settings service and seed data
- replace the manual rate form on the settings page with a database-backed table and force-refresh action

## Testing
- `npm run lint` *(fails: Next CLI not available before installing dependencies)*
- `npm install` *(fails: registry returned HTTP 403 for @prisma/client)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a1cbb8dc833199b7088bdf379279