### PR TITLE
Disable authentication module

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,3 +1,12 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+export const POST = async (_request: NextRequest) =>
+  NextResponse.json(
+    { error: "Модуль авторизации временно отключен" },
+    { status: 503 }
+  );
+
+/*
 import bcrypt from "bcrypt";
 import { NextResponse, type NextRequest } from "next/server";
 import { createSession, setSessionCookie } from "@/lib/auth";
@@ -77,3 +86,4 @@ export const POST = async (request: NextRequest) => {
     );
   }
 };
+*/

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,4 +1,13 @@
 import { NextResponse, type NextRequest } from "next/server";
+
+export const POST = (_request: NextRequest) =>
+  NextResponse.json(
+    { error: "Модуль авторизации временно отключен" },
+    { status: 503 }
+  );
+
+/*
+import { NextResponse, type NextRequest } from "next/server";
 import { SESSION_COOKIE_NAME, clearSessionCookie, destroySession } from "@/lib/auth";
 
 export const POST = (request: NextRequest) => {
@@ -14,3 +23,4 @@ export const POST = (request: NextRequest) => {
 
   return response;
 };
+*/

--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -1,4 +1,13 @@
 import { NextResponse, type NextRequest } from "next/server";
+
+export const GET = async (_request: NextRequest) =>
+  NextResponse.json(
+    { user: null, error: "Модуль авторизации временно отключен" },
+    { status: 503 }
+  );
+
+/*
+import { NextResponse, type NextRequest } from "next/server";
 import { getSessionUser } from "@/lib/auth";
 
 export const GET = async (request: NextRequest) => {
@@ -6,3 +15,4 @@ export const GET = async (request: NextRequest) => {
 
   return NextResponse.json({ user: user ?? null });
 };
+*/

--- a/components/AuthGate.tsx
+++ b/components/AuthGate.tsx
@@ -1,5 +1,14 @@
 "use client";
 
+import type { ReactNode } from "react";
+
+const AuthGate = ({ children }: { children: ReactNode }) => <>{children}</>;
+
+export default AuthGate;
+
+/*
+"use client";
+
 import { useState, type FormEvent, type ReactNode } from "react";
 import { useSession } from "@/components/SessionProvider";
 
@@ -175,3 +184,4 @@ const AuthGate = ({ children }: { children: ReactNode }) => {
 };
 
 export default AuthGate;
+*/

--- a/components/SessionProvider.tsx
+++ b/components/SessionProvider.tsx
@@ -1,5 +1,46 @@
 "use client";
 
+import { createContext, useContext, type ReactNode } from "react";
+import type { SessionUser } from "@/lib/types";
+
+const defaultSessionUser: SessionUser = {
+  id: "auth-disabled",
+  login: "auth-disabled",
+  role: "admin"
+};
+
+const defaultValue = {
+  user: defaultSessionUser,
+  initializing: false,
+  authenticating: false,
+  authError: null as string | null,
+  login: async () => {
+    /* auth temporarily disabled */
+  },
+  logout: async () => {
+    /* auth temporarily disabled */
+  },
+  refresh: async () => {
+    /* auth temporarily disabled */
+  },
+  clearError: () => {
+    /* auth temporarily disabled */
+  }
+};
+
+const SessionContext = createContext(defaultValue);
+
+const SessionProvider = ({ children }: { children: ReactNode }) => (
+  <SessionContext.Provider value={defaultValue}>{children}</SessionContext.Provider>
+);
+
+export const useSession = () => useContext(SessionContext);
+
+export default SessionProvider;
+
+/*
+"use client";
+
 import {
   createContext,
   useCallback,
@@ -147,3 +188,4 @@ export const useSession = () => {
 };
 
 export default SessionProvider;
+*/

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,3 +1,74 @@
+import { NextResponse, type NextRequest } from "next/server";
+import type { SessionUser, UserRole } from "@/lib/types";
+
+export const SESSION_COOKIE_NAME = "iskcon_session";
+
+const stubUser: SessionUser = {
+  id: "auth-disabled",
+  login: "auth-disabled",
+  role: "admin"
+};
+
+export const createSession = (_userId: string) => ({
+  token: "",
+  expiresAt: Date.now()
+});
+
+export const destroySession = (_token: string) => {
+  /* auth temporarily disabled */
+};
+
+export const getSessionUser = async (_request: NextRequest): Promise<SessionUser | null> =>
+  stubUser;
+
+export const setSessionCookie = (
+  response: NextResponse,
+  _token: string,
+  _expiresAt: number
+) => {
+  response.cookies.set({
+    name: SESSION_COOKIE_NAME,
+    value: "",
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    expires: new Date(0)
+  });
+};
+
+export const clearSessionCookie = (response: NextResponse) => {
+  response.cookies.set({
+    name: SESSION_COOKIE_NAME,
+    value: "",
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    expires: new Date(0)
+  });
+};
+
+type AuthResult = {
+  user: SessionUser;
+  response?: undefined;
+};
+
+export const ensureAuthenticated = async (
+  _request: NextRequest
+): Promise<AuthResult> => ({
+  user: stubUser
+});
+
+export const ensureRole = async (
+  request: NextRequest,
+  _allowedRole: UserRole
+): Promise<AuthResult> => ensureAuthenticated(request);
+
+export const ensureAccountant = (request: NextRequest): Promise<AuthResult> =>
+  ensureRole(request, "admin");
+
+/*
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { NextResponse, type NextRequest } from "next/server";
 import prisma from "@/lib/prisma";
@@ -163,3 +234,4 @@ export const ensureRole = async (
 
 export const ensureAccountant = (request: NextRequest): Promise<AuthResult> =>
   ensureRole(request, "admin");
+*/


### PR DESCRIPTION
## Summary
- replace the session provider with a no-op context and comment out the original implementation while authentication is disabled
- simplify the AuthGate component to render children directly and leave the previous UI commented out
- stub authentication helpers and API routes so that every auth endpoint now returns a 503 response, keeping the prior logic commented for future restoration

## Testing
- `npm run lint` *(fails: missing Next.js binary because dependencies are not installed in the environment)*
- `npm install` *(fails: registry responded with 403 for @types/bcrypt)*

------
https://chatgpt.com/codex/tasks/task_e_68d57a6c62cc833192d9f004db13f4f0