### PR TITLE
Improve mobile responsiveness across dashboards

### DIFF
--- a/app/debts/page.tsx
+++ b/app/debts/page.tsx
@@ -292,7 +292,10 @@ const DebtsContent = () => {
 
   return (
     <PageContainer activeTab="debts">
-      <header style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+      <header
+        className="flex flex-col gap-3 text-left sm:gap-4"
+        style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}
+      >
         <h1 style={{ fontSize: "1.85rem", fontWeight: 700 }}>
           Управление долгами
         </h1>
@@ -303,6 +306,7 @@ const DebtsContent = () => {
 
       <section
         data-layout="stat-grid"
+        className="grid gap-5 sm:gap-6"
         style={{
           display: "grid",
           gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
@@ -344,6 +348,7 @@ const DebtsContent = () => {
       <form
         onSubmit={handleSubmit}
         data-layout="responsive-form"
+        className="grid gap-4 sm:gap-5"
         style={{
           display: "grid",
           gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
@@ -481,7 +486,10 @@ const DebtsContent = () => {
 
       {error ? <p style={{ color: "var(--accent-danger)" }}>{error}</p> : null}
 
-      <section style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+      <section
+        className="flex flex-col gap-4 sm:gap-5"
+        style={{ display: "flex", flexDirection: "column", gap: "1rem" }}
+      >
         <h2 style={{ fontSize: "1.4rem", fontWeight: 600 }}>
           Текущие долги
         </h2>
@@ -490,10 +498,14 @@ const DebtsContent = () => {
             Пока нет записей о долгах.
           </p>
         ) : (
-          <ul style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+          <ul
+            className="flex flex-col gap-3"
+            style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}
+          >
             {debts.map((debt) => (
               <li
                 key={debt.id}
+                className="flex flex-col gap-3"
                 style={{
                   padding: "1rem 1.25rem",
                   borderRadius: "1rem",
@@ -506,6 +518,7 @@ const DebtsContent = () => {
               >
                 <div
                   data-card="split"
+                  className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between"
                   style={{
                     display: "flex",
                     justifyContent: "space-between",
@@ -513,7 +526,10 @@ const DebtsContent = () => {
                     gap: "0.75rem"
                   }}
                 >
-                  <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem" }}>
+                  <div
+                    className="flex min-w-full flex-col gap-2 sm:min-w-[220px]"
+                    style={{ display: "flex", flexDirection: "column", gap: "0.35rem" }}
+                  >
                     <strong>
                       {debt.type === "borrowed" ? "Взяли" : "Выдали"} — {debt.amount.toLocaleString("ru-RU", {
                         minimumFractionDigits: 2,
@@ -534,6 +550,7 @@ const DebtsContent = () => {
                       onClick={() => handleDelete(debt.id)}
                       disabled={deletingId === debt.id}
                       data-variant="danger"
+                      className="w-full sm:w-auto"
                     >
                       {deletingId === debt.id ? "Удаляем..." : "Удалить"}
                     </button>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -426,6 +426,7 @@ const Dashboard = () => {
   return (
     <PageContainer activeTab="home">
       <header
+        className="flex flex-col gap-4 text-left sm:gap-5"
           style={{
             display: "flex",
             flexDirection: "column",
@@ -437,8 +438,12 @@ const Dashboard = () => {
           </h1>
         </header>
 
-        <section style={{ display: "flex", flexDirection: "column", gap: "1.75rem" }}>
+        <section
+          className="flex flex-col gap-6 sm:gap-7"
+          style={{ display: "flex", flexDirection: "column", gap: "1.75rem" }}
+        >
           <div
+            className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
             style={{
               display: "flex",
               justifyContent: "space-between",
@@ -465,6 +470,7 @@ const Dashboard = () => {
           ) : null}
 
           <form
+            className="grid gap-4 sm:gap-5"
             onSubmit={handleSubmit}
             data-layout="responsive-form"
             style={{
@@ -602,7 +608,10 @@ const Dashboard = () => {
         </section>
 
 
-        <section style={{ display: "flex", flexDirection: "column", gap: "1.25rem" }}>
+        <section
+          className="flex flex-col gap-5 sm:gap-6"
+          style={{ display: "flex", flexDirection: "column", gap: "1.25rem" }}
+        >
           <h2 style={{ fontSize: "1.5rem", fontWeight: 600 }}>
             Последние операции
           </h2>
@@ -611,11 +620,15 @@ const Dashboard = () => {
               Пока нет данных — добавьте первую операцию.
             </p>
           ) : (
-            <ul style={{ display: "flex", flexDirection: "column", gap: "0.85rem" }}>
+            <ul
+              className="flex flex-col gap-3"
+              style={{ display: "flex", flexDirection: "column", gap: "0.85rem" }}
+            >
               {operations.map((operation) => (
                 <li
                   key={operation.id}
                   data-card="split"
+                  className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between"
                   style={{
                     padding: "1rem",
                     borderRadius: "var(--radius-2xl)",
@@ -630,6 +643,7 @@ const Dashboard = () => {
                   }}
                 >
                   <div
+                    className="flex min-w-full flex-col gap-2 sm:min-w-[220px]"
                     style={{
                       display: "flex",
                       flexDirection: "column",
@@ -652,6 +666,7 @@ const Dashboard = () => {
                   </div>
                   <div
                     data-card-section="meta"
+                    className="flex w-full flex-col items-start gap-3 sm:w-auto sm:items-end"
                     style={{
                       display: "flex",
                       flexDirection: "column",

--- a/app/planning/page.tsx
+++ b/app/planning/page.tsx
@@ -247,6 +247,7 @@ const PlanningContent = () => {
   return (
     <PageContainer activeTab="planning">
       <header
+        className="flex flex-col gap-4 text-left sm:gap-5"
         style={{
           display: "flex",
           flexDirection: "column",
@@ -263,6 +264,7 @@ const PlanningContent = () => {
 
         <section
           data-layout="stat-grid"
+          className="grid gap-5 sm:gap-6"
           style={{
             display: "grid",
             gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
@@ -304,6 +306,7 @@ const PlanningContent = () => {
         <form
           onSubmit={handleSubmit}
           data-layout="responsive-form"
+          className="grid gap-4 sm:gap-5"
           style={{
             display: "grid",
             gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
@@ -369,7 +372,10 @@ const PlanningContent = () => {
         {error ? <p style={{ color: "var(--accent-danger)" }}>{error}</p> : null}
         {message ? <p style={{ color: "var(--accent-success)" }}>{message}</p> : null}
 
-        <section style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}>
+        <section
+          className="flex flex-col gap-6 sm:gap-7"
+          style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}
+        >
           <h2 style={{ fontSize: "1.5rem", fontWeight: 600 }}>
             Активные цели
           </h2>
@@ -378,7 +384,10 @@ const PlanningContent = () => {
               Пока нет активных целей.
             </p>
           ) : (
-            <ul style={{ display: "flex", flexDirection: "column", gap: "1.1rem" }}>
+            <ul
+              className="flex flex-col gap-4"
+              style={{ display: "flex", flexDirection: "column", gap: "1.1rem" }}
+            >
               {goals.map((goal) => {
                 const target = convertFromBase(goal.targetAmount, goal.currency, activeSettings);
                 const current = convertFromBase(goal.currentAmount, goal.currency, activeSettings);
@@ -387,6 +396,7 @@ const PlanningContent = () => {
                 return (
                   <li
                     key={goal.id}
+                    className="flex flex-col gap-4"
                     style={{
                       border: "1px solid var(--border-strong)",
                       borderRadius: "var(--radius-2xl)",
@@ -400,6 +410,7 @@ const PlanningContent = () => {
                   >
                     <div
                       data-card="split"
+                      className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between"
                       style={{
                         display: "flex",
                         justifyContent: "space-between",
@@ -408,7 +419,10 @@ const PlanningContent = () => {
                         flexWrap: "wrap"
                       }}
                     >
-                      <div style={{ display: "flex", flexDirection: "column", gap: "0.4rem" }}>
+                      <div
+                        className="flex min-w-full flex-col gap-2 sm:min-w-[220px]"
+                        style={{ display: "flex", flexDirection: "column", gap: "0.4rem" }}
+                      >
                         <strong style={{ fontSize: "1.1rem" }}>
                           {goal.title}
                         </strong>
@@ -422,6 +436,7 @@ const PlanningContent = () => {
                           onClick={() => handleDelete(goal.id)}
                           disabled={deletingId === goal.id}
                           data-variant="danger"
+                          className="w-full sm:w-auto"
                         >
                           {deletingId === goal.id ? "Удаляем..." : "Удалить"}
                         </button>

--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -491,6 +491,7 @@ const ReportsContent = () => {
   return (
     <PageContainer activeTab="reports">
       <header
+        className="flex flex-col gap-4 text-left sm:gap-5"
         style={{
           display: "flex",
           flexDirection: "column",
@@ -510,6 +511,7 @@ const ReportsContent = () => {
 
         <section
           data-layout="stat-grid"
+          className="grid gap-5 sm:gap-6"
           style={{
             display: "grid",
             gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
@@ -517,6 +519,7 @@ const ReportsContent = () => {
           }}
         >
           <article
+            className="flex flex-col gap-3"
             style={{
               backgroundColor: "var(--surface-violet)",
               borderRadius: "1rem",
@@ -532,6 +535,7 @@ const ReportsContent = () => {
             </strong>
           </article>
           <article
+            className="flex flex-col gap-3"
             style={{
               backgroundColor: "var(--surface-danger)",
               borderRadius: "1rem",
@@ -547,6 +551,7 @@ const ReportsContent = () => {
             </strong>
           </article>
           <article
+            className="flex flex-col gap-3"
             style={{
               backgroundColor: "var(--surface-success)",
               borderRadius: "1rem",
@@ -565,6 +570,7 @@ const ReportsContent = () => {
 
         <section
           data-layout="responsive-form"
+          className="grid gap-4 sm:gap-5"
           style={{
             display: "grid",
             gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
@@ -572,7 +578,10 @@ const ReportsContent = () => {
             alignItems: "end"
           }}
         >
-          <label style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+          <label
+            className="flex flex-col gap-2"
+            style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}
+          >
             <span>Период</span>
             <select
               value={selectedPeriod}
@@ -593,7 +602,10 @@ const ReportsContent = () => {
 
           {selectedPeriod === "custom" ? (
             <>
-              <label style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+              <label
+                className="flex flex-col gap-2"
+                style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}
+              >
                 <span>Начало</span>
                 <input
                   type="date"
@@ -606,7 +618,10 @@ const ReportsContent = () => {
                   }}
                 />
               </label>
-              <label style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+              <label
+                className="flex flex-col gap-2"
+                style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}
+              >
                 <span>Конец</span>
                 <input
                   type="date"
@@ -626,19 +641,26 @@ const ReportsContent = () => {
             type="button"
             onClick={() => void loadOperations()}
             data-variant="primary"
+            className="w-full sm:w-auto"
           >
             Обновить данные
           </button>
         </section>
 
-        <section style={{ display: "flex", flexDirection: "column", gap: "1.25rem" }}>
+        <section
+          className="flex flex-col gap-5 overflow-x-auto sm:gap-6"
+          style={{ display: "flex", flexDirection: "column", gap: "1.25rem" }}
+        >
           <h2 style={{ fontSize: "1.4rem", fontWeight: 600 }}>
             Категории
           </h2>
           {categoryRows.length === 0 ? (
             <p style={{ color: "var(--text-muted)" }}>Нет операций за выбранный период.</p>
           ) : (
-            <table style={{ width: "100%", borderCollapse: "collapse" }}>
+            <table
+              className="w-full min-w-[640px] sm:min-w-0"
+              style={{ width: "100%", borderCollapse: "collapse" }}
+            >
               <thead>
                 <tr style={{ backgroundColor: "var(--surface-purple)" }}>
                   <th style={{ textAlign: "left", padding: "0.75rem", color: "var(--text-strong)" }}>
@@ -680,6 +702,7 @@ const ReportsContent = () => {
           onClick={handleExport}
           disabled={isExporting}
           data-variant="primary"
+          className="w-full sm:w-auto"
           style={{ alignSelf: "flex-start" }}
         >
           {isExporting ? "Готовим файл..." : "Экспортировать PDF"}

--- a/app/settings/categories/page.tsx
+++ b/app/settings/categories/page.tsx
@@ -205,6 +205,7 @@ const CategoriesSettings = () => {
       }}
     >
         <nav
+          className="flex flex-wrap items-center justify-center gap-3 sm:justify-start"
           style={{
             display: "flex",
             alignItems: "center",
@@ -242,6 +243,7 @@ const CategoriesSettings = () => {
         </nav>
 
         <header
+          className="flex flex-col gap-4 text-left sm:gap-5"
           style={{
             display: "flex",
             flexDirection: "column",
@@ -261,6 +263,7 @@ const CategoriesSettings = () => {
 
         <section
           data-layout="stat-grid"
+          className="grid gap-5 sm:gap-6"
           style={{
             display: "grid",
             gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
@@ -288,6 +291,7 @@ const CategoriesSettings = () => {
             }
           ]).map((config) => (
             <article
+              className="flex flex-col gap-4"
               key={config.type}
               style={{
                 backgroundColor: config.background,
@@ -299,7 +303,10 @@ const CategoriesSettings = () => {
                 gap: "1rem"
               }}
             >
-              <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+              <div
+                className="flex flex-col gap-3"
+                style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}
+              >
                 <h2 style={{ color: config.color, fontWeight: 600 }}>{config.title}</h2>
                 <form
                   onSubmit={(event) => handleAdd(event, config.type)}
@@ -332,6 +339,7 @@ const CategoriesSettings = () => {
                 <p style={{ color: "var(--text-muted)" }}>Категории ещё не добавлены.</p>
               ) : (
                 <ul
+                  className="flex flex-col gap-3"
                   style={{
                     margin: 0,
                     padding: 0,
@@ -349,6 +357,7 @@ const CategoriesSettings = () => {
                       <li
                         key={item}
                         data-card="split"
+                        className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
                         style={{
                           display: "flex",
                           alignItems: "center",
@@ -366,6 +375,7 @@ const CategoriesSettings = () => {
                             onClick={() => handleDelete(config.type, item)}
                             disabled={isDeleting}
                             data-variant="danger"
+                            className="w-full sm:w-auto"
                           >
                             {isDeleting ? "Удаляем..." : "Удалить"}
                           </button>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -245,6 +245,7 @@ const SettingsContent = () => {
   return (
     <PageContainer activeTab="settings">
       <header
+        className="flex flex-col gap-4 text-left sm:gap-5"
         style={{
           display: "flex",
           flexDirection: "column",
@@ -260,6 +261,7 @@ const SettingsContent = () => {
       </header>
 
         <div
+          className="flex justify-center sm:justify-end"
           style={{
             display: "flex",
             justifyContent: "flex-end"
@@ -271,6 +273,7 @@ const SettingsContent = () => {
         {loading ? <p style={{ color: "var(--text-muted)" }}>Загружаем настройки...</p> : null}
 
         <div
+          className="flex flex-col gap-6"
           style={{
             display: "flex",
             flexDirection: "column",
@@ -279,6 +282,7 @@ const SettingsContent = () => {
         >
           <section
             data-layout="stat-grid"
+            className="grid gap-5 sm:gap-6"
             style={{
               display: "grid",
               gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
@@ -286,6 +290,7 @@ const SettingsContent = () => {
             }}
           >
             <article
+              className="flex flex-col gap-3"
               style={{
                 backgroundColor: "var(--surface-indigo)",
                 borderRadius: "1rem",
@@ -302,6 +307,7 @@ const SettingsContent = () => {
               </p>
             </article>
             <article
+              className="flex flex-col gap-3"
               style={{
                 backgroundColor: "var(--surface-success)",
                 borderRadius: "1rem",
@@ -323,6 +329,7 @@ const SettingsContent = () => {
 
           <div
             data-layout="toolbar"
+            className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-end"
             style={{
               display: "flex",
               justifyContent: "flex-end",
@@ -339,6 +346,7 @@ const SettingsContent = () => {
               onClick={handleForceUpdate}
               disabled={!canManage || ratesLoading}
               data-variant="primary"
+              className="w-full sm:w-auto"
             >
               {ratesLoading ? "Обновляем..." : "Обновить сейчас"}
             </button>
@@ -346,6 +354,7 @@ const SettingsContent = () => {
 
           <section
             data-layout="stat-grid"
+            className="grid gap-4 sm:gap-5"
             style={{
               display: "grid",
               gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
@@ -361,6 +370,7 @@ const SettingsContent = () => {
               return (
                 <label
                   key={code}
+                  className="flex flex-col gap-2"
                   style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}
                 >
                   <span style={{ fontWeight: 600, color: "var(--text-strong)" }}>
@@ -388,6 +398,7 @@ const SettingsContent = () => {
 
         <section
           data-layout="stat-grid"
+          className="grid gap-4 sm:gap-5"
           style={{
             display: "grid",
             gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
@@ -396,6 +407,7 @@ const SettingsContent = () => {
         >
           <Link
             href="/settings/categories"
+            className="flex flex-col gap-3"
             style={{
               display: "flex",
               flexDirection: "column",
@@ -417,6 +429,7 @@ const SettingsContent = () => {
 
           <Link
             href="/settings/wallets"
+            className="flex flex-col gap-3"
             style={{
               display: "flex",
               flexDirection: "column",

--- a/app/settings/wallets/page.tsx
+++ b/app/settings/wallets/page.tsx
@@ -184,6 +184,7 @@ const WalletSettings = () => {
       }}
     >
         <nav
+          className="flex flex-wrap items-center justify-center gap-3 sm:justify-start"
           style={{
             display: "flex",
             alignItems: "center",
@@ -221,6 +222,7 @@ const WalletSettings = () => {
         </nav>
 
         <header
+          className="flex flex-col gap-4 text-left sm:gap-5"
           style={{
             display: "flex",
             flexDirection: "column",
@@ -271,6 +273,7 @@ const WalletSettings = () => {
           </p>
         ) : (
           <ul
+            className="flex flex-col gap-3"
             style={{
               margin: 0,
               padding: 0,
@@ -287,6 +290,7 @@ const WalletSettings = () => {
                 <li
                   key={wallet}
                   data-card="split"
+                  className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
                   style={{
                     display: "flex",
                     alignItems: "center",
@@ -305,6 +309,7 @@ const WalletSettings = () => {
                       onClick={() => handleDelete(wallet)}
                       disabled={isDeleting}
                       data-variant="danger"
+                      className="w-full sm:w-auto"
                     >
                       {isDeleting ? "Удаляем..." : "Удалить"}
                     </button>

--- a/app/wallets/page.tsx
+++ b/app/wallets/page.tsx
@@ -207,6 +207,7 @@ const WalletsContent = () => {
   return (
     <PageContainer activeTab="wallets">
       <header
+        className="flex flex-col gap-4 text-left sm:gap-5"
         style={{
           display: "flex",
           flexDirection: "column",
@@ -224,8 +225,12 @@ const WalletsContent = () => {
         {loading ? <p style={{ color: "var(--text-muted)" }}>Загружаем данные...</p> : null}
         {error ? <p style={{ color: "var(--accent-danger)" }}>{error}</p> : null}
 
-        <section style={{ display: "flex", flexDirection: "column", gap: "1.25rem" }}>
+        <section
+          className="flex flex-col gap-5 sm:gap-6"
+          style={{ display: "flex", flexDirection: "column", gap: "1.25rem" }}
+        >
           <div
+            className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
             style={{
               display: "flex",
               justifyContent: "space-between",
@@ -259,6 +264,7 @@ const WalletsContent = () => {
 
         <section
           data-layout="stat-grid"
+          className="grid gap-5 sm:gap-6"
           style={{
             display: "grid",
             gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
@@ -273,6 +279,7 @@ const WalletsContent = () => {
             summaries.map((summary) => (
               <article
                 key={summary.wallet}
+                className="flex flex-col gap-3"
                 style={{
                   backgroundColor: summary.active ? "var(--surface-subtle)" : "var(--surface-muted)",
                   borderRadius: "1rem",
@@ -286,7 +293,10 @@ const WalletsContent = () => {
                   gap: "0.6rem"
                 }}
               >
-                <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem" }}>
+                <div
+                  className="flex flex-col gap-2 text-left"
+                  style={{ display: "flex", flexDirection: "column", gap: "0.35rem" }}
+                >
                   <h2 style={{ fontWeight: 600 }}>{summary.wallet}</h2>
                   {!summary.active ? (
                     <span style={{ color: "var(--accent-amber)", fontSize: "0.85rem" }}>

--- a/components/AppNavigation.tsx
+++ b/components/AppNavigation.tsx
@@ -31,7 +31,7 @@ type AppNavigationProps = {
 };
 
 const AppNavigation = ({ activeTab }: AppNavigationProps) => (
-  <nav className="flex w-full gap-3">
+  <nav className="flex w-full flex-wrap gap-2 sm:flex-nowrap sm:gap-3">
     {TABS.map((tab) => {
       const isActive = tab.key === activeTab;
       const Icon = tab.icon;
@@ -40,7 +40,7 @@ const AppNavigation = ({ activeTab }: AppNavigationProps) => (
         <Link
           key={tab.key}
           href={tab.href}
-          className="tab-pill flex-1 justify-center"
+          className="tab-pill flex-1 justify-center sm:flex-none sm:min-w-0"
           data-active={isActive ? "true" : "false"}
         >
           <Icon aria-hidden className="tab-pill__icon" />

--- a/components/PageContainer.tsx
+++ b/components/PageContainer.tsx
@@ -9,7 +9,7 @@ type PageContainerProps = {
 
 const PageContainer = ({ activeTab, children }: PageContainerProps) => (
   <main className="page-shell">
-    <div className="flex w-full flex-col gap-10">
+    <div className="flex w-full flex-col gap-8 sm:gap-10">
       <AppNavigation activeTab={activeTab} />
       {children}
     </div>


### PR DESCRIPTION
## Summary
- allow the navigation bar to wrap and adjust container spacing so tabs fit on small screens
- add responsive flex and grid classes across dashboard, wallets, debts, planning, and settings layouts to stack content on mobile
- make the reports filters and table mobile-friendly with wrapping controls and horizontal scrolling

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d444db4db083319d26689079c0a30e