### PR TITLE
ui: improve dark theme contrast and mobile responsiveness

### DIFF
--- a/app/debts/page.tsx
+++ b/app/debts/page.tsx
@@ -293,7 +293,7 @@ const DebtsContent = () => {
   return (
     <PageContainer activeTab="debts">
       <header style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
-        <h1 style={{ fontSize: "1.85rem", fontWeight: 700, color: "var(--text-primary)" }}>
+        <h1 style={{ fontSize: "1.85rem", fontWeight: 700 }}>
           Управление долгами
         </h1>
         <p style={{ color: "var(--text-secondary)", lineHeight: 1.5 }}>
@@ -302,6 +302,7 @@ const DebtsContent = () => {
       </header>
 
       <section
+        data-layout="stat-grid"
         style={{
           display: "grid",
           gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
@@ -316,7 +317,7 @@ const DebtsContent = () => {
             boxShadow: "0 12px 24px rgba(15, 23, 42, 0.08)"
           }}
         >
-          <h2 style={{ color: "var(--text-primary)", fontWeight: 600, marginBottom: "0.5rem" }}>
+          <h2 style={{ fontWeight: 600, marginBottom: "0.5rem" }}>
             Мы должны
           </h2>
           <strong style={{ fontSize: "1.5rem", color: "var(--accent-danger)" }}>
@@ -331,7 +332,7 @@ const DebtsContent = () => {
             boxShadow: "0 12px 24px rgba(34, 197, 94, 0.15)"
           }}
         >
-          <h2 style={{ color: "var(--text-primary)", fontWeight: 600, marginBottom: "0.5rem" }}>
+          <h2 style={{ fontWeight: 600, marginBottom: "0.5rem" }}>
             Нам должны
           </h2>
           <strong style={{ fontSize: "1.5rem", color: "var(--accent-success)" }}>
@@ -342,6 +343,7 @@ const DebtsContent = () => {
 
       <form
         onSubmit={handleSubmit}
+        data-layout="responsive-form"
         style={{
           display: "grid",
           gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
@@ -489,7 +491,7 @@ const DebtsContent = () => {
       {error ? <p style={{ color: "var(--accent-danger)" }}>{error}</p> : null}
 
       <section style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
-        <h2 style={{ fontSize: "1.4rem", fontWeight: 600, color: "var(--text-primary)" }}>
+        <h2 style={{ fontSize: "1.4rem", fontWeight: 600 }}>
           Текущие долги
         </h2>
         {debts.length === 0 ? (
@@ -512,6 +514,7 @@ const DebtsContent = () => {
                 }}
               >
                 <div
+                  data-card="split"
                   style={{
                     display: "flex",
                     justifyContent: "space-between",
@@ -520,7 +523,7 @@ const DebtsContent = () => {
                   }}
                 >
                   <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem" }}>
-                    <strong style={{ color: "var(--text-primary)" }}>
+                    <strong>
                       {debt.type === "borrowed" ? "Взяли" : "Выдали"} — {debt.amount.toLocaleString("ru-RU", {
                         minimumFractionDigits: 2,
                         maximumFractionDigits: 2

--- a/app/globals.css
+++ b/app/globals.css
@@ -126,6 +126,16 @@ body {
   transition: background-color 0.3s ease, color 0.3s ease;
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: var(--text-strong);
+  line-height: 1.2;
+}
+
 a {
   color: inherit;
   text-decoration: none;
@@ -157,6 +167,59 @@ button {
 
 .bg-white {
   background-color: var(--surface-primary);
+}
+
+@media (max-width: 768px) {
+  body {
+    padding: 1.75rem 1rem 3rem;
+    align-items: stretch;
+  }
+
+  .page-shell {
+    width: 100%;
+    border-radius: 20px;
+    padding: 2rem 1.5rem;
+    box-shadow: var(--shadow-soft);
+  }
+}
+
+[data-layout="responsive-form"] {
+  width: 100%;
+}
+
+@media (max-width: 768px) {
+  [data-layout="responsive-form"] {
+    grid-template-columns: 1fr !important;
+    align-items: stretch !important;
+  }
+
+  [data-layout="responsive-form"] > * {
+    width: 100%;
+  }
+
+  [data-card="split"] {
+    flex-direction: column !important;
+    align-items: stretch !important;
+  }
+
+  [data-card-section="meta"] {
+    align-items: flex-start !important;
+    width: 100%;
+  }
+
+  [data-card="split"] button {
+    width: 100%;
+  }
+
+  [data-layout="stat-grid"] {
+    grid-template-columns: 1fr !important;
+  }
+
+  [data-layout="toolbar"] {
+    flex-direction: column !important;
+    align-items: stretch !important;
+    gap: 0.75rem !important;
+  }
 }
 
 .text-black {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -447,7 +447,7 @@ const Dashboard = () => {
               gap: "1rem"
             }}
           >
-            <h2 style={{ fontSize: "1.5rem", fontWeight: 600, color: "var(--text-primary)" }}>
+            <h2 style={{ fontSize: "1.5rem", fontWeight: 600 }}>
               Текущий баланс
             </h2>
             <strong
@@ -466,6 +466,7 @@ const Dashboard = () => {
 
           <form
             onSubmit={handleSubmit}
+            data-layout="responsive-form"
             style={{
               display: "grid",
               gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
@@ -617,7 +618,7 @@ const Dashboard = () => {
 
 
         <section style={{ display: "flex", flexDirection: "column", gap: "1.25rem" }}>
-          <h2 style={{ fontSize: "1.5rem", fontWeight: 600, color: "var(--text-primary)" }}>
+          <h2 style={{ fontSize: "1.5rem", fontWeight: 600 }}>
             Последние операции
           </h2>
           {operations.length === 0 ? (
@@ -629,6 +630,7 @@ const Dashboard = () => {
               {operations.map((operation) => (
                 <li
                   key={operation.id}
+                  data-card="split"
                   style={{
                     padding: "1.1rem 1.35rem",
                     borderRadius: "1rem",
@@ -647,7 +649,7 @@ const Dashboard = () => {
                       display: "flex",
                       flexDirection: "column",
                       gap: "0.35rem",
-                      minWidth: "220px"
+                      minWidth: "min(220px, 100%)"
                     }}
                   >
                     <p style={{ fontWeight: 600, color: "var(--text-primary)" }}>
@@ -664,12 +666,13 @@ const Dashboard = () => {
                     ) : null}
                   </div>
                   <div
+                    data-card-section="meta"
                     style={{
                       display: "flex",
                       flexDirection: "column",
                       alignItems: canManage ? "flex-end" : "flex-start",
                       gap: "0.65rem",
-                      minWidth: "140px"
+                      minWidth: "min(140px, 100%)"
                     }}
                   >
                     <span

--- a/app/planning/page.tsx
+++ b/app/planning/page.tsx
@@ -247,21 +247,22 @@ const PlanningContent = () => {
   return (
     <PageContainer activeTab="planning">
       <header
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            gap: "0.75rem"
-          }}
-        >
-          <h1 style={{ fontSize: "2rem", fontWeight: 700, color: "var(--text-primary)" }}>
-            Планирование проектов и целей
-          </h1>
-          <p style={{ color: "var(--text-secondary)", lineHeight: 1.6 }}>
-            Следите за прогрессом накоплений по ключевым инициативам общины.
-          </p>
-        </header>
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "0.75rem"
+        }}
+      >
+        <h1 style={{ fontSize: "2rem", fontWeight: 700 }}>
+          Планирование проектов и целей
+        </h1>
+        <p style={{ color: "var(--text-secondary)", lineHeight: 1.6 }}>
+          Следите за прогрессом накоплений по ключевым инициативам общины.
+        </p>
+      </header>
 
         <section
+          data-layout="stat-grid"
           style={{
             display: "grid",
             gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
@@ -276,7 +277,7 @@ const PlanningContent = () => {
               boxShadow: "0 16px 35px rgba(99, 102, 241, 0.12)"
             }}
           >
-            <h2 style={{ color: "var(--surface-navy)", fontWeight: 600, marginBottom: "0.5rem" }}>
+            <h2 style={{ fontWeight: 600, marginBottom: "0.5rem" }}>
               Сохранено
             </h2>
             <strong style={{ fontSize: "1.5rem", color: "var(--accent-indigo-strong)" }}>
@@ -291,7 +292,7 @@ const PlanningContent = () => {
               boxShadow: "0 16px 35px rgba(34, 197, 94, 0.12)"
             }}
           >
-            <h2 style={{ color: "var(--accent-success-strong)", fontWeight: 600, marginBottom: "0.5rem" }}>
+            <h2 style={{ fontWeight: 600, marginBottom: "0.5rem" }}>
               Цель
             </h2>
             <strong style={{ fontSize: "1.5rem", color: "var(--accent-success)" }}>
@@ -302,6 +303,7 @@ const PlanningContent = () => {
 
         <form
           onSubmit={handleSubmit}
+          data-layout="responsive-form"
           style={{
             display: "grid",
             gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
@@ -392,7 +394,7 @@ const PlanningContent = () => {
         {message ? <p style={{ color: "var(--accent-success)" }}>{message}</p> : null}
 
         <section style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}>
-          <h2 style={{ fontSize: "1.5rem", fontWeight: 600, color: "var(--text-primary)" }}>
+          <h2 style={{ fontSize: "1.5rem", fontWeight: 600 }}>
             Активные цели
           </h2>
           {goals.length === 0 ? (
@@ -421,6 +423,7 @@ const PlanningContent = () => {
                     }}
                   >
                     <div
+                      data-card="split"
                       style={{
                         display: "flex",
                         justifyContent: "space-between",
@@ -430,7 +433,7 @@ const PlanningContent = () => {
                       }}
                     >
                       <div style={{ display: "flex", flexDirection: "column", gap: "0.4rem" }}>
-                        <strong style={{ fontSize: "1.1rem", color: "var(--text-primary)" }}>
+                        <strong style={{ fontSize: "1.1rem" }}>
                           {goal.title}
                         </strong>
                         <span style={{ color: "var(--text-secondary)", fontSize: "0.95rem" }}>

--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -491,24 +491,25 @@ const ReportsContent = () => {
   return (
     <PageContainer activeTab="reports">
       <header
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            gap: "0.75rem"
-          }}
-        >
-          <h1 style={{ fontSize: "2.1rem", fontWeight: 700, color: "var(--accent-purple-deep)" }}>
-            Финансовые отчёты
-          </h1>
-          <p style={{ color: "var(--text-secondary)", lineHeight: 1.6 }}>
-            Анализируйте поступления и расходы за выбранный период.
-          </p>
-        </header>
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "0.75rem"
+        }}
+      >
+        <h1 style={{ fontSize: "2.1rem", fontWeight: 700 }}>
+          Финансовые отчёты
+        </h1>
+        <p style={{ color: "var(--text-secondary)", lineHeight: 1.6 }}>
+          Анализируйте поступления и расходы за выбранный период.
+        </p>
+      </header>
 
         {error ? <p style={{ color: "var(--accent-danger)" }}>{error}</p> : null}
         {loading ? <p style={{ color: "var(--text-muted)" }}>Загружаем данные...</p> : null}
 
         <section
+          data-layout="stat-grid"
           style={{
             display: "grid",
             gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
@@ -523,7 +524,7 @@ const ReportsContent = () => {
               boxShadow: "0 16px 35px rgba(129, 140, 248, 0.25)"
             }}
           >
-            <h2 style={{ color: "var(--surface-navy)", fontWeight: 600, marginBottom: "0.5rem" }}>
+            <h2 style={{ fontWeight: 600, marginBottom: "0.5rem" }}>
               Приход
             </h2>
             <strong style={{ fontSize: "1.6rem", color: "var(--accent-indigo-strong)" }}>
@@ -538,7 +539,7 @@ const ReportsContent = () => {
               boxShadow: "0 16px 35px rgba(248, 113, 113, 0.25)"
             }}
           >
-            <h2 style={{ color: "var(--accent-danger-strong)", fontWeight: 600, marginBottom: "0.5rem" }}>
+            <h2 style={{ fontWeight: 600, marginBottom: "0.5rem" }}>
               Расход
             </h2>
             <strong style={{ fontSize: "1.6rem", color: "var(--accent-danger)" }}>
@@ -553,7 +554,7 @@ const ReportsContent = () => {
               boxShadow: "0 16px 35px rgba(34, 197, 94, 0.25)"
             }}
           >
-            <h2 style={{ color: "var(--accent-success-strong)", fontWeight: 600, marginBottom: "0.5rem" }}>
+            <h2 style={{ fontWeight: 600, marginBottom: "0.5rem" }}>
               Баланс
             </h2>
             <strong style={{ fontSize: "1.6rem", color: totals.balance >= 0 ? "var(--accent-success)" : "var(--accent-danger)" }}>
@@ -563,6 +564,7 @@ const ReportsContent = () => {
         </section>
 
         <section
+          data-layout="responsive-form"
           style={{
             display: "grid",
             gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
@@ -639,7 +641,7 @@ const ReportsContent = () => {
         </section>
 
         <section style={{ display: "flex", flexDirection: "column", gap: "1.25rem" }}>
-          <h2 style={{ fontSize: "1.4rem", fontWeight: 600, color: "var(--accent-purple-deep)" }}>
+          <h2 style={{ fontSize: "1.4rem", fontWeight: 600 }}>
             Категории
           </h2>
           {categoryRows.length === 0 ? (
@@ -648,16 +650,16 @@ const ReportsContent = () => {
             <table style={{ width: "100%", borderCollapse: "collapse" }}>
               <thead>
                 <tr style={{ backgroundColor: "var(--surface-purple)" }}>
-                  <th style={{ textAlign: "left", padding: "0.75rem", color: "var(--surface-navy)" }}>
+                  <th style={{ textAlign: "left", padding: "0.75rem", color: "var(--text-strong)" }}>
                     Категория
                   </th>
-                  <th style={{ textAlign: "right", padding: "0.75rem", color: "var(--surface-navy)" }}>
+                  <th style={{ textAlign: "right", padding: "0.75rem", color: "var(--text-strong)" }}>
                     Приход
                   </th>
-                  <th style={{ textAlign: "right", padding: "0.75rem", color: "var(--surface-navy)" }}>
+                  <th style={{ textAlign: "right", padding: "0.75rem", color: "var(--text-strong)" }}>
                     Расход
                   </th>
-                  <th style={{ textAlign: "right", padding: "0.75rem", color: "var(--surface-navy)" }}>
+                  <th style={{ textAlign: "right", padding: "0.75rem", color: "var(--text-strong)" }}>
                     Итого
                   </th>
                 </tr>

--- a/app/settings/categories/page.tsx
+++ b/app/settings/categories/page.tsx
@@ -248,7 +248,7 @@ const CategoriesSettings = () => {
             gap: "0.75rem"
           }}
         >
-          <h1 style={{ fontSize: "2rem", fontWeight: 700, color: "var(--surface-navy)" }}>
+          <h1 style={{ fontSize: "2rem", fontWeight: 700 }}>
             Управление категориями
           </h1>
           <p style={{ color: "var(--text-secondary)", lineHeight: 1.6 }}>
@@ -260,6 +260,7 @@ const CategoriesSettings = () => {
         {loading ? <p style={{ color: "var(--text-muted)" }}>Загружаем категории...</p> : null}
 
         <section
+          data-layout="stat-grid"
           style={{
             display: "grid",
             gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
@@ -302,7 +303,7 @@ const CategoriesSettings = () => {
                 <h2 style={{ color: config.color, fontWeight: 600 }}>{config.title}</h2>
                 <form
                   onSubmit={(event) => handleAdd(event, config.type)}
-                  className="flex items-center gap-3"
+                  className="flex flex-col gap-3 sm:flex-row sm:items-center"
                 >
                   <input
                     type="text"
@@ -314,12 +315,12 @@ const CategoriesSettings = () => {
                     }}
                     placeholder="Новая категория"
                     disabled={!canManage || pendingType === config.type}
-                    className="flex-1 min-w-0 rounded-xl border px-4 py-3"
+                    className="w-full flex-1 min-w-0 rounded-xl border px-4 py-3"
                   />
                   <button
                     type="submit"
                     disabled={!canManage || pendingType === config.type}
-                    className="inline-flex items-center justify-center rounded-xl px-5 py-3 font-semibold whitespace-nowrap transition-colors"
+                    className="inline-flex w-full items-center justify-center rounded-xl px-5 py-3 font-semibold whitespace-nowrap transition-colors sm:w-auto"
                     style={{
                       backgroundColor:
                         !canManage || pendingType === config.type
@@ -355,6 +356,7 @@ const CategoriesSettings = () => {
                     return (
                       <li
                         key={item}
+                        data-card="split"
                         style={{
                           display: "flex",
                           alignItems: "center",

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -245,19 +245,19 @@ const SettingsContent = () => {
   return (
     <PageContainer activeTab="settings">
       <header
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            gap: "0.75rem"
-          }}
-        >
-          <h1 style={{ fontSize: "2rem", fontWeight: 700, color: "var(--surface-navy)" }}>
-            Финансовые настройки общины
-          </h1>
-          <p style={{ color: "var(--text-secondary)", lineHeight: 1.6 }}>
-            Обновляйте базовую валюту и курсы конвертации, чтобы отчёты оставались точными.
-          </p>
-        </header>
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "0.75rem"
+        }}
+      >
+        <h1 style={{ fontSize: "2rem", fontWeight: 700 }}>
+          Финансовые настройки общины
+        </h1>
+        <p style={{ color: "var(--text-secondary)", lineHeight: 1.6 }}>
+          Обновляйте базовую валюту и курсы конвертации, чтобы отчёты оставались точными.
+        </p>
+      </header>
 
         <div
           style={{
@@ -278,6 +278,7 @@ const SettingsContent = () => {
           }}
         >
           <section
+            data-layout="stat-grid"
             style={{
               display: "grid",
               gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
@@ -292,7 +293,7 @@ const SettingsContent = () => {
                 boxShadow: "0 12px 28px rgba(99, 102, 241, 0.15)"
               }}
             >
-              <h2 style={{ color: "var(--surface-navy)", fontWeight: 600, marginBottom: "0.5rem" }}>
+              <h2 style={{ fontWeight: 600, marginBottom: "0.5rem" }}>
                 Базовая валюта
               </h2>
               <strong style={{ fontSize: "1.5rem", color: "var(--accent-indigo-strong)" }}>{baseCurrency}</strong>
@@ -308,7 +309,7 @@ const SettingsContent = () => {
                 boxShadow: "0 12px 28px rgba(34, 197, 94, 0.12)"
               }}
             >
-              <h2 style={{ color: "var(--accent-success-strong)", fontWeight: 600, marginBottom: "0.5rem" }}>
+              <h2 style={{ fontWeight: 600, marginBottom: "0.5rem" }}>
                 Текущий баланс (пример)
               </h2>
               <strong style={{ fontSize: "1.5rem", color: "var(--accent-success)" }}>
@@ -321,6 +322,7 @@ const SettingsContent = () => {
           </section>
 
           <div
+            data-layout="toolbar"
             style={{
               display: "flex",
               justifyContent: "flex-end",
@@ -355,6 +357,7 @@ const SettingsContent = () => {
           </div>
 
           <section
+            data-layout="stat-grid"
             style={{
               display: "grid",
               gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
@@ -396,6 +399,7 @@ const SettingsContent = () => {
         </div>
 
         <section
+          data-layout="stat-grid"
           style={{
             display: "grid",
             gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",

--- a/app/settings/wallets/page.tsx
+++ b/app/settings/wallets/page.tsx
@@ -227,7 +227,7 @@ const WalletSettings = () => {
             gap: "0.75rem"
           }}
         >
-          <h1 style={{ fontSize: "2rem", fontWeight: 700, color: "var(--text-primary)" }}>
+          <h1 style={{ fontSize: "2rem", fontWeight: 700 }}>
             Управление кошельками
           </h1>
           <p style={{ color: "var(--text-secondary)", lineHeight: 1.6 }}>
@@ -238,7 +238,10 @@ const WalletSettings = () => {
 
         {loading ? <p style={{ color: "var(--text-muted)" }}>Загружаем список...</p> : null}
 
-        <form onSubmit={handleAdd} className="flex items-center gap-3">
+        <form
+          onSubmit={handleAdd}
+          className="flex flex-col gap-3 sm:flex-row sm:items-center"
+        >
           <input
             type="text"
             value={newWallet}
@@ -249,13 +252,13 @@ const WalletSettings = () => {
             }}
             disabled={!canManage || saving}
             placeholder="Название кошелька"
-            className="flex-1 min-w-0 rounded-xl border px-4 py-3"
-            style={{ minWidth: "220px" }}
+            className="w-full flex-1 min-w-0 rounded-xl border px-4 py-3"
+            style={{ minWidth: "min(220px, 100%)" }}
           />
           <button
             type="submit"
             disabled={!canManage || saving}
-            className="inline-flex items-center justify-center rounded-xl px-5 py-3 font-semibold whitespace-nowrap transition-colors"
+            className="inline-flex w-full items-center justify-center rounded-xl px-5 py-3 font-semibold whitespace-nowrap transition-colors sm:w-auto"
             style={{
               backgroundColor: !canManage || saving ? "var(--accent-disabled-strong)" : "var(--accent-teal)",
               color: "var(--surface-primary)",
@@ -288,6 +291,7 @@ const WalletSettings = () => {
               return (
                 <li
                   key={wallet}
+                  data-card="split"
                   style={{
                     display: "flex",
                     alignItems: "center",

--- a/app/wallets/page.tsx
+++ b/app/wallets/page.tsx
@@ -207,19 +207,19 @@ const WalletsContent = () => {
   return (
     <PageContainer activeTab="wallets">
       <header
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            gap: "0.75rem"
-          }}
-        >
-          <h1 style={{ fontSize: "2rem", fontWeight: 700, color: "var(--text-primary)" }}>
-            Состояние кошельков
-          </h1>
-          <p style={{ color: "var(--text-secondary)", lineHeight: 1.6 }}>
-            Анализируйте балансы по каждому кошельку с учётом долгов и целевых средств.
-          </p>
-        </header>
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "0.75rem"
+        }}
+      >
+        <h1 style={{ fontSize: "2rem", fontWeight: 700 }}>
+          Состояние кошельков
+        </h1>
+        <p style={{ color: "var(--text-secondary)", lineHeight: 1.6 }}>
+          Анализируйте балансы по каждому кошельку с учётом долгов и целевых средств.
+        </p>
+      </header>
 
         {loading ? <p style={{ color: "var(--text-muted)" }}>Загружаем данные...</p> : null}
         {error ? <p style={{ color: "var(--accent-danger)" }}>{error}</p> : null}
@@ -234,7 +234,7 @@ const WalletsContent = () => {
               flexWrap: "wrap"
             }}
           >
-            <h2 style={{ fontSize: "1.4rem", fontWeight: 600, color: "var(--text-primary)" }}>
+            <h2 style={{ fontSize: "1.4rem", fontWeight: 600 }}>
               Активные кошельки
             </h2>
           </div>
@@ -258,6 +258,7 @@ const WalletsContent = () => {
         </section>
 
         <section
+          data-layout="stat-grid"
           style={{
             display: "grid",
             gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
@@ -286,7 +287,7 @@ const WalletsContent = () => {
                 }}
               >
                 <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem" }}>
-                  <h2 style={{ color: "var(--text-primary)", fontWeight: 600 }}>{summary.wallet}</h2>
+                  <h2 style={{ fontWeight: 600 }}>{summary.wallet}</h2>
                   {!summary.active ? (
                     <span style={{ color: "var(--accent-amber)", fontSize: "0.85rem" }}>
                       Кошелёк удалён — операции и остатки сохранены


### PR DESCRIPTION
## Summary
- adjust global styling to increase heading contrast in dark mode and add shared responsive helpers for forms, grids, and cards
- update dashboard, debts, planning, reports, and wallets screens to leverage responsive helpers so cards and forms stack cleanly on small displays
- refresh settings sections, including categories and wallets management, with mobile-friendly form layouts and consistent heading colors

## Testing
- npm run lint *(fails: Next.js binary is unavailable under the container's Node 20 runtime; project requires Node 22+)*

------
https://chatgpt.com/codex/tasks/task_e_68d2353720ac83319e559b771fd9859a