### PR TITLE
Align auth status bar with main layout

### DIFF
--- a/components/AuthGate.tsx
+++ b/components/AuthGate.tsx
@@ -162,7 +162,9 @@ const AuthGate = ({ children }: { children: ReactNode }) => {
           justifyContent: "space-between",
           gap: "1rem",
           flexWrap: "wrap",
-          borderBottom: "1px solid var(--border-strong)"
+          borderBottom: "1px solid var(--border-strong)",
+          width: "min(100%, 980px)",
+          margin: "0 auto"
         }}
       >
         <span style={{ fontWeight: 600 }}>


### PR DESCRIPTION
## Summary
- limit the authenticated status banner to the same max-width as the main page shell so it no longer overflows the central block

## Testing
- `npm run lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d381a63ad083318558e2ce19bc6d4a