### PR TITLE
Add admin user management

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -4,44 +4,54 @@ import prisma from "@/lib/prisma";
 import type { SessionUser } from "@/lib/types";
 
 type LoginPayload = {
-  login?: string;
+  username?: string;
   password?: string;
 };
 
-const normalizeLogin = (value: string) => value.trim().toLowerCase();
+const normalizeUsername = (value: string) => value.trim().toLowerCase();
 
 export const POST = async (request: NextRequest) => {
   const payload = (await request.json().catch(() => null)) as LoginPayload | null;
 
-  if (!payload || typeof payload.login !== "string" || typeof payload.password !== "string") {
+  if (!payload || typeof payload.username !== "string" || typeof payload.password !== "string") {
     return NextResponse.json({ error: "Укажите логин и пароль" }, { status: 400 });
   }
 
-  const login = normalizeLogin(payload.login);
+  const username = normalizeUsername(payload.username);
   const password = payload.password.trim();
 
-  if (!login || !password) {
+  if (!username || !password) {
     return NextResponse.json({ error: "Укажите логин и пароль" }, { status: 400 });
   }
 
   const user = await prisma.user.findFirst({
     where: {
-      login: {
-        equals: payload.login.trim(),
+      username: {
+        equals: payload.username.trim(),
         mode: "insensitive"
       }
     }
   });
 
-  if (!user || user.password !== password) {
+  if (!user) {
+    return NextResponse.json({ error: "Неверный логин или пароль" }, { status: 401 });
+  }
+
+  await prisma.$executeRaw`CREATE EXTENSION IF NOT EXISTS pgcrypto;`;
+
+  const [verification] = await prisma.$queryRaw<{ matches: boolean }[]>`
+    SELECT crypt(${password}, ${user.password_hash}) = ${user.password_hash} AS matches
+  `;
+
+  if (!verification?.matches) {
     return NextResponse.json({ error: "Неверный логин или пароль" }, { status: 401 });
   }
 
   const { token, expiresAt } = createSession(user.id);
   const sessionUser: SessionUser = {
     id: user.id,
-    login: user.login,
-    role: user.role === "accountant" ? "accountant" : "user"
+    username: user.username,
+    role: user.role === "admin" ? "admin" : "user"
   };
   const response = NextResponse.json({ user: sessionUser });
 

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,0 +1,76 @@
+import { randomInt, randomUUID } from "node:crypto";
+import { NextResponse, type NextRequest } from "next/server";
+import { ensureAccountant } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+
+const USERNAME_PREFIX = "user";
+const USERNAME_MIN = 1000;
+const USERNAME_MAX = 10_000;
+const PASSWORD_LENGTH = 10;
+const PASSWORD_CHARSET =
+  "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789!@#$%^&*";
+
+const generatePassword = () => {
+  let result = "";
+
+  for (let index = 0; index < PASSWORD_LENGTH; index += 1) {
+    const position = randomInt(0, PASSWORD_CHARSET.length);
+    result += PASSWORD_CHARSET[position];
+  }
+
+  return result;
+};
+
+const generateCandidateUsername = () =>
+  `${USERNAME_PREFIX}${randomInt(USERNAME_MIN, USERNAME_MAX)}`;
+
+const generateUniqueUsername = async (): Promise<string> => {
+  for (let attempt = 0; attempt < 25; attempt += 1) {
+    const candidate = generateCandidateUsername();
+    const existing = await prisma.user.findUnique({ where: { username: candidate } });
+
+    if (!existing) {
+      return candidate;
+    }
+  }
+
+  throw new Error("Не удалось сгенерировать уникальный логин");
+};
+
+export const POST = async (request: NextRequest) => {
+  const auth = await ensureAccountant(request);
+
+  if (auth.response) {
+    return auth.response;
+  }
+
+  try {
+    const username = await generateUniqueUsername();
+    const password = generatePassword();
+
+    await prisma.$executeRaw`CREATE EXTENSION IF NOT EXISTS pgcrypto;`;
+
+    const [hashRow] = await prisma.$queryRaw<{ hash: string }[]>`
+      SELECT crypt(${password}, gen_salt('bf', 12)) AS hash
+    `;
+
+    if (!hashRow?.hash) {
+      throw new Error("Не удалось создать пользователя");
+    }
+
+    await prisma.user.create({
+      data: {
+        id: randomUUID(),
+        username,
+        role: "user",
+        passwordHash: hashRow.hash
+      }
+    });
+
+    return NextResponse.json({ username, password });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Не удалось создать пользователя";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+};

--- a/app/debts/page.tsx
+++ b/app/debts/page.tsx
@@ -22,7 +22,7 @@ const DebtsContent = () => {
     return null;
   }
 
-  const canManage = user.role === "accountant";
+  const canManage = user.role === "admin";
 
   const [debts, setDebts] = useState<Debt[]>([]);
   const [type, setType] = useState<Debt["type"]>("borrowed");

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -35,7 +35,7 @@ const Dashboard = () => {
     return null;
   }
 
-  const canManage = user.role === "accountant";
+  const canManage = user.role === "admin";
 
   const [operations, setOperations] = useState<Operation[]>([]);
   const [goals, setGoals] = useState<Goal[]>([]);

--- a/app/planning/page.tsx
+++ b/app/planning/page.tsx
@@ -19,7 +19,7 @@ const PlanningContent = () => {
     return null;
   }
 
-  const canManage = user.role === "accountant";
+  const canManage = user.role === "admin";
 
   const [goals, setGoals] = useState<Goal[]>([]);
   const [title, setTitle] = useState<string>("");

--- a/app/settings/categories/page.tsx
+++ b/app/settings/categories/page.tsx
@@ -17,7 +17,7 @@ const CategoriesSettings = () => {
     return null;
   }
 
-  const canManage = user.role === "accountant";
+  const canManage = user.role === "admin";
   const [incomeCategories, setIncomeCategories] = useState<string[]>([]);
   const [expenseCategories, setExpenseCategories] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -129,7 +129,7 @@ const SettingsContent = () => {
     return null;
   }
 
-  const canManage = user.role === "accountant";
+  const canManage = user.role === "admin";
 
   const [settings, setSettings] = useState<Settings>(DEFAULT_SETTINGS);
   const [rates, setRates] = useState<Partial<Record<Currency, RateInfo>>>(
@@ -140,6 +140,11 @@ const SettingsContent = () => {
   const [settingsError, setSettingsError] = useState<string | null>(null);
   const [ratesError, setRatesError] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
+  const [creatingUser, setCreatingUser] = useState(false);
+  const [newUserCredentials, setNewUserCredentials] = useState<
+    { username: string; password: string } | null
+  >(null);
+  const [userError, setUserError] = useState<string | null>(null);
 
   useEffect(() => {
     const loadSettings = async () => {
@@ -242,8 +247,94 @@ const SettingsContent = () => {
     void loadRates(true);
   };
 
+  const handleCreateUser = async () => {
+    if (!canManage || creatingUser) {
+      return;
+    }
+
+    setCreatingUser(true);
+    setUserError(null);
+
+    try {
+      const response = await fetch("/api/users", { method: "POST" });
+
+      if (response.status === 401) {
+        setUserError("Сессия истекла, войдите заново.");
+        await refresh();
+        return;
+      }
+
+      if (response.status === 403) {
+        setUserError("Недостаточно прав для создания пользователя.");
+        return;
+      }
+
+      const data = (await response.json().catch(() => null)) as
+        | { username?: string; password?: string; error?: string }
+        | null;
+
+      if (!response.ok || !data?.username || !data?.password) {
+        throw new Error(data?.error ?? "Не удалось создать пользователя");
+      }
+
+      setNewUserCredentials({ username: data.username, password: data.password });
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Не удалось создать пользователя";
+      setUserError(message);
+    } finally {
+      setCreatingUser(false);
+    }
+  };
+
   return (
     <PageContainer activeTab="settings">
+      {newUserCredentials ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4">
+          <div className="w-full max-w-sm rounded-lg bg-white p-3 shadow dark:bg-slate-900">
+            <div className="flex items-start justify-between gap-3">
+              <div className="space-y-2">
+                <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+                  Новый пользователь создан
+                </h2>
+                <p className="text-sm text-slate-600 dark:text-slate-300">
+                  Скопируйте эти данные — после закрытия окна они будут недоступны.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setNewUserCredentials(null)}
+                className="rounded-full p-2 text-slate-500 transition hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-800"
+                aria-label="Закрыть"
+              >
+                ×
+              </button>
+            </div>
+            <dl className="mt-4 space-y-3 text-sm">
+              <div className="rounded-lg bg-slate-100 p-3 text-slate-900 dark:bg-slate-800 dark:text-slate-100">
+                <dt className="font-semibold">Имя пользователя</dt>
+                <dd className="mt-1 break-all font-mono">
+                  {newUserCredentials.username}
+                </dd>
+              </div>
+              <div className="rounded-lg bg-slate-100 p-3 text-slate-900 dark:bg-slate-800 dark:text-slate-100">
+                <dt className="font-semibold">Пароль</dt>
+                <dd className="mt-1 break-all font-mono">
+                  {newUserCredentials.password}
+                </dd>
+              </div>
+            </dl>
+            <button
+              type="button"
+              onClick={() => setNewUserCredentials(null)}
+              className="mt-4 w-full rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-indigo-700"
+            >
+              Понятно
+            </button>
+          </div>
+        </div>
+      ) : null}
+
       <header
         style={{
           display: "flex",
@@ -267,6 +358,25 @@ const SettingsContent = () => {
         >
           <ThemeToggle />
         </div>
+
+        {canManage ? (
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "flex-end",
+              marginTop: "1rem"
+            }}
+          >
+            <button
+              type="button"
+              onClick={handleCreateUser}
+              disabled={creatingUser}
+              className="inline-flex items-center justify-center rounded-xl bg-indigo-600 px-4 py-2 font-semibold text-white shadow transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-indigo-400"
+            >
+              {creatingUser ? "Создаём..." : "Create new user"}
+            </button>
+          </div>
+        ) : null}
 
         {loading ? <p style={{ color: "var(--text-muted)" }}>Загружаем настройки...</p> : null}
 
@@ -449,6 +559,7 @@ const SettingsContent = () => {
         {ratesError ? (
           <p style={{ color: "var(--accent-danger)" }}>{ratesError}</p>
         ) : null}
+        {userError ? <p style={{ color: "var(--accent-danger)" }}>{userError}</p> : null}
         {message ? <p style={{ color: "var(--accent-success)" }}>{message}</p> : null}
     </PageContainer>
   );

--- a/app/settings/wallets/page.tsx
+++ b/app/settings/wallets/page.tsx
@@ -17,7 +17,7 @@ const WalletSettings = () => {
     return null;
   }
 
-  const canManage = user.role === "accountant";
+  const canManage = user.role === "admin";
   const [wallets, setWallets] = useState<Wallet[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/app/wallets/page.tsx
+++ b/app/wallets/page.tsx
@@ -27,7 +27,7 @@ const WalletsContent = () => {
   const [error, setError] = useState<string | null>(null);
   const [wallets, setWallets] = useState<Wallet[]>([]);
 
-  const canManage = user.role === "accountant";
+  const canManage = user.role === "admin";
 
   useEffect(() => {
     const loadData = async () => {

--- a/components/AuthGate.tsx
+++ b/components/AuthGate.tsx
@@ -4,7 +4,7 @@ import { useState, type FormEvent, type ReactNode } from "react";
 import { useSession } from "@/components/SessionProvider";
 
 const labelForRole = (role: string) => {
-  if (role === "accountant") {
+  if (role === "admin") {
     return "Бухгалтер";
   }
 
@@ -14,14 +14,14 @@ const labelForRole = (role: string) => {
 const AuthGate = ({ children }: { children: ReactNode }) => {
   const { user, initializing, authenticating, authError, login, clearError, logout } =
     useSession();
-  const [loginValue, setLoginValue] = useState("");
+  const [usernameValue, setUsernameValue] = useState("");
   const [password, setPassword] = useState("");
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
     try {
-      await login(loginValue, password);
+      await login(usernameValue, password);
       setPassword("");
     } catch (error) {
       console.error(error);
@@ -88,12 +88,14 @@ const AuthGate = ({ children }: { children: ReactNode }) => {
           </div>
 
           <label>
-            <span style={{ fontWeight: 600, color: "var(--text-secondary-strong)" }}>Логин</span>
+            <span style={{ fontWeight: 600, color: "var(--text-secondary-strong)" }}>
+              Имя пользователя
+            </span>
             <input
               type="text"
-              value={loginValue}
+              value={usernameValue}
               onChange={(event) => {
-                setLoginValue(event.target.value);
+                setUsernameValue(event.target.value);
                 clearError();
               }}
               placeholder="например, buh"
@@ -166,7 +168,7 @@ const AuthGate = ({ children }: { children: ReactNode }) => {
         }}
       >
         <span style={{ fontWeight: 600 }}>
-          Вы вошли как {user.login} ({labelForRole(user.role)})
+          Вы вошли как {user.username} ({labelForRole(user.role)})
         </span>
         <button
           type="button"

--- a/components/SessionProvider.tsx
+++ b/components/SessionProvider.tsx
@@ -16,7 +16,7 @@ type SessionContextValue = {
   initializing: boolean;
   authenticating: boolean;
   authError: string | null;
-  login: (login: string, password: string) => Promise<void>;
+  login: (username: string, password: string) => Promise<void>;
   logout: () => Promise<void>;
   refresh: () => Promise<void>;
   clearError: () => void;
@@ -60,7 +60,7 @@ const SessionProvider = ({ children }: { children: ReactNode }) => {
     void fetchSession();
   }, [fetchSession]);
 
-  const login = useCallback(async (loginValue: string, password: string) => {
+  const login = useCallback(async (usernameValue: string, password: string) => {
     setAuthenticating(true);
     setAuthError(null);
 
@@ -68,7 +68,7 @@ const SessionProvider = ({ children }: { children: ReactNode }) => {
       const response = await fetch("/api/auth/login", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ login: loginValue, password })
+        body: JSON.stringify({ username: usernameValue, password })
       });
 
       const data = (await response.json().catch(() => null)) as

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -36,7 +36,7 @@ const toSessionUser = async (userId: string): Promise<SessionUser | null> => {
     return null;
   }
 
-  return { id: user.id, login: user.login, role: user.role as UserRole };
+  return { id: user.id, username: user.username, role: user.role as UserRole };
 };
 
 export const createSession = (userId: string) => {
@@ -162,4 +162,4 @@ export const ensureRole = async (
 };
 
 export const ensureAccountant = (request: NextRequest): Promise<AuthResult> =>
-  ensureRole(request, "accountant");
+  ensureRole(request, "admin");

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -46,16 +46,17 @@ export type Goal = {
   currency: Currency;
 };
 
-export type UserRole = "user" | "accountant";
+export type UserRole = "user" | "admin";
 
 export type User = {
   id: string;
   role: UserRole;
-  login: string;
-  password: string;
+  username: string;
+  passwordHash: string;
+  createdAt: string;
 };
 
-export type SessionUser = Pick<User, "id" | "login" | "role">;
+export type SessionUser = Pick<User, "id" | "username" | "role">;
 
 export type CategoryStore = {
   income: string[];

--- a/prisma/migrations/20240925000001_user_management/migration.sql
+++ b/prisma/migrations/20240925000001_user_management/migration.sql
@@ -1,0 +1,11 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+ALTER TABLE "users" RENAME COLUMN "login" TO "username";
+ALTER TABLE "users" RENAME COLUMN "password" TO "password_hash";
+
+ALTER TABLE "users"
+  ADD COLUMN "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+UPDATE "users" SET "role" = 'admin' WHERE "role" = 'accountant';
+
+ALTER INDEX IF EXISTS "users_login_key" RENAME TO "users_username_key";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,10 +8,11 @@ datasource db {
 }
 
 model User {
-  id       String @id @db.Uuid
-  role     String @db.Text
-  login    String @unique @db.Text
-  password String @db.Text
+  id           String   @id @db.Uuid
+  role         String   @db.Text
+  username     String   @unique @db.Text
+  passwordHash String   @map("password_hash") @db.Text
+  createdAt    DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
 
   @@map("users")
 }

--- a/prisma/seed-data.json
+++ b/prisma/seed-data.json
@@ -2,13 +2,13 @@
   "users": [
     {
       "id": "00000000-0000-0000-0000-000000000001",
-      "login": "buh",
+      "username": "buh",
       "password": "buh123",
-      "role": "accountant"
+      "role": "admin"
     },
     {
       "id": "00000000-0000-0000-0000-000000000002",
-      "login": "viewer",
+      "username": "viewer",
       "password": "viewer123",
       "role": "user"
     }

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -8,7 +8,21 @@ const normalizeWalletSlug = (value) => value.trim().toLowerCase().replace(/\s+/g
 async function main() {
   const { users, categories, wallets, currencies, baseCurrency } = seedData;
 
-  await prisma.user.createMany({ data: users, skipDuplicates: true });
+  await prisma.$executeRaw`CREATE EXTENSION IF NOT EXISTS pgcrypto;`;
+
+  const hashedUsers = await Promise.all(
+    users.map(async ({ id, username, password, role }) => {
+      const [row] = await prisma.$queryRaw`SELECT crypt(${password}, gen_salt('bf', 12)) AS hash`;
+
+      if (!row?.hash) {
+        throw new Error(`Не удалось захешировать пароль для пользователя ${username}`);
+      }
+
+      return { id, username, role, passwordHash: row.hash };
+    })
+  );
+
+  await prisma.user.createMany({ data: hashedUsers, skipDuplicates: true });
 
   await prisma.category.createMany({
     data: [


### PR DESCRIPTION
## Summary
- migrate the Prisma user model to use usernames, bcrypt-ready hashes, and created timestamps while keeping pgcrypto available
- use Postgres crypt() for login verification, seed data hashing, and introduce an admin-only API endpoint to create random user credentials
- update authentication/session flows and the settings UI so admins can generate users and see credentials once in a modal

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d4d1e4b83c8331857ff269b379093a