### PR TITLE
Add wallet currency selection in settings

### DIFF
--- a/app/debts/page.tsx
+++ b/app/debts/page.tsx
@@ -10,11 +10,17 @@ import {
   DEFAULT_SETTINGS,
   SUPPORTED_CURRENCIES
 } from "@/lib/currency";
-import { type Currency, type Debt, type Settings, type Wallet } from "@/lib/types";
+import {
+  type Currency,
+  type Debt,
+  type Settings,
+  type Wallet,
+  type WalletWithCurrency
+} from "@/lib/types";
 import { fetcher, type FetcherError } from "@/lib/fetcher";
 
 type WalletsResponse = {
-  wallets: Wallet[];
+  wallets: WalletWithCurrency[];
 };
 
 const DebtsContent = () => {
@@ -28,7 +34,7 @@ const DebtsContent = () => {
   const [to, setTo] = useState<string>("");
   const [comment, setComment] = useState<string>("");
   const [currency, setCurrency] = useState<Currency>(DEFAULT_SETTINGS.baseCurrency);
-  const [wallets, setWallets] = useState<Wallet[]>([]);
+  const [wallets, setWallets] = useState<WalletWithCurrency[]>([]);
   const [wallet, setWallet] = useState<Wallet>("");
   const [settings, setSettings] = useState<Settings | null>(null);
   const [activeSubmission, setActiveSubmission] = useState<"new" | "existing" | null>(null);
@@ -89,15 +95,15 @@ const DebtsContent = () => {
 
       if (current) {
         const matched = walletList.find(
-          (item) => item.toLowerCase() === current.toLowerCase()
+          (item) => item.name.toLowerCase() === current.toLowerCase()
         );
 
         if (matched) {
-          return matched;
+          return matched.name;
         }
       }
 
-      return walletList[0];
+      return walletList[0].name;
     });
   }, [walletsData]);
 
@@ -126,8 +132,8 @@ const DebtsContent = () => {
       return;
     }
 
-    if (!wallets.some((item) => item.toLowerCase() === wallet.toLowerCase())) {
-      setWallet(wallets[0]);
+    if (!wallets.some((item) => item.name.toLowerCase() === wallet.toLowerCase())) {
+      setWallet(wallets[0]?.name ?? "");
     }
   }, [wallets, wallet]);
 
@@ -451,8 +457,8 @@ const DebtsContent = () => {
               <option value="">Нет доступных кошельков</option>
             ) : (
               wallets.map((item) => (
-                <option key={item} value={item}>
-                  {item}
+                <option key={item.id} value={item.name}>
+                  {item.name}
                 </option>
               ))
             )}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,7 +23,8 @@ import {
   type Goal,
   type Operation,
   type Settings,
-  type Wallet
+  type Wallet,
+  type WalletWithCurrency
 } from "@/lib/types";
 import { extractDebtPaymentAmount } from "@/lib/debtPayments";
 
@@ -35,7 +36,7 @@ type CategoriesResponse = {
 };
 
 type WalletsResponse = {
-  wallets: Wallet[];
+  wallets: WalletWithCurrency[];
 };
 
 const getWalletIcon = (walletName: string) => {
@@ -70,7 +71,7 @@ const Dashboard = () => {
   const [type, setType] = useState<Operation["type"]>("income");
   const [category, setCategory] = useState<string>("");
   const [currency, setCurrency] = useState<Currency>(DEFAULT_SETTINGS.baseCurrency);
-  const [wallets, setWallets] = useState<Wallet[]>([]);
+  const [wallets, setWallets] = useState<WalletWithCurrency[]>([]);
   const [wallet, setWallet] = useState<Wallet>("");
   const [debts, setDebts] = useState<Debt[]>([]);
   const [settings, setSettings] = useState<Settings | null>(null);
@@ -196,15 +197,15 @@ const Dashboard = () => {
 
       if (current) {
         const matched = walletList.find(
-          (item) => item.toLowerCase() === current.toLowerCase()
+          (item) => item.name.toLowerCase() === current.toLowerCase()
         );
 
         if (matched) {
-          return matched;
+          return matched.name;
         }
       }
 
-      return walletList[0];
+      return walletList[0].name;
     });
   }, [walletsData]);
 
@@ -311,8 +312,8 @@ const Dashboard = () => {
       return;
     }
 
-    if (!wallets.some((item) => item.toLowerCase() === wallet.toLowerCase())) {
-      setWallet(wallets[0]);
+    if (!wallets.some((item) => item.name.toLowerCase() === wallet.toLowerCase())) {
+      setWallet(wallets[0]?.name ?? "");
     }
   }, [wallets, wallet]);
 
@@ -792,8 +793,8 @@ const Dashboard = () => {
                   <option value="">Нет доступных кошельков</option>
                 ) : (
                   wallets.map((item) => (
-                    <option key={item} value={item}>
-                      {`${getWalletIcon(item)} ${item}`}
+                    <option key={item.id} value={item.name}>
+                      {`${getWalletIcon(item.name)} ${item.name}`}
                     </option>
                   ))
                 )}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -11,6 +11,12 @@ export const DEFAULT_WALLETS = [
 
 export type Wallet = string;
 
+export type WalletWithCurrency = {
+  id: string;
+  name: Wallet;
+  currency: Currency;
+};
+
 export type Operation = {
   id: string;
   type: "income" | "expense";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,6 +64,7 @@ model Goal {
 model Wallet {
   wallet       String @id
   display_name String
+  currency     String
 
   @@map("wallets")
 }

--- a/prisma/seed-data.json
+++ b/prisma/seed-data.json
@@ -34,10 +34,10 @@
     ]
   },
   "wallets": [
-    "крипта",
-    "русская карта",
-    "грузинская карта",
-    "наличные"
+    { "name": "крипта", "currency": "USD" },
+    { "name": "русская карта", "currency": "RUB" },
+    { "name": "грузинская карта", "currency": "GEL" },
+    { "name": "наличные", "currency": "USD" }
   ],
   "currencies": ["USD", "RUB", "GEL", "EUR"],
   "baseCurrency": "USD"

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -28,9 +28,10 @@ async function main() {
   });
 
   await prisma.wallet.createMany({
-    data: wallets.map((displayName) => ({
-      wallet: normalizeWalletSlug(displayName),
-      display_name: displayName,
+    data: wallets.map(({ name, currency }) => ({
+      wallet: normalizeWalletSlug(name),
+      display_name: name,
+      currency,
     })),
     skipDuplicates: true,
   });

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -10,7 +10,7 @@ const main = async () => {
   const { users, categories, wallets, currencies, baseCurrency } = seedData as {
     users: Array<{ id: string; login: string; password: string; role: string }>;
     categories: { income: string[]; expense: string[] };
-    wallets: string[];
+    wallets: Array<{ name: string; currency: string }>;
     currencies: string[];
     baseCurrency: string;
   };
@@ -34,9 +34,10 @@ const main = async () => {
   });
 
   await prisma.wallet.createMany({
-    data: wallets.map((displayName) => ({
-      wallet: normalizeWalletSlug(displayName),
-      display_name: displayName,
+    data: wallets.map(({ name, currency }) => ({
+      wallet: normalizeWalletSlug(name),
+      display_name: name,
+      currency,
     })),
     skipDuplicates: true,
   });


### PR DESCRIPTION
## Summary
- allow choosing a currency when creating wallets in the settings UI and show stored wallet currencies
- persist wallet currencies in the API, Prisma schema, and seed data
- update dashboard, debts, and wallets pages to consume wallet metadata with currencies

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d63695acb08331aa2a65cd717fd5ad