### PR TITLE
Improve mobile layout responsiveness

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -419,15 +419,67 @@ ol {
 
 @media (max-width: 768px) {
   body {
-    padding: 1.75rem 1rem 3rem;
+    padding: 1.75rem 1rem 2.75rem;
     align-items: stretch;
   }
 
   .page-shell {
     width: 100%;
     border-radius: 1rem;
-    padding: 2rem 1.5rem;
+    padding: 1.85rem 1.4rem;
+    gap: 1.85rem;
     box-shadow: var(--shadow-soft);
+  }
+
+  .page-shell section {
+    padding: 1.35rem !important;
+  }
+
+  .app-navigation {
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .app-navigation .tab-pill {
+    flex: 1 1 calc(50% - 0.75rem);
+    min-width: calc(50% - 0.75rem);
+    justify-content: center;
+    padding: 0.65rem 1rem;
+  }
+
+  .app-navigation .tab-pill__icon {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  .app-navigation .tab-pill span {
+    font-size: 0.9rem;
+  }
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 1.25rem 0.75rem 2.25rem;
+  }
+
+  .page-shell {
+    padding: 1.5rem 1rem;
+    gap: 1.5rem;
+  }
+
+  .page-shell section {
+    padding: 1.15rem !important;
+  }
+
+  .app-navigation .tab-pill {
+    flex-basis: 100%;
+    min-width: 100%;
+    padding: 0.6rem 0.85rem;
+    gap: 0.4rem;
+  }
+
+  .app-navigation .tab-pill span {
+    font-size: 0.85rem;
   }
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -425,14 +425,14 @@ const Dashboard = () => {
   };
   return (
     <PageContainer activeTab="home">
-      <header
+        <header
           style={{
             display: "flex",
             flexDirection: "column",
             gap: "0.75rem"
           }}
         >
-          <h1 style={{ fontSize: "2.25rem", fontWeight: 700 }}>
+          <h1 style={{ fontSize: "clamp(1.75rem, 5vw, 2.25rem)", fontWeight: 700 }}>
             Бухгалтерия ISCKON Batumi
           </h1>
         </header>
@@ -447,12 +447,12 @@ const Dashboard = () => {
               gap: "1rem"
             }}
           >
-            <h2 style={{ fontSize: "1.5rem", fontWeight: 600 }}>
+            <h2 style={{ fontSize: "clamp(1.25rem, 4.5vw, 1.5rem)", fontWeight: 600 }}>
               Текущий баланс
             </h2>
             <strong
               style={{
-                fontSize: "1.75rem",
+                fontSize: "clamp(1.45rem, 4.5vw, 1.75rem)",
                 color: balance >= 0 ? "var(--accent-success)" : "var(--accent-danger)"
               }}
             >
@@ -603,7 +603,7 @@ const Dashboard = () => {
 
 
         <section style={{ display: "flex", flexDirection: "column", gap: "1.25rem" }}>
-          <h2 style={{ fontSize: "1.5rem", fontWeight: 600 }}>
+          <h2 style={{ fontSize: "clamp(1.25rem, 4.5vw, 1.5rem)", fontWeight: 600 }}>
             Последние операции
           </h2>
           {operations.length === 0 ? (
@@ -617,7 +617,7 @@ const Dashboard = () => {
                   key={operation.id}
                   data-card="split"
                   style={{
-                    padding: "1rem",
+                    padding: "clamp(0.85rem, 2.5vw, 1rem)",
                     borderRadius: "var(--radius-2xl)",
                     border: "1px solid var(--border-strong)",
                     display: "flex",
@@ -664,7 +664,7 @@ const Dashboard = () => {
                       style={{
                         fontWeight: 700,
                         color: operation.type === "income" ? "var(--accent-success)" : "var(--accent-danger)",
-                        fontSize: "1.1rem"
+                        fontSize: "clamp(1rem, 3.5vw, 1.1rem)"
                       }}
                     >
                       {`${operation.type === "income" ? "+" : "-"}${operation.amount.toLocaleString(

--- a/components/AppNavigation.tsx
+++ b/components/AppNavigation.tsx
@@ -31,7 +31,7 @@ type AppNavigationProps = {
 };
 
 const AppNavigation = ({ activeTab }: AppNavigationProps) => (
-  <nav className="flex w-full gap-3">
+  <nav className="app-navigation flex w-full gap-3">
     {TABS.map((tab) => {
       const isActive = tab.key === activeTab;
       const Icon = tab.icon;


### PR DESCRIPTION
## Summary
- reduce global padding and adjust navigation layout to better support mobile breakpoints
- tweak dashboard typography and card spacing with clamp-based sizes for smaller screens

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d4487a19a48331b574fe234eff714a