### PR TITLE
feat: restyle wallet transfer form

### DIFF
--- a/app/wallets/page.tsx
+++ b/app/wallets/page.tsx
@@ -17,6 +17,7 @@ import {
   type WalletWithCurrency
 } from "@/lib/types";
 import { fetcher, type FetcherError } from "@/lib/fetcher";
+import styles from "./transfer-form.module.css";
 
 type WalletsResponse = {
   wallets: WalletWithCurrency[];
@@ -49,6 +50,13 @@ const inferWalletCurrencyFromName = (wallet: Wallet): Currency | null => {
 };
 
 const isRussianWallet = (wallet: Wallet) => /рус/.test(wallet.toLowerCase());
+
+const currencyIcons: Record<Currency, string> = {
+  USD: "🇺🇸",
+  RUB: "🇷🇺",
+  GEL: "🇬🇪",
+  EUR: "🇪🇺"
+};
 
 const WalletsContent = () => {
   const { user, refresh } = useSession();
@@ -899,203 +907,133 @@ const WalletsContent = () => {
           </div>
         </section>
 
-        <section
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            gap: "1rem",
-            backgroundColor: "var(--surface-subtle)",
-            borderRadius: "1rem",
-            padding: "1.5rem"
-          }}
-        >
-          <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem" }}>
-            <h2 style={{ fontSize: "1.35rem", fontWeight: 600 }}>Перевод между кошельками</h2>
-            <p style={{ color: "var(--text-secondary)", margin: 0 }}>
+        <section className={styles.transferSection}>
+          <div className={styles.transferHeader}>
+            <h2 className={styles.transferTitle}>Перевод между кошельками</h2>
+            <p className={styles.transferDescription}>
               Перемещайте средства между кошельками и автоматически конвертируйте валюту по
               актуальным настройкам.
             </p>
           </div>
 
-          <form
-            onSubmit={handleTransferSubmit}
-            style={{
-              display: "flex",
-              flexWrap: "wrap",
-              gap: "1rem",
-              alignItems: "flex-end"
-            }}
-          >
-            <label style={{ display: "flex", flexDirection: "column", gap: "0.4rem" }}>
-              <span style={{ fontSize: "0.9rem", color: "var(--text-secondary)" }}>
-                Сумма к списанию
-              </span>
+          <form onSubmit={handleTransferSubmit} className={styles.transferForm}>
+            <label className={styles.transferField}>
+              <span className={styles.transferLabel}>Сумма к списанию</span>
               <input
                 type="number"
                 min="0"
                 step="0.01"
                 value={transferAmount}
                 onChange={(event) => handleTransferAmountChange(event.target.value)}
-                style={{
-                  padding: "0.6rem 0.75rem",
-                  borderRadius: "0.75rem",
-                  border: "1px solid var(--surface-muted)",
-                  backgroundColor: "var(--surface-base)",
-                  color: "inherit",
-                  minWidth: "160px"
-                }}
+                className={styles.transferInput}
               />
             </label>
 
-            <label style={{ display: "flex", flexDirection: "column", gap: "0.4rem" }}>
-              <span style={{ fontSize: "0.9rem", color: "var(--text-secondary)" }}>
-                Из кошелька
-              </span>
-              <select
-                value={transferFromWallet}
-                onChange={(event) => handleTransferFromWalletChange(event.target.value)}
-                style={{
-                  padding: "0.6rem 0.75rem",
-                  borderRadius: "0.75rem",
-                  border: "1px solid var(--surface-muted)",
-                  backgroundColor: "var(--surface-base)",
-                  color: "inherit",
-                  minWidth: "180px"
-                }}
-              >
-                <option value="">Выберите кошелёк</option>
-                {wallets.map((wallet) => (
-                  <option key={wallet.id} value={wallet.name}>
-                    {wallet.name}
-                  </option>
-                ))}
-              </select>
+            <label className={styles.transferField}>
+              <span className={styles.transferLabel}>Из кошелька</span>
+              <div className={styles.currencyControl}>
+                <span className={styles.currencyIcon}>💼</span>
+                <select
+                  value={transferFromWallet}
+                  onChange={(event) => handleTransferFromWalletChange(event.target.value)}
+                  className={styles.transferSelect}
+                >
+                  <option value="">Выберите кошелёк</option>
+                  {wallets.map((wallet) => (
+                    <option key={wallet.id} value={wallet.name}>
+                      {wallet.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
             </label>
 
-            <label style={{ display: "flex", flexDirection: "column", gap: "0.4rem" }}>
-              <span style={{ fontSize: "0.9rem", color: "var(--text-secondary)" }}>
-                Валюта списания
-              </span>
-              <select
-                value={transferFromCurrency}
-                onChange={(event) =>
-                  handleTransferFromCurrencyChange(event.target.value as Currency)
-                }
-                style={{
-                  padding: "0.6rem 0.75rem",
-                  borderRadius: "0.75rem",
-                  border: "1px solid var(--surface-muted)",
-                  backgroundColor: "var(--surface-base)",
-                  color: "inherit",
-                  minWidth: "140px"
-                }}
-              >
-                {SUPPORTED_CURRENCIES.map((currency) => (
-                  <option key={currency} value={currency}>
-                    {currency}
-                  </option>
-                ))}
-              </select>
+            <label className={styles.transferField}>
+              <span className={styles.transferLabel}>Валюта списания</span>
+              <div className={styles.currencyControl}>
+                <span className={styles.currencyIcon}>
+                  {currencyIcons[transferFromCurrency] ?? "💱"}
+                </span>
+                <select
+                  value={transferFromCurrency}
+                  onChange={(event) =>
+                    handleTransferFromCurrencyChange(event.target.value as Currency)
+                  }
+                  className={styles.transferSelect}
+                >
+                  {SUPPORTED_CURRENCIES.map((currency) => (
+                    <option key={currency} value={currency}>
+                      {currency}
+                    </option>
+                  ))}
+                </select>
+              </div>
             </label>
 
-            <label style={{ display: "flex", flexDirection: "column", gap: "0.4rem" }}>
-              <span style={{ fontSize: "0.9rem", color: "var(--text-secondary)" }}>
-                В кошелёк
-              </span>
-              <select
-                value={transferToWallet}
-                onChange={(event) => handleTransferToWalletChange(event.target.value)}
-                style={{
-                  padding: "0.6rem 0.75rem",
-                  borderRadius: "0.75rem",
-                  border: "1px solid var(--surface-muted)",
-                  backgroundColor: "var(--surface-base)",
-                  color: "inherit",
-                  minWidth: "180px"
-                }}
-              >
-                <option value="">Выберите кошелёк</option>
-                {wallets.map((wallet) => (
-                  <option key={wallet.id} value={wallet.name}>
-                    {wallet.name}
-                  </option>
-                ))}
-              </select>
+            <label className={styles.transferField}>
+              <span className={styles.transferLabel}>В кошелёк</span>
+              <div className={styles.currencyControl}>
+                <span className={styles.currencyIcon}>📥</span>
+                <select
+                  value={transferToWallet}
+                  onChange={(event) => handleTransferToWalletChange(event.target.value)}
+                  className={styles.transferSelect}
+                >
+                  <option value="">Выберите кошелёк</option>
+                  {wallets.map((wallet) => (
+                    <option key={wallet.id} value={wallet.name}>
+                      {wallet.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
             </label>
 
-            <label style={{ display: "flex", flexDirection: "column", gap: "0.4rem" }}>
-              <span style={{ fontSize: "0.9rem", color: "var(--text-secondary)" }}>
-                Валюта зачисления
-              </span>
-              <select
-                value={transferToCurrency}
-                onChange={(event) =>
-                  handleTransferToCurrencyChange(event.target.value as Currency)
-                }
-                style={{
-                  padding: "0.6rem 0.75rem",
-                  borderRadius: "0.75rem",
-                  border: "1px solid var(--surface-muted)",
-                  backgroundColor: "var(--surface-base)",
-                  color: "inherit",
-                  minWidth: "140px"
-                }}
-              >
-                {SUPPORTED_CURRENCIES.map((currency) => (
-                  <option key={currency} value={currency}>
-                    {currency}
-                  </option>
-                ))}
-              </select>
+            <label className={styles.transferField}>
+              <span className={styles.transferLabel}>Валюта зачисления</span>
+              <div className={styles.currencyControl}>
+                <span className={styles.currencyIcon}>
+                  {currencyIcons[transferToCurrency] ?? "💱"}
+                </span>
+                <select
+                  value={transferToCurrency}
+                  onChange={(event) =>
+                    handleTransferToCurrencyChange(event.target.value as Currency)
+                  }
+                  className={styles.transferSelect}
+                >
+                  {SUPPORTED_CURRENCIES.map((currency) => (
+                    <option key={currency} value={currency}>
+                      {currency}
+                    </option>
+                  ))}
+                </select>
+              </div>
             </label>
 
-            <label
-              style={{
-                display: "flex",
-                flexDirection: "column",
-                gap: "0.4rem",
-                flexBasis: "100%"
-              }}
-            >
-              <span style={{ fontSize: "0.9rem", color: "var(--text-secondary)" }}>
-                Комментарий (по желанию)
-              </span>
+            <label className={`${styles.transferField} ${styles.transferFieldWide}`}>
+              <span className={styles.transferLabel}>Комментарий (по желанию)</span>
               <input
                 type="text"
                 value={transferComment}
                 onChange={(event) => handleTransferCommentChange(event.target.value)}
                 placeholder="Например, перевод для оплаты счёта"
-                style={{
-                  padding: "0.6rem 0.75rem",
-                  borderRadius: "0.75rem",
-                  border: "1px solid var(--surface-muted)",
-                  backgroundColor: "var(--surface-base)",
-                  color: "inherit"
-                }}
+                className={styles.transferInput}
               />
             </label>
 
-            <div
-              style={{
-                display: "flex",
-                flexDirection: "column",
-                gap: "0.25rem",
-                minWidth: "220px"
-              }}
-            >
-              <span style={{ fontSize: "0.9rem", color: "var(--text-secondary)" }}>
-                К зачислению
-              </span>
-              <strong style={{ fontSize: "1.1rem" }}>
+            <div className={styles.transferSummary}>
+              <span className={styles.transferSummaryTitle}>К зачислению</span>
+              <strong className={styles.transferSummaryValue}>
                 {formattedTransferTargetAmount ?? "—"}
               </strong>
               {transferRate ? (
-                <span style={{ color: "var(--text-muted)", fontSize: "0.85rem" }}>
+                <span className={styles.transferSummaryHint}>
                   1 {transferFromCurrency} ≈ {transferRate}
                 </span>
               ) : null}
               {formattedTransferSourceAmount ? (
-                <span style={{ color: "var(--text-muted)", fontSize: "0.85rem" }}>
+                <span className={styles.transferSummaryHint}>
                   Списываем {formattedTransferSourceAmount}
                 </span>
               ) : null}
@@ -1104,17 +1042,7 @@ const WalletsContent = () => {
             <button
               type="submit"
               disabled={!canSubmitTransfer || transferSubmitting}
-              style={{
-                padding: "0.7rem 1.25rem",
-                borderRadius: "0.75rem",
-                border: "1px solid transparent",
-                backgroundColor: canSubmitTransfer
-                  ? "var(--accent-teal-strong)"
-                  : "var(--surface-muted)",
-                color: canSubmitTransfer ? "white" : "var(--text-muted)",
-                fontWeight: 600,
-                cursor: canSubmitTransfer ? "pointer" : "not-allowed"
-              }}
+              className={styles.transferButton}
             >
               {transferSubmitting ? "Переводим..." : "Выполнить перевод"}
             </button>

--- a/app/wallets/transfer-form.module.css
+++ b/app/wallets/transfer-form.module.css
@@ -1,0 +1,215 @@
+.transferSection {
+  background: linear-gradient(145deg, #1c1f2b 0%, #131620 100%);
+  border-radius: 1.25rem;
+  padding: 2rem;
+  box-shadow: 0 24px 48px rgba(10, 12, 22, 0.35);
+  color: #f6f8ff;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.transferHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.transferTitle {
+  font-size: 1.45rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.transferDescription {
+  margin: 0;
+  color: rgba(246, 248, 255, 0.64);
+  line-height: 1.5;
+}
+
+.transferForm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+  width: 100%;
+}
+
+.transferField {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.transferFieldWide {
+  grid-column: 1 / -1;
+}
+
+.transferLabel {
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  color: rgba(246, 248, 255, 0.6);
+}
+
+.transferInput,
+.currencyControl {
+  background: rgba(38, 43, 61, 0.9);
+  border-radius: 0.95rem;
+  border: 1px solid rgba(88, 96, 125, 0.4);
+  box-shadow: 0 12px 24px rgba(8, 10, 20, 0.25);
+  transition: border 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease,
+    background 0.2s ease;
+}
+
+.transferInput {
+  padding: 0.85rem 1rem;
+  color: inherit;
+  font-size: 1rem;
+  border: none;
+  outline: none;
+  width: 100%;
+  background: transparent;
+}
+
+.transferInput:focus,
+.transferInput:hover,
+.currencyControl:focus-within,
+.currencyControl:hover {
+  border-color: rgba(93, 214, 189, 0.7);
+  box-shadow: 0 16px 32px rgba(12, 184, 157, 0.25);
+  transform: translateY(-1px);
+  background: rgba(47, 53, 73, 0.95);
+}
+
+.transferInput:disabled,
+.transferInput[disabled],
+.transferSelect:disabled {
+  cursor: not-allowed;
+  box-shadow: none;
+  border-color: rgba(88, 96, 125, 0.3);
+  transform: none;
+  background: rgba(38, 43, 61, 0.6);
+}
+
+.currencyControl {
+  display: flex;
+  align-items: center;
+  padding: 0.35rem 0.6rem 0.35rem 0.75rem;
+}
+
+.currencyIcon {
+  font-size: 1.3rem;
+  filter: drop-shadow(0 3px 6px rgba(0, 0, 0, 0.35));
+}
+
+.transferSelect {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 1rem;
+  width: 100%;
+  padding: 0.5rem 0.25rem 0.5rem 0.75rem;
+  outline: none;
+  cursor: pointer;
+  position: relative;
+}
+
+.currencyControl::after {
+  content: "";
+  width: 0.65rem;
+  height: 0.65rem;
+  border-right: 2px solid rgba(246, 248, 255, 0.6);
+  border-bottom: 2px solid rgba(246, 248, 255, 0.6);
+  transform: rotate(45deg);
+  margin-left: 0.75rem;
+  pointer-events: none;
+}
+
+.transferSummary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  background: rgba(31, 35, 51, 0.75);
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+  min-height: 140px;
+  justify-content: center;
+  box-shadow: inset 0 0 0 1px rgba(88, 96, 125, 0.25);
+  grid-column: span 1;
+}
+
+.transferSummaryTitle {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(246, 248, 255, 0.55);
+}
+
+.transferSummaryValue {
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.transferSummaryHint {
+  font-size: 0.85rem;
+  color: rgba(246, 248, 255, 0.55);
+}
+
+.transferButton {
+  align-self: flex-start;
+  padding: 0.95rem 2.5rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #3ae2b2 0%, #0bb59a 100%);
+  color: #0b1420;
+  font-weight: 700;
+  font-size: 1rem;
+  cursor: pointer;
+  box-shadow: 0 18px 32px rgba(12, 181, 154, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  min-width: 230px;
+  grid-column: span 1;
+}
+
+.transferButton:hover {
+  transform: translateY(-1px) scale(1.01);
+  box-shadow: 0 20px 38px rgba(12, 181, 154, 0.4);
+}
+
+.transferButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+  box-shadow: none;
+  transform: none;
+}
+
+@media (max-width: 900px) {
+  .transferSection {
+    padding: 1.75rem 1.5rem;
+  }
+
+  .transferForm {
+    gap: 1.25rem;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+
+  .transferSummary {
+    grid-column: 1 / -1;
+  }
+
+  .transferButton {
+    grid-column: 1 / -1;
+    justify-self: stretch;
+  }
+}
+
+@media (max-width: 600px) {
+  .transferSection {
+    padding: 1.5rem 1.25rem;
+  }
+
+  .transferButton {
+    width: 100%;
+    justify-self: stretch;
+  }
+}

--- a/app/wallets/transfer-form.module.css
+++ b/app/wallets/transfer-form.module.css
@@ -54,27 +54,32 @@
 .currencyControl {
   background: rgba(38, 43, 61, 0.9);
   border-radius: 0.95rem;
-  border: 1px solid rgba(88, 96, 125, 0.4);
   box-shadow: 0 12px 24px rgba(8, 10, 20, 0.25);
   transition: border 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease,
     background 0.2s ease;
 }
 
 .transferInput {
+  border: 1px solid rgba(88, 96, 125, 0.4);
   padding: 0.85rem 1rem;
   color: inherit;
   font-size: 1rem;
-  border: none;
   outline: none;
   width: 100%;
   background: transparent;
 }
 
+
 .transferInput:focus,
-.transferInput:hover,
+.transferInput:hover {
+  border-color: rgba(93, 214, 189, 0.7);
+  box-shadow: 0 16px 32px rgba(12, 184, 157, 0.25);
+  transform: translateY(-1px);
+  background: rgba(47, 53, 73, 0.95);
+}
+
 .currencyControl:focus-within,
 .currencyControl:hover {
-  border-color: rgba(93, 214, 189, 0.7);
   box-shadow: 0 16px 32px rgba(12, 184, 157, 0.25);
   transform: translateY(-1px);
   background: rgba(47, 53, 73, 0.95);
@@ -94,6 +99,7 @@
   display: flex;
   align-items: center;
   padding: 0.35rem 0.6rem 0.35rem 0.75rem;
+  border: none;
 }
 
 .currencyIcon {


### PR DESCRIPTION
## Summary
- redesign the wallet transfer form with a modern responsive layout and theming
- add currency and wallet icons plus updated input/button styling for a refreshed UX
- introduce a dedicated CSS module to manage the dark neutral aesthetic and hover effects

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d657fd748331a857ba8d9464e33e