### PR TITLE
feat: refresh styling with dark-first theming

### DIFF
--- a/app/debts/page.tsx
+++ b/app/debts/page.tsx
@@ -465,16 +465,7 @@ const DebtsContent = () => {
         <button
           type="submit"
           disabled={!canManage || loading || !wallet}
-          style={{
-            padding: "0.95rem 1.5rem",
-            borderRadius: "0.75rem",
-            border: "none",
-            backgroundColor: loading || !canManage ? "var(--accent-disabled)" : "var(--accent-primary)",
-            color: "var(--surface-primary)",
-            fontWeight: 600,
-            boxShadow: "0 10px 20px rgba(37, 99, 235, 0.25)",
-            cursor: !canManage || loading ? "not-allowed" : "pointer"
-          }}
+          data-variant="primary"
         >
           {loading ? "Добавляем..." : "Добавить"}
         </button>
@@ -542,16 +533,7 @@ const DebtsContent = () => {
                       type="button"
                       onClick={() => handleDelete(debt.id)}
                       disabled={deletingId === debt.id}
-                      style={{
-                        padding: "0.55rem 1rem",
-                        borderRadius: "0.75rem",
-                        border: "1px solid var(--accent-danger-bright)",
-                        backgroundColor: deletingId === debt.id ? "var(--surface-danger-strong)" : "var(--surface-danger)",
-                        color: "var(--accent-danger)",
-                        fontWeight: 600,
-                        cursor: deletingId === debt.id ? "not-allowed" : "pointer",
-                        boxShadow: "0 10px 18px rgba(239, 68, 68, 0.15)"
-                      }}
+                      data-variant="danger"
                     >
                       {deletingId === debt.id ? "Удаляем..." : "Удалить"}
                     </button>

--- a/app/globals.css
+++ b/app/globals.css
@@ -6,113 +6,125 @@
 
 :root {
   color-scheme: light;
-  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-  --page-background: #f3f4f6;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --page-background: #ffffff;
   --surface-primary: #ffffff;
   --surface-subtle: #f8fafc;
-  --surface-muted: #f1f5f9;
-  --surface-contrast: #f9fafb;
-  --surface-teal: #ccfbf1;
-  --surface-teal-strong: #99f6e4;
-  --surface-teal-bright: #f0fdfa;
+  --surface-muted: #e2e8f0;
+  --surface-contrast: #cbd5f5;
+  --surface-teal: #dbeafe;
+  --surface-teal-strong: #bfdbfe;
+  --surface-teal-bright: #eff6ff;
   --surface-success: #dcfce7;
-  --surface-success-strong: #f0fdf4;
+  --surface-success-strong: #bbf7d0;
   --surface-danger: #fee2e2;
   --surface-danger-strong: #fecaca;
   --surface-amber: #fef3c7;
   --surface-amber-soft: #fff7ed;
-  --surface-purple: #f5f3ff;
-  --surface-violet: #ede9fe;
+  --surface-purple: #ede9fe;
+  --surface-violet: #e0e7ff;
   --surface-magenta: #fdf4ff;
-  --surface-blue: #e0e7ff;
+  --surface-blue: #dbeafe;
   --surface-blue-soft: #eff6ff;
-  --surface-indigo: #eef2ff;
-  --surface-navy: #312e81;
-  --surface-deep: #111827;
-  --border-muted: #d1d5db;
-  --border-strong: #e2e8f0;
+  --surface-indigo: #e0e7ff;
+  --surface-navy: #1e3a8a;
+  --surface-deep: #0f172a;
+  --border-muted: #e2e8f0;
+  --border-strong: #cbd5f5;
   --border-subtle: #e5e7eb;
-  --text-primary: #0f172a;
-  --text-strong: #1f2937;
-  --text-secondary: #475569;
-  --text-secondary-strong: #334155;
+  --text-primary: #1e293b;
+  --text-strong: #0f172a;
+  --text-secondary: #334155;
+  --text-secondary-strong: #1e293b;
   --text-muted: #64748b;
-  --text-muted-strong: #6b7280;
+  --text-muted-strong: #475569;
   --accent-primary: #2563eb;
-  --accent-blue: #1d4ed8;
+  --accent-primary-hover: #1d4ed8;
+  --accent-blue: #2563eb;
   --accent-indigo: #4338ca;
   --accent-indigo-strong: #3730a3;
-  --accent-purple: #6d28d9;
-  --accent-purple-bright: #7c3aed;
-  --accent-purple-deep: #3b0764;
-  --accent-violet: #5b21b6;
-  --accent-amber: #b45309;
-  --accent-teal: #0f766e;
-  --accent-teal-strong: #047857;
-  --accent-success: #15803d;
-  --accent-success-strong: #166534;
-  --accent-danger: #b91c1c;
-  --accent-danger-strong: #991b1b;
-  --accent-danger-bright: #ef4444;
+  --accent-purple: #7c3aed;
+  --accent-purple-bright: #a855f7;
+  --accent-purple-deep: #5b21b6;
+  --accent-violet: #6366f1;
+  --accent-amber: #f59e0b;
+  --accent-teal: #0ea5e9;
+  --accent-teal-strong: #0284c7;
+  --accent-success: #16a34a;
+  --accent-success-strong: #15803d;
+  --accent-danger: #ef4444;
+  --accent-danger-strong: #dc2626;
+  --accent-danger-bright: #f87171;
   --accent-disabled: #94a3b8;
-  --accent-disabled-strong: #9ca3af;
-  --shadow-soft: 0 18px 35px rgba(15, 23, 42, 0.12);
-  --shadow-strong: 0 24px 45px rgba(15, 23, 42, 0.16);
+  --accent-disabled-strong: #94a3b8;
+  --shadow-soft: 0 24px 45px rgba(15, 23, 42, 0.08);
+  --shadow-strong: 0 32px 70px rgba(15, 23, 42, 0.12);
+  --shadow-card: 0 20px 45px rgba(15, 23, 42, 0.1);
+  --shadow-button: 0 20px 40px rgba(37, 99, 235, 0.25);
+  --shadow-button-danger: 0 20px 40px rgba(239, 68, 68, 0.2);
+  --shadow-button-outline: 0 15px 35px rgba(15, 23, 42, 0.08);
+  --radius-2xl: 1rem;
+  --card-padding: 1rem;
 }
 
 .dark {
   color-scheme: dark;
-  --page-background: #020617;
-  --surface-primary: #0b1220;
-  --surface-subtle: #111a2e;
-  --surface-muted: #16213a;
-  --surface-contrast: #0e1627;
-  --surface-teal: #0d3a32;
-  --surface-teal-strong: #0f473a;
-  --surface-teal-bright: #115243;
-  --surface-success: #123021;
-  --surface-success-strong: #0f2719;
-  --surface-danger: #3a141d;
-  --surface-danger-strong: #4a1824;
-  --surface-amber: #422006;
-  --surface-amber-soft: #4b2a07;
-  --surface-purple: #261248;
-  --surface-violet: #2f1859;
-  --surface-magenta: #35134f;
-  --surface-blue: #1c2a4e;
-  --surface-blue-soft: #1f315c;
-  --surface-indigo: #1b2a4b;
-  --surface-navy: #1a1f4a;
-  --surface-deep: #0b1220;
-  --border-muted: #27324c;
-  --border-strong: #324163;
-  --border-subtle: #1d2840;
+  --page-background: #0f172a;
+  --surface-primary: #101a2c;
+  --surface-subtle: #1e293b;
+  --surface-muted: #334155;
+  --surface-contrast: #1f2a44;
+  --surface-teal: rgba(56, 189, 248, 0.18);
+  --surface-teal-strong: rgba(14, 165, 233, 0.28);
+  --surface-teal-bright: rgba(96, 165, 250, 0.2);
+  --surface-success: rgba(34, 197, 94, 0.18);
+  --surface-success-strong: rgba(22, 163, 74, 0.3);
+  --surface-danger: rgba(248, 113, 113, 0.18);
+  --surface-danger-strong: rgba(248, 113, 113, 0.28);
+  --surface-amber: rgba(251, 191, 36, 0.2);
+  --surface-amber-soft: rgba(251, 191, 36, 0.12);
+  --surface-purple: rgba(192, 132, 252, 0.2);
+  --surface-violet: rgba(129, 140, 248, 0.22);
+  --surface-magenta: rgba(236, 72, 153, 0.2);
+  --surface-blue: rgba(96, 165, 250, 0.2);
+  --surface-blue-soft: rgba(59, 130, 246, 0.14);
+  --surface-indigo: rgba(129, 140, 248, 0.25);
+  --surface-navy: #1e293b;
+  --surface-deep: #0f172a;
+  --border-muted: #1f2a44;
+  --border-strong: #334155;
+  --border-subtle: #1c2540;
   --text-primary: #e2e8f0;
-  --text-strong: #f8fafc;
+  --text-strong: #ffffff;
   --text-secondary: #cbd5f5;
-  --text-secondary-strong: #a5b4fc;
+  --text-secondary-strong: #f8fafc;
   --text-muted: #94a3b8;
-  --text-muted-strong: #94a3b8;
+  --text-muted-strong: #cbd5f5;
   --accent-primary: #60a5fa;
+  --accent-primary-hover: #3b82f6;
   --accent-blue: #60a5fa;
   --accent-indigo: #a78bfa;
   --accent-indigo-strong: #c4b5fd;
   --accent-purple: #c084fc;
   --accent-purple-bright: #d8b4fe;
-  --accent-purple-deep: #e9d5ff;
-  --accent-violet: #c4b5fd;
+  --accent-purple-deep: #a855f7;
+  --accent-violet: #818cf8;
   --accent-amber: #fbbf24;
-  --accent-teal: #34d399;
-  --accent-teal-strong: #2dd4bf;
+  --accent-teal: #38bdf8;
+  --accent-teal-strong: #0ea5e9;
   --accent-success: #4ade80;
   --accent-success-strong: #22c55e;
   --accent-danger: #f87171;
-  --accent-danger-strong: #dc2626;
+  --accent-danger-strong: #ef4444;
   --accent-danger-bright: #fca5a5;
   --accent-disabled: #64748b;
   --accent-disabled-strong: #475569;
-  --shadow-soft: 0 22px 40px rgba(2, 8, 23, 0.45);
-  --shadow-strong: 0 32px 60px rgba(2, 8, 23, 0.55);
+  --shadow-soft: 0 32px 55px rgba(8, 15, 35, 0.5);
+  --shadow-strong: 0 45px 85px rgba(8, 15, 35, 0.65);
+  --shadow-card: 0 40px 70px rgba(8, 15, 35, 0.55);
+  --shadow-button: 0 30px 60px rgba(96, 165, 250, 0.35);
+  --shadow-button-danger: 0 30px 60px rgba(248, 113, 113, 0.3);
+  --shadow-button-outline: 0 25px 55px rgba(8, 15, 35, 0.45);
 }
 
 body {
@@ -149,24 +161,260 @@ textarea {
 }
 
 button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 1rem !important;
+  border-radius: var(--radius-2xl) !important;
+  font-weight: 600;
+  font-size: 0.95rem;
+  border: 1px solid transparent;
   cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease,
+    box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+  box-shadow: none;
+}
+
+button:not(.theme-toggle) {
+  box-shadow: var(--shadow-button);
+}
+
+button[data-variant="primary"],
+button:not([data-variant]):not(.theme-toggle) {
+  background-color: var(--accent-primary);
+  color: var(--surface-primary);
+}
+
+button[data-variant="primary"]:hover,
+button:not([data-variant]):not(.theme-toggle):hover {
+  background-color: var(--accent-primary-hover);
+}
+
+button[data-variant="danger"] {
+  background-color: var(--accent-danger);
+  color: var(--surface-primary);
+  box-shadow: var(--shadow-button-danger);
+}
+
+button[data-variant="danger"]:hover {
+  background-color: var(--accent-danger-strong);
+}
+
+button[data-variant="outline"] {
+  background-color: transparent;
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-button-outline);
+}
+
+button[data-variant="outline"]:hover {
+  background-color: var(--surface-subtle);
+}
+
+.dark button[data-variant="outline"] {
+  color: var(--text-secondary);
+  border-color: rgba(148, 163, 184, 0.35);
+}
+
+.dark button[data-variant="outline"]:hover {
+  background-color: rgba(51, 65, 85, 0.65);
+  color: var(--text-strong);
+}
+
+button[data-variant="ghost"] {
+  background-color: transparent;
+  color: var(--text-secondary);
+  border: none;
+  box-shadow: none;
+}
+
+button[data-variant="ghost"]:hover {
+  color: var(--text-strong);
+}
+
+button:not(:disabled):hover {
+  transform: translateY(-1px);
+}
+
+button:not(:disabled):active {
+  transform: translateY(0);
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-2xl);
+  border: 1px solid var(--border-muted);
+  background-color: var(--surface-primary);
+  color: var(--text-primary);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease,
+    color 0.2s ease;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
+}
+
+.dark input:focus,
+.dark select:focus,
+.dark textarea:focus {
+  box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.25);
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  color: var(--text-secondary);
 }
 
 .page-shell {
   width: min(100%, 980px);
   background-color: var(--surface-primary);
   color: var(--text-primary);
-  border-radius: 24px;
+  border-radius: 1.25rem;
   box-shadow: var(--shadow-strong);
   padding: 2.75rem 2.5rem;
   display: flex;
   flex-direction: column;
   gap: 2.25rem;
-  transition: background-color 0.3s ease, color 0.3s ease, box-shadow 0.3s ease;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  transition: background-color 0.3s ease, color 0.3s ease, box-shadow 0.3s ease,
+    border-color 0.3s ease;
 }
 
