### PR TITLE
Adjust navigation layout and theme toggle placement

### DIFF
--- a/components/AppNavigation.tsx
+++ b/components/AppNavigation.tsx
@@ -31,7 +31,7 @@ type AppNavigationProps = {
 };
 
 const AppNavigation = ({ activeTab }: AppNavigationProps) => (
-  <nav className="flex flex-wrap items-center gap-3">
+  <nav className="grid w-full grid-cols-6 gap-3">
     {TABS.map((tab) => {
       const isActive = tab.key === activeTab;
       const Icon = tab.icon;
@@ -40,7 +40,7 @@ const AppNavigation = ({ activeTab }: AppNavigationProps) => (
         <Link
           key={tab.key}
           href={tab.href}
-          className="tab-pill"
+          className="tab-pill w-full justify-center"
           data-active={isActive ? "true" : "false"}
         >
           <Icon aria-hidden className="tab-pill__icon" />

--- a/components/AppNavigation.tsx
+++ b/components/AppNavigation.tsx
@@ -31,7 +31,7 @@ type AppNavigationProps = {
 };
 
 const AppNavigation = ({ activeTab }: AppNavigationProps) => (
-  <nav className="grid w-full grid-cols-6 gap-3">
+  <nav className="flex w-full gap-3">
     {TABS.map((tab) => {
       const isActive = tab.key === activeTab;
       const Icon = tab.icon;
@@ -40,7 +40,7 @@ const AppNavigation = ({ activeTab }: AppNavigationProps) => (
         <Link
           key={tab.key}
           href={tab.href}
-          className="tab-pill w-full justify-center"
+          className="tab-pill flex-1 justify-center"
           data-active={isActive ? "true" : "false"}
         >
           <Icon aria-hidden className="tab-pill__icon" />

--- a/components/PageContainer.tsx
+++ b/components/PageContainer.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from "react";
 
 import AppNavigation, { type AppTabKey } from "@/components/AppNavigation";
-import ThemeToggle from "@/components/ThemeToggle";
 
 type PageContainerProps = {
   activeTab: AppTabKey;
@@ -11,10 +10,7 @@ type PageContainerProps = {
 const PageContainer = ({ activeTab, children }: PageContainerProps) => (
   <main className="page-shell">
     <div className="flex w-full flex-col gap-10">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <AppNavigation activeTab={activeTab} />
-        <ThemeToggle />
-      </div>
+      <AppNavigation activeTab={activeTab} />
       {children}
     </div>
   </main>


### PR DESCRIPTION
## Summary
- remove the global theme toggle from the shared page container so it only appears in the settings section
- arrange the main navigation tabs in a single-row grid with consistent spacing between buttons

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d37d164a688331bb437dddabe5a47c