-.bg-white {
+.page-shell section {
+  background-color: var(--surface-subtle);
+  border-radius: var(--radius-2xl) !important;
+  padding: var(--card-padding) !important;
+  box-shadow: var(--shadow-card) !important;
+  border: 1px solid var(--border-strong);
+  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease,
+    box-shadow 0.3s ease;
+}
+
+.page-shell section[data-variant="plain"] {
+  background: transparent;
+  border: none !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+}
+
+.page-shell .muted {
+  color: var(--text-muted);
+}
+
+.tab-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  border-radius: var(--radius-2xl);
+  background-color: var(--surface-muted);
+  color: var(--accent-primary);
+  font-weight: 600;
+  border: 1px solid var(--border-subtle);
+  box-shadow: var(--shadow-soft);
+  transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease,
+    box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.tab-pill[data-active="true"] {
+  background-color: var(--accent-primary);
+  color: var(--surface-primary);
+  border-color: transparent;
+  box-shadow: var(--shadow-button);
+}
+
+.tab-pill[data-active="false"]:hover {
+  background-color: var(--surface-subtle);
+  box-shadow: var(--shadow-card);
+}
+
+.tab-pill__icon {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.dark .tab-pill {
+  background-color: rgba(51, 65, 85, 0.55);
+  border-color: rgba(148, 163, 184, 0.2);
+}
+
+.dark .tab-pill[data-active="true"] {
+  color: var(--text-strong);
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 0.9rem !important;
+  border-radius: var(--radius-2xl) !important;
+  border: 1px solid var(--border-muted);
+  background-color: var(--surface-subtle);
+  color: var(--text-secondary);
+  box-shadow: var(--shadow-button-outline);
+}
+
+.theme-toggle:hover {
+  background-color: var(--surface-muted);
+  color: var(--text-strong);
+}
+
+.theme-toggle__track {
+  position: relative;
+  width: 52px;
+  height: 26px;
+  border-radius: 999px;
+  background-color: var(--border-muted);
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 0.45rem;
+}
+
+.theme-toggle__thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
   background-color: var(--surface-primary);
+  box-shadow: var(--shadow-soft);
+  transition: transform 0.2s ease;
+}
+
+.theme-toggle[data-mode="dark"] .theme-toggle__thumb {
+  transform: translateX(26px);
+}
+
+.theme-toggle__icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+.theme-toggle__label {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+ul,
+ol {
+  list-style: none;
 }
 
 @media (max-width: 768px) {
@@ -177,7 +425,7 @@ button {
 
   .page-shell {
     width: 100%;
-    border-radius: 20px;
+    border-radius: 1rem;
     padding: 2rem 1.5rem;
     box-shadow: var(--shadow-soft);
   }
@@ -222,89 +470,6 @@ button {
   }
 }
 
-.text-black {
-  color: var(--text-strong);
-}
-
-.dark .dark\:bg-midnight {
-  background-color: var(--surface-deep);
-}
-
-.dark .dark\:text-slate-100 {
-  color: var(--text-strong);
-}
-
-.page-shell h1,
-.page-shell h2,
-.page-shell h3,
-.page-shell h4,
-.page-shell h5,
-.page-shell h6 {
-  color: var(--text-strong);
-}
-
-.page-shell .muted {
-  color: var(--text-muted);
-}
-
-.page-shell section {
-  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
-}
-
-.theme-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.85rem 1.25rem;
-  border-radius: 999px;
-  border: 1px solid var(--border-muted);
-  background-color: var(--surface-subtle);
-  color: var(--text-secondary);
-  font-weight: 600;
-  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-}
-
-.theme-toggle:hover {
-  background-color: var(--surface-muted);
-  color: var(--text-strong);
-}
-
-.theme-toggle__track {
-  position: relative;
-  width: 48px;
-  height: 24px;
-  border-radius: 999px;
-  background-color: var(--border-muted);
-  transition: background-color 0.2s ease;
-}
-
-.theme-toggle__thumb {
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  background-color: var(--surface-primary);
-  box-shadow: var(--shadow-soft);
-  transition: transform 0.2s ease, background-color 0.2s ease;
-}
-
-.theme-toggle[data-mode="dark"] .theme-toggle__track {
-  background-color: var(--accent-primary);
-}
-
-.theme-toggle[data-mode="dark"] .theme-toggle__thumb {
-  transform: translateX(24px);
-  background-color: var(--accent-primary);
-}
-
-.theme-toggle__label {
-  font-size: 0.95rem;
-  color: var(--text-secondary);
-}
-
-/* Tailwind-inspired utility classes used for layout adjustments */
 .flex {
   display: flex;
 }
@@ -397,31 +562,4 @@ button {
 
 .font-semibold {
   font-weight: 600;
-}
-
-.border {
-  border: 1px solid var(--border-muted);
-}
-
-.whitespace-nowrap {
-  white-space: nowrap;
-}
-
-.transition-colors {
-  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.tab-pill {
-  box-shadow: var(--shadow-soft);
-}
-
-@media (max-width: 900px) {
-  body {
-    padding: 2rem 1rem 3rem;
-  }
-
-  .page-shell {
-    padding: 2rem 1.5rem;
-    border-radius: 20px;
-  }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,14 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { Inter } from "next/font/google";
 import SessionProvider from "@/components/SessionProvider";
 import { ThemeProvider } from "next-themes";
 import "./globals.css";
+
+const inter = Inter({
+  subsets: ["latin", "cyrillic"],
+  display: "swap"
+});
 
 export const metadata: Metadata = {
   title: "Финансы храма — MVP",
@@ -11,8 +17,8 @@ export const metadata: Metadata = {
 
 const RootLayout = ({ children }: { children: ReactNode }) => (
   <html lang="ru" suppressHydrationWarning>
-    <body>
-      <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
+    <body className={inter.className}>
+      <ThemeProvider attribute="class" defaultTheme="dark">
         <SessionProvider>{children}</SessionProvider>
       </ThemeProvider>
     </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -565,11 +565,6 @@ const Dashboard = () => {
                   (type === "income"
                     ? incomeCategories.length === 0
                     : expenseOptions.length === 0)}
-                style={{
-                  padding: "0.75rem 1rem",
-                  borderRadius: "0.75rem",
-                  border: "1px solid var(--border-muted)"
-                }}
               >
                 {(type === "income" ? incomeCategories : expenseOptions).length === 0 ? (
                   <option value="">
@@ -590,18 +585,8 @@ const Dashboard = () => {
             <button
               type="submit"
               disabled={!canManage || loading || !wallet || !category}
-              style={{
-                padding: "0.95rem 1.5rem",
-                borderRadius: "0.75rem",
-                border: "none",
-                backgroundColor: loading || !canManage ? "var(--accent-disabled)" : "var(--accent-primary)",
-                color: "var(--surface-primary)",
-                fontWeight: 600,
-                transition: "background-color 0.2s ease",
-                boxShadow: "0 10px 20px rgba(37, 99, 235, 0.25)",
-                width: "100%",
-                cursor: !canManage || loading ? "not-allowed" : "pointer"
-              }}
+              data-variant="primary"
+              className="w-full"
             >
               {loading ? "Добавляем..." : "Добавить"}
             </button>
@@ -632,15 +617,15 @@ const Dashboard = () => {
                   key={operation.id}
                   data-card="split"
                   style={{
-                    padding: "1.1rem 1.35rem",
-                    borderRadius: "1rem",
+                    padding: "1rem",
+                    borderRadius: "var(--radius-2xl)",
                     border: "1px solid var(--border-strong)",
                     display: "flex",
                     justifyContent: "space-between",
                     alignItems: "flex-start",
                     gap: "1.25rem",
                     backgroundColor: "var(--surface-subtle)",
-                    boxShadow: "0 12px 24px rgba(15, 23, 42, 0.08)",
+                    boxShadow: "var(--shadow-card)",
                     flexWrap: "wrap"
                   }}
                 >
@@ -695,19 +680,8 @@ const Dashboard = () => {
                         type="button"
                         onClick={() => handleDelete(operation.id)}
                         disabled={deletingId === operation.id}
-                        style={{
-                          padding: "0.55rem 0.95rem",
-                          borderRadius: "0.75rem",
-                          border: "1px solid var(--accent-danger-bright)",
-                          backgroundColor:
-                            deletingId === operation.id ? "var(--surface-danger-strong)" : "var(--surface-danger)",
-                          color: "var(--accent-danger)",
-                          fontWeight: 600,
-                          cursor: deletingId === operation.id ? "not-allowed" : "pointer",
-                          transition: "background-color 0.2s ease, transform 0.2s ease",
-                          boxShadow: "0 10px 18px rgba(239, 68, 68, 0.15)",
-                          width: "100%"
-                        }}
+                        data-variant="danger"
+                        className="w-full"
                       >
                         {deletingId === operation.id ? "Удаляем..." : "Удалить"}
                       </button>

--- a/app/planning/page.tsx
+++ b/app/planning/page.tsx
@@ -310,7 +310,7 @@ const PlanningContent = () => {
             gap: "1rem"
           }}
         >
-          <label style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+          <label>
             <span>Название цели</span>
             <input
               type="text"
@@ -318,15 +318,10 @@ const PlanningContent = () => {
               onChange={(event) => setTitle(event.target.value)}
               disabled={!canManage || loading}
               placeholder="Например, фестиваль Гауранги"
-              style={{
-                padding: "0.75rem 1rem",
-                borderRadius: "0.75rem",
-                border: "1px solid var(--border-muted)"
-              }}
             />
           </label>
 
-          <label style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+          <label>
             <span>Сумма</span>
             <input
               type="number"
@@ -336,25 +331,15 @@ const PlanningContent = () => {
               onChange={(event) => setTargetAmount(event.target.value)}
               disabled={!canManage || loading}
               placeholder="0.00"
-              style={{
-                padding: "0.75rem 1rem",
-                borderRadius: "0.75rem",
-                border: "1px solid var(--border-muted)"
-              }}
             />
           </label>
 
-          <label style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+          <label>
             <span>Валюта</span>
             <select
               value={currency}
               onChange={(event) => setCurrency(event.target.value as Currency)}
               disabled={!canManage || loading}
-              style={{
-                padding: "0.75rem 1rem",
-                borderRadius: "0.75rem",
-                border: "1px solid var(--border-muted)"
-              }}
             >
               {SUPPORTED_CURRENCIES.map((item) => (
                 <option key={item} value={item}>
@@ -367,16 +352,7 @@ const PlanningContent = () => {
           <button
             type="submit"
             disabled={!canManage || loading}
-            style={{
-              padding: "0.95rem 1.5rem",
-              borderRadius: "0.75rem",
-              border: "none",
-              backgroundColor: loading || !canManage ? "var(--accent-disabled)" : "var(--accent-primary)",
-              color: "var(--surface-primary)",
-              fontWeight: 600,
-              boxShadow: "0 10px 20px rgba(37, 99, 235, 0.25)",
-              cursor: !canManage || loading ? "not-allowed" : "pointer"
-            }}
+            data-variant="primary"
           >
             {loading ? "Добавляем..." : "Добавить цель"}
           </button>
@@ -413,10 +389,10 @@ const PlanningContent = () => {
                     key={goal.id}
                     style={{
                       border: "1px solid var(--border-strong)",
-                      borderRadius: "1rem",
-                      padding: "1.5rem",
+                      borderRadius: "var(--radius-2xl)",
+                      padding: "1rem",
                       backgroundColor: "var(--surface-subtle)",
-                      boxShadow: "0 12px 24px rgba(15, 23, 42, 0.08)",
+                      boxShadow: "var(--shadow-card)",
                       display: "flex",
                       flexDirection: "column",
                       gap: "0.85rem"
@@ -445,16 +421,7 @@ const PlanningContent = () => {
                           type="button"
                           onClick={() => handleDelete(goal.id)}
                           disabled={deletingId === goal.id}
-                          style={{
-                            padding: "0.55rem 1rem",
-                            borderRadius: "0.75rem",
-                            border: "1px solid var(--accent-danger-bright)",
-                            backgroundColor: deletingId === goal.id ? "var(--surface-danger-strong)" : "var(--surface-danger)",
-                            color: "var(--accent-danger)",
-                            fontWeight: 600,
-                            cursor: deletingId === goal.id ? "not-allowed" : "pointer",
-                            boxShadow: "0 10px 18px rgba(239, 68, 68, 0.15)"
-                          }}
+                          data-variant="danger"
                         >
                           {deletingId === goal.id ? "Удаляем..." : "Удалить"}
                         </button>

--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -625,16 +625,7 @@ const ReportsContent = () => {
           <button
             type="button"
             onClick={() => void loadOperations()}
-            style={{
-              padding: "0.95rem 1.5rem",
-              borderRadius: "0.75rem",
-              border: "none",
-              backgroundColor: "var(--accent-purple-bright)",
-              color: "var(--surface-primary)",
-              fontWeight: 600,
-              boxShadow: "0 12px 24px rgba(124, 58, 237, 0.35)",
-              cursor: "pointer"
-            }}
+            data-variant="primary"
           >
             Обновить данные
           </button>
@@ -688,17 +679,8 @@ const ReportsContent = () => {
           type="button"
           onClick={handleExport}
           disabled={isExporting}
-          style={{
-            alignSelf: "flex-start",
-            padding: "0.95rem 1.75rem",
-            borderRadius: "0.85rem",
-            border: "none",
-            backgroundColor: isExporting ? "var(--accent-purple-bright)" : "var(--accent-violet)",
-            color: "var(--surface-primary)",
-            fontWeight: 600,
-            boxShadow: "0 16px 35px rgba(91, 33, 182, 0.25)",
-            cursor: isExporting ? "not-allowed" : "pointer"
-          }}
+          data-variant="primary"
+          style={{ alignSelf: "flex-start" }}
         >
           {isExporting ? "Готовим файл..." : "Экспортировать PDF"}
         </button>

--- a/app/settings/categories/page.tsx
+++ b/app/settings/categories/page.tsx
@@ -321,15 +321,7 @@ const CategoriesSettings = () => {
                     type="submit"
                     disabled={!canManage || pendingType === config.type}
                     className="inline-flex w-full items-center justify-center rounded-xl px-5 py-3 font-semibold whitespace-nowrap transition-colors sm:w-auto"
-                    style={{
-                      backgroundColor:
-                        !canManage || pendingType === config.type
-                          ? "var(--accent-disabled-strong)"
-                          : "var(--accent-primary)",
-                      color: "var(--surface-primary)",
-                      boxShadow: "0 10px 18px rgba(37, 99, 235, 0.2)",
-                      cursor: !canManage || pendingType === config.type ? "not-allowed" : "pointer"
-                    }}
+                    data-variant="primary"
                   >
                     {pendingType === config.type ? "Сохраняем..." : "Добавить"}
                   </button>
@@ -373,15 +365,7 @@ const CategoriesSettings = () => {
                             type="button"
                             onClick={() => handleDelete(config.type, item)}
                             disabled={isDeleting}
-                            style={{
-                              border: "none",
-                              backgroundColor: "var(--accent-danger-bright)",
-                              color: "var(--surface-primary)",
-                              borderRadius: "999px",
-                              padding: "0.35rem 0.85rem",
-                              fontSize: "0.85rem",
-                              cursor: isDeleting ? "not-allowed" : "pointer"
-                            }}
+                            data-variant="danger"
                           >
                             {isDeleting ? "Удаляем..." : "Удалить"}
                           </button>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -338,19 +338,7 @@ const SettingsContent = () => {
               type="button"
               onClick={handleForceUpdate}
               disabled={!canManage || ratesLoading}
-              style={{
-                padding: "0.95rem 1.5rem",
-                borderRadius: "0.85rem",
-                border: "none",
-                backgroundColor:
-                  !canManage || ratesLoading
-                    ? "var(--accent-disabled)"
-                    : "var(--accent-purple)",
-                color: "var(--surface-primary)",
-                fontWeight: 600,
-                boxShadow: "0 12px 24px rgba(109, 40, 217, 0.25)",
-                cursor: !canManage || ratesLoading ? "not-allowed" : "pointer"
-              }}
+              data-variant="primary"
             >
               {ratesLoading ? "Обновляем..." : "Обновить сейчас"}
             </button>

--- a/app/settings/wallets/page.tsx
+++ b/app/settings/wallets/page.tsx
@@ -259,12 +259,7 @@ const WalletSettings = () => {
             type="submit"
             disabled={!canManage || saving}
             className="inline-flex w-full items-center justify-center rounded-xl px-5 py-3 font-semibold whitespace-nowrap transition-colors sm:w-auto"
-            style={{
-              backgroundColor: !canManage || saving ? "var(--accent-disabled-strong)" : "var(--accent-teal)",
-              color: "var(--surface-primary)",
-              boxShadow: "0 10px 18px rgba(13, 148, 136, 0.25)",
-              cursor: !canManage || saving ? "not-allowed" : "pointer"
-            }}
+            data-variant="primary"
           >
             {saving ? "Сохраняем..." : "Добавить"}
           </button>
@@ -309,15 +304,7 @@ const WalletSettings = () => {
                       type="button"
                       onClick={() => handleDelete(wallet)}
                       disabled={isDeleting}
-                      style={{
-                        border: "none",
-                        backgroundColor: "var(--accent-danger-bright)",
-                        color: "var(--surface-primary)",
-                        borderRadius: "999px",
-                        padding: "0.35rem 0.85rem",
-                        fontSize: "0.85rem",
-                        cursor: isDeleting ? "not-allowed" : "pointer"
-                      }}
+                      data-variant="danger"
                     >
                       {isDeleting ? "Удаляем..." : "Удалить"}
                     </button>

--- a/components/AppNavigation.tsx
+++ b/components/AppNavigation.tsx
@@ -1,4 +1,6 @@
 import Link from "next/link";
+import type { LucideIcon } from "lucide-react";
+import { BarChart3, HandCoins, LayoutDashboard, ListChecks, Settings, Wallet } from "lucide-react";
 
 export type AppTabKey =
   | "home"
@@ -12,88 +14,16 @@ type TabConfig = {
   key: AppTabKey;
   href: string;
   label: string;
-  palette: {
-    bg: string;
-    text: string;
-    activeBg: string;
-    activeText: string;
-    shadow: string;
-  };
+  icon: LucideIcon;
 };
 
 const TABS: TabConfig[] = [
-  {
-    key: "home",
-    href: "/",
-    label: "Главная",
-    palette: {
-      bg: "var(--surface-blue)",
-      text: "var(--accent-blue)",
-      activeBg: "var(--accent-blue)",
-      activeText: "var(--surface-primary)",
-      shadow: "0 4px 12px rgba(59, 130, 246, 0.25)"
-    }
-  },
-  {
-    key: "debts",
-    href: "/debts",
-    label: "Долги",
-    palette: {
-      bg: "var(--surface-indigo)",
-      text: "var(--accent-indigo)",
-      activeBg: "var(--accent-indigo)",
-      activeText: "var(--surface-primary)",
-      shadow: "0 4px 12px rgba(99, 102, 241, 0.2)"
-    }
-  },
-  {
-    key: "wallets",
-    href: "/wallets",
-    label: "Кошельки",
-    palette: {
-      bg: "var(--surface-teal)",
-      text: "var(--accent-teal)",
-      activeBg: "var(--accent-teal)",
-      activeText: "var(--surface-primary)",
-      shadow: "0 4px 12px rgba(45, 212, 191, 0.25)"
-    }
-  },
-  {
-    key: "planning",
-    href: "/planning",
-    label: "Планирование",
-    palette: {
-      bg: "var(--surface-success)",
-      text: "var(--accent-success)",
-      activeBg: "var(--accent-success)",
-      activeText: "var(--surface-primary)",
-      shadow: "0 4px 12px rgba(34, 197, 94, 0.2)"
-    }
-  },
-  {
-    key: "reports",
-    href: "/reports",
-    label: "Отчёты",
-    palette: {
-      bg: "var(--surface-amber)",
-      text: "var(--accent-amber)",
-      activeBg: "var(--accent-amber)",
-      activeText: "var(--surface-primary)",
-      shadow: "0 4px 12px rgba(217, 119, 6, 0.2)"
-    }
-  },
-  {
-    key: "settings",
-    href: "/settings",
-    label: "Настройки",
-    palette: {
-      bg: "var(--surface-purple)",
-      text: "var(--accent-purple)",
-      activeBg: "var(--accent-purple)",
-      activeText: "var(--surface-primary)",
-      shadow: "0 4px 12px rgba(109, 40, 217, 0.2)"
-    }
-  }
+  { key: "home", href: "/", label: "Главная", icon: LayoutDashboard },
+  { key: "debts", href: "/debts", label: "Долги", icon: HandCoins },
+  { key: "wallets", href: "/wallets", label: "Кошельки", icon: Wallet },
+  { key: "planning", href: "/planning", label: "Планирование", icon: ListChecks },
+  { key: "reports", href: "/reports", label: "Отчёты", icon: BarChart3 },
+  { key: "settings", href: "/settings", label: "Настройки", icon: Settings }
 ];
 
 type AppNavigationProps = {
@@ -104,19 +34,17 @@ const AppNavigation = ({ activeTab }: AppNavigationProps) => (
   <nav className="flex flex-wrap items-center gap-3">
     {TABS.map((tab) => {
       const isActive = tab.key === activeTab;
+      const Icon = tab.icon;
 
       return (
         <Link
           key={tab.key}
           href={tab.href}
-          className="tab-pill inline-flex items-center justify-center rounded-full px-5 py-2.5 text-sm font-semibold transition-colors"
-          style={{
-            backgroundColor: isActive ? tab.palette.activeBg : tab.palette.bg,
-            color: isActive ? tab.palette.activeText : tab.palette.text,
-            boxShadow: tab.palette.shadow
-          }}
+          className="tab-pill"
+          data-active={isActive ? "true" : "false"}
         >
-          {tab.label}
+          <Icon aria-hidden className="tab-pill__icon" />
+          <span>{tab.label}</span>
         </Link>
       );
     })}

--- a/components/AuthGate.tsx
+++ b/components/AuthGate.tsx
@@ -36,9 +36,10 @@ const AuthGate = ({ children }: { children: ReactNode }) => {
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
-          background: "#f8fafc",
-          color: "#334155",
-          fontSize: "1.1rem"
+          backgroundColor: "var(--page-background)",
+          color: "var(--text-secondary)",
+          fontSize: "1.1rem",
+          transition: "background-color 0.3s ease, color 0.3s ease"
         }}
       >
         Загружаем данные...
@@ -51,37 +52,43 @@ const AuthGate = ({ children }: { children: ReactNode }) => {
       <div
         style={{
           minHeight: "100vh",
-          background: "linear-gradient(135deg, #c7d2fe, #fef9c3)",
+          backgroundColor: "var(--page-background)",
           display: "flex",
+          flexDirection: "column",
           alignItems: "center",
           justifyContent: "center",
-          padding: "2rem"
+          gap: "1.5rem",
+          padding: "2rem",
+          transition: "background-color 0.3s ease, color 0.3s ease"
         }}
       >
         <form
           onSubmit={handleSubmit}
           style={{
             width: "min(420px, 100%)",
-            backgroundColor: "#ffffff",
-            padding: "2.5rem",
-            borderRadius: "20px",
-            boxShadow: "0 24px 65px rgba(15, 23, 42, 0.15)",
+            backgroundColor: "var(--surface-subtle)",
+            padding: "1.5rem",
+            borderRadius: "var(--radius-2xl)",
+            boxShadow: "var(--shadow-card)",
+            border: "1px solid var(--border-strong)",
             display: "flex",
             flexDirection: "column",
-            gap: "1.5rem"
+            gap: "1.25rem",
+            color: "var(--text-primary)",
+            transition: "background-color 0.3s ease, border-color 0.3s ease"
           }}
         >
           <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
-            <h1 style={{ fontSize: "1.8rem", fontWeight: 700, color: "#1e293b" }}>
+            <h1 style={{ fontSize: "1.8rem", fontWeight: 700, color: "var(--text-strong)" }}>
               Войдите в систему
             </h1>
-            <p style={{ color: "#475569", lineHeight: 1.5 }}>
+            <p style={{ color: "var(--text-secondary)", lineHeight: 1.5 }}>
               Укажите логин и пароль бухгалтера или наблюдателя.
             </p>
           </div>
 
-          <label style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
-            <span style={{ fontWeight: 600, color: "#1f2937" }}>Логин</span>
+          <label>
+            <span style={{ fontWeight: 600, color: "var(--text-secondary-strong)" }}>Логин</span>
             <input
               type="text"
               value={loginValue}
@@ -90,17 +97,12 @@ const AuthGate = ({ children }: { children: ReactNode }) => {
                 clearError();
               }}
               placeholder="например, buh"
-              style={{
-                padding: "0.85rem 1rem",
-                borderRadius: "0.75rem",
-                border: "1px solid #cbd5f5",
-                fontSize: "1rem"
-              }}
+              style={{ fontSize: "1rem" }}
             />
           </label>
 
-          <label style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
-            <span style={{ fontWeight: 600, color: "#1f2937" }}>Пароль</span>
+          <label>
+            <span style={{ fontWeight: 600, color: "var(--text-secondary-strong)" }}>Пароль</span>
             <input
               type="password"
               value={password}
@@ -109,38 +111,24 @@ const AuthGate = ({ children }: { children: ReactNode }) => {
                 clearError();
               }}
               placeholder="Введите пароль"
-              style={{
-                padding: "0.85rem 1rem",
-                borderRadius: "0.75rem",
-                border: "1px solid #cbd5f5",
-                fontSize: "1rem"
-              }}
+              style={{ fontSize: "1rem" }}
             />
           </label>
 
           {authError ? (
-            <p style={{ color: "#b91c1c", fontWeight: 500 }}>{authError}</p>
+            <p style={{ color: "var(--accent-danger)", fontWeight: 500 }}>{authError}</p>
           ) : null}
 
           <button
             type="submit"
             disabled={authenticating}
-            style={{
-              padding: "0.95rem 1.2rem",
-              borderRadius: "0.85rem",
-              border: "none",
-              background: authenticating ? "#4f46e5" : "#4338ca",
-              color: "#ffffff",
-              fontWeight: 600,
-              fontSize: "1rem",
-              cursor: authenticating ? "not-allowed" : "pointer",
-              boxShadow: "0 16px 35px rgba(79, 70, 229, 0.35)"
-            }}
+            data-variant="primary"
+            className="w-full"
           >
             {authenticating ? "Входим..." : "Войти"}
           </button>
 
-          <div style={{ color: "#64748b", fontSize: "0.95rem" }}>
+          <div style={{ color: "var(--text-muted)", fontSize: "0.95rem" }}>
             <p>Доступные роли:</p>
             <ul style={{ marginTop: "0.5rem", paddingLeft: "1.2rem", display: "flex", flexDirection: "column", gap: "0.25rem" }}>
               <li>
@@ -166,14 +154,15 @@ const AuthGate = ({ children }: { children: ReactNode }) => {
     >
       <div
         style={{
-          background: "linear-gradient(90deg, #312e81, #4338ca)",
-          color: "#e0e7ff",
+          backgroundColor: "var(--surface-subtle)",
+          color: "var(--text-secondary)",
           padding: "0.75rem 1.5rem",
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
           gap: "1rem",
-          flexWrap: "wrap"
+          flexWrap: "wrap",
+          borderBottom: "1px solid var(--border-strong)"
         }}
       >
         <span style={{ fontWeight: 600 }}>
@@ -185,16 +174,7 @@ const AuthGate = ({ children }: { children: ReactNode }) => {
             void logout();
           }}
           disabled={authenticating}
-          style={{
-            padding: "0.55rem 1.15rem",
-            borderRadius: "999px",
-            border: "1px solid rgba(224, 231, 255, 0.6)",
-            background: "rgba(30, 64, 175, 0.35)",
-            color: "#f8fafc",
-            fontWeight: 600,
-            cursor: authenticating ? "not-allowed" : "pointer",
-            boxShadow: "0 6px 18px rgba(30, 64, 175, 0.35)"
-          }}
+          data-variant="outline"
         >
           {authenticating ? "Выходим..." : "Выйти"}
         </button>

--- a/components/PageContainer.tsx
+++ b/components/PageContainer.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 import AppNavigation, { type AppTabKey } from "@/components/AppNavigation";
+import ThemeToggle from "@/components/ThemeToggle";
 
 type PageContainerProps = {
   activeTab: AppTabKey;
@@ -8,9 +9,12 @@ type PageContainerProps = {
 };
 
 const PageContainer = ({ activeTab, children }: PageContainerProps) => (
-  <main className="page-shell bg-white text-black dark:bg-midnight dark:text-slate-100">
+  <main className="page-shell">
     <div className="flex w-full flex-col gap-10">
-      <AppNavigation activeTab={activeTab} />
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <AppNavigation activeTab={activeTab} />
+        <ThemeToggle />
+      </div>
       {children}
     </div>
   </main>

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useTheme } from "next-themes";
+import { MoonStar, Sun } from "lucide-react";
 
 const ThemeToggle = () => {
   const { resolvedTheme, setTheme, theme } = useTheme();
@@ -25,10 +26,13 @@ const ThemeToggle = () => {
       data-mode={isDark ? "dark" : "light"}
       onClick={() => setTheme(isDark ? "light" : "dark")}
       aria-label={isDark ? "Включить светлую тему" : "Включить тёмную тему"}
+      aria-pressed={isDark}
       title={isDark ? "Светлая тема" : "Тёмная тема"}
     >
       <span className="theme-toggle__track">
+        <Sun aria-hidden className="theme-toggle__icon" />
         <span className="theme-toggle__thumb" />
+        <MoonStar aria-hidden className="theme-toggle__icon" />
       </span>
       <span className="theme-toggle__label">{isDark ? "Тёмная тема" : "Светлая тема"}</span>
     </button>

--- a/lib/lucide-react.tsx
+++ b/lib/lucide-react.tsx
@@ -1,0 +1,133 @@
+import { forwardRef } from "react";
+import type { ForwardRefExoticComponent, ReactNode, RefAttributes, SVGProps } from "react";
+
+export type IconProps = SVGProps<SVGSVGElement>;
+export type LucideIcon = ForwardRefExoticComponent<IconProps & RefAttributes<SVGSVGElement>>;
+
+const createIcon = (children: ReactNode, displayName: string): LucideIcon => {
+  const Icon = forwardRef<SVGSVGElement, IconProps>(
+    ({ strokeWidth = 2, width = 24, height = 24, ...rest }, ref) => (
+      <svg
+        ref={ref}
+        xmlns="http://www.w3.org/2000/svg"
+        width={width}
+        height={height}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        {...rest}
+      >
+        {children}
+      </svg>
+    )
+  );
+
+  Icon.displayName = displayName;
+  return Icon;
+};
+
+export const Sun = createIcon(
+  <>
+    <circle cx="12" cy="12" r="4" />
+    <path d="M12 2v2" />
+    <path d="M12 20v2" />
+    <path d="M4.93 4.93 6.34 6.34" />
+    <path d="M17.66 17.66 19.07 19.07" />
+    <path d="M2 12h2" />
+    <path d="M20 12h2" />
+    <path d="M6.34 17.66 4.93 19.07" />
+    <path d="M17.66 6.34 19.07 4.93" />
+  </>,
+  "Sun"
+);
+
+export const MoonStar = createIcon(
+  <>
+    <path d="M21 12.5A8.5 8.5 0 0 1 11.5 3a7 7 0 1 0 9.5 9.5Z" />
+    <path d="M18.5 2.75 19.4 4.4l1.75.24-1.26 1.27.3 1.78-1.69-.9-1.69.9.3-1.78-1.26-1.27 1.75-.24Z" />
+  </>,
+  "MoonStar"
+);
+
+export const LayoutDashboard = createIcon(
+  <>
+    <rect x="3" y="3" width="7" height="7" rx="1" />
+    <rect x="14" y="3" width="7" height="4" rx="1" />
+    <rect x="14" y="9" width="7" height="12" rx="1" />
+    <rect x="3" y="14" width="7" height="7" rx="1" />
+  </>,
+  "LayoutDashboard"
+);
+
+export const Wallet = createIcon(
+  <>
+    <path d="M5 6h14a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2Z" />
+    <path d="M17 12h2" />
+    <path d="M5 6V4a2 2 0 0 1 2-2h9" />
+  </>,
+  "Wallet"
+);
+
+export const HandCoins = createIcon(
+  <>
+    <circle cx="9" cy="6" r="3" />
+    <path d="M21 10a2 2 0 1 1-4 0 2 2 0 0 1 4 0Z" />
+    <path d="M4 13.5s1.5-1.5 3.5-1.5h3.5a3 3 0 0 1 3 3v.5l3 .5c1.25.2 2 1.24 2 2.32V20h-7l-1.75 2H8a4 4 0 0 1-4-4Z" />
+  </>,
+  "HandCoins"
+);
+
+export const ListChecks = createIcon(
+  <>
+    <path d="M3 6h9" />
+    <path d="M3 12h9" />
+    <path d="M3 18h9" />
+    <path d="m15 5.5 2 2 4-4" />
+    <path d="m15 11.5 2 2 4-4" />
+  </>,
+  "ListChecks"
+);
+
+export const Target = createIcon(
+  <>
+    <circle cx="12" cy="12" r="9" />
+    <circle cx="12" cy="12" r="5" />
+    <circle cx="12" cy="12" r="2" />
+  </>,
+  "Target"
+);
+
+export const BarChart3 = createIcon(
+  <>
+    <path d="M3 3v18h18" />
+    <rect x="7" y="10" width="3" height="7" rx="1" />
+    <rect x="12" y="6" width="3" height="11" rx="1" />
+    <rect x="17" y="13" width="3" height="4" rx="1" />
+  </>,
+  "BarChart3"
+);
+
+export const Settings = createIcon(
+  <>
+    <circle cx="12" cy="12" r="3" />
+    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1Z" />
+  </>,
+  "Settings"
+);
+
+const icons = {
+  Sun,
+  MoonStar,
+  LayoutDashboard,
+  Wallet,
+  HandCoins,
+  ListChecks,
+  Target,
+  BarChart3,
+  Settings
+};
+
+export default icons;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,9 @@
       ],
       "next-themes": [
         "./lib/next-themes"
+      ],
+      "lucide-react": [
+        "./lib/lucide-react"
       ]
     },
     "plugins": [


### PR DESCRIPTION
## Summary
- set the app to load Inter by default and switch the theme provider to a dark-first palette supported by new light/dark design tokens
- restyle navigation with lucide icons, surface the theme toggle globally, and rebuild the toggle UI to react to the current mode
- align authentication, dashboards, and settings actions with the new card and button treatments, including reusable primary and danger variants

## Testing
- `npm run lint` *(fails: ESLint is not installed in this workspace)*
- `npm run build` *(fails: Next.js cannot download the Inter font because outbound network access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68d308182e888331888d4550652b4a34