### PR TITLE
feat: redesign wallet transactions UX

### DIFF
--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -1,0 +1,178 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { Prisma, type Operation as PrismaOperation } from "@prisma/client";
+
+import { ensureAccountant } from "@/lib/auth";
+import { sanitizeCurrency } from "@/lib/currency";
+import { appendDebtPaymentSource } from "@/lib/debtPayments";
+import { recalculateGoalProgress } from "@/lib/goals";
+import prisma from "@/lib/prisma";
+import { serializeOperation } from "@/lib/serializers";
+import { loadSettings } from "@/lib/settingsService";
+
+const normalize = (value: string | null | undefined) => value?.trim() ?? "";
+
+const errorResponse = (message: string, status = 400) =>
+  NextResponse.json({ error: message }, { status });
+
+const applyExpenseToDebts = async (
+  tx: Prisma.TransactionClient,
+  operation: PrismaOperation,
+  category: string
+) => {
+  const debts = await tx.debt.findMany({
+    where: {
+      status: "open",
+      currency: operation.currency,
+      OR: [
+        {
+          from_contact: {
+            equals: category,
+            mode: "insensitive"
+          }
+        },
+        {
+          to_contact: {
+            equals: category,
+            mode: "insensitive"
+          }
+        }
+      ]
+    },
+    orderBy: { registered_at: "asc" }
+  });
+
+  if (debts.length === 0) {
+    return new Prisma.Decimal(0);
+  }
+
+  const originalAmount = new Prisma.Decimal(operation.amount);
+  let remainingPayment = new Prisma.Decimal(operation.amount);
+
+  for (const debt of debts) {
+    if (remainingPayment.lte(0)) {
+      break;
+    }
+
+    const debtAmount = new Prisma.Decimal(debt.amount);
+    const placeholderSource = `debt:${debt.id}`;
+
+    const paymentToApply = remainingPayment.gte(debtAmount) ? debtAmount : remainingPayment;
+    const updatedAmount = debtAmount.minus(paymentToApply);
+
+    if (updatedAmount.lte(0)) {
+      await tx.debt.delete({ where: { id: debt.id } });
+    } else {
+      await tx.debt.update({
+        where: { id: debt.id },
+        data: { amount: updatedAmount }
+      });
+    }
+
+    await tx.operation.deleteMany({ where: { source: placeholderSource } });
+
+    remainingPayment = remainingPayment.minus(paymentToApply);
+  }
+
+  return originalAmount.minus(remainingPayment);
+};
+
+type TransactionPayload = {
+  walletId?: string;
+  type?: "INCOME" | "EXPENSE";
+  amount?: number;
+  source?: string | null;
+  category?: string | null;
+  description?: string | null;
+};
+
+export const POST = async (request: NextRequest) => {
+  const auth = await ensureAccountant(request);
+
+  if (auth.response) {
+    return auth.response;
+  }
+
+  const payload = (await request.json().catch(() => null)) as TransactionPayload | null;
+
+  if (!payload) {
+    return errorResponse("Некорректные данные", 400);
+  }
+
+  const { walletId, type, amount, source, category, description } = payload;
+
+  if (!walletId || typeof walletId !== "string") {
+    return errorResponse("Укажите кошелёк", 400);
+  }
+
+  if (type !== "INCOME" && type !== "EXPENSE") {
+    return errorResponse("Некорректный тип операции", 400);
+  }
+
+  if (typeof amount !== "number" || !Number.isFinite(amount) || amount <= 0) {
+    return errorResponse("Введите корректную сумму", 400);
+  }
+
+  const trimmedSource = normalize(source);
+  const trimmedCategory = normalize(category);
+  const trimmedDescription = normalize(description);
+
+  if (type === "EXPENSE" && !trimmedCategory) {
+    return errorResponse("Укажите категорию расхода", 400);
+  }
+
+  if (type === "INCOME" && !trimmedSource) {
+    return errorResponse("Выберите источник дохода", 400);
+  }
+
+  const wallet = await prisma.wallet.findUnique({ where: { wallet: walletId } });
+
+  if (!wallet) {
+    return errorResponse("Кошелёк не найден", 404);
+  }
+
+  const settings = await loadSettings();
+  const currency = sanitizeCurrency(wallet.currency, settings.baseCurrency);
+  const operationType = type === "INCOME" ? "income" : "expense";
+  const categoryValue =
+    operationType === "expense" ? trimmedCategory : trimmedSource || wallet.display_name;
+
+  try {
+    const operation = await prisma.$transaction(async (tx) => {
+      let created = await tx.operation.create({
+        data: {
+          id: crypto.randomUUID(),
+          type: operationType,
+          amount,
+          currency,
+          category: categoryValue,
+          wallet: wallet.display_name,
+          comment: trimmedDescription ? trimmedDescription : null,
+          source: type === "INCOME" ? trimmedSource : null,
+          occurred_at: new Date()
+        }
+      });
+
+      if (created.type === "expense") {
+        const appliedAmount = await applyExpenseToDebts(tx, created, categoryValue);
+
+        if (appliedAmount.gt(0)) {
+          const updatedSource = appendDebtPaymentSource(null, appliedAmount.toString());
+
+          created = await tx.operation.update({
+            where: { id: created.id },
+            data: { source: updatedSource || null }
+          });
+        }
+      }
+
+      return created;
+    });
+
+    await recalculateGoalProgress();
+
+    return NextResponse.json(serializeOperation(operation), { status: 201 });
+  } catch (error) {
+    console.error("Failed to create transaction", error);
+    return errorResponse("Не удалось сохранить операцию", 500);
+  }
+};

--- a/app/wallets/components/IncomeSources.tsx
+++ b/app/wallets/components/IncomeSources.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+type IncomeSourcesProps = {
+  sources: string[];
+  activeSource: string | null;
+  onDragStart: (source: string) => void;
+  onDragEnd: () => void;
+  isMobile?: boolean;
+};
+
+const IncomeSources = ({ sources, activeSource, onDragStart, onDragEnd, isMobile = false }: IncomeSourcesProps) => (
+  <div className="flex h-full flex-col gap-3 rounded-2xl border border-dashed border-emerald-200 bg-emerald-50/40 p-4 dark:border-emerald-600/40 dark:bg-emerald-950/30">
+    <div className="space-y-1">
+      <h3 className="text-base font-semibold text-emerald-700 dark:text-emerald-200">Источники дохода</h3>
+      <p className="text-sm text-emerald-700/70 dark:text-emerald-200/70">
+        {isMobile
+          ? "Выберите источник в модальном окне после выбора кошелька."
+          : "Перетащите источник на кошелёк, чтобы добавить приход."}
+      </p>
+    </div>
+
+    <ul className="flex flex-col gap-2">
+      {sources.map((source) => {
+        const isActive = activeSource === source;
+
+        return (
+          <li key={source}>
+            <button
+              type="button"
+              draggable={!isMobile}
+              onDragStart={(event) => {
+                if (isMobile) {
+                  return;
+                }
+
+                event.dataTransfer.effectAllowed = "copy";
+                event.dataTransfer.setData("text/income-source", source);
+                onDragStart(source);
+              }}
+              onDragEnd={onDragEnd}
+              className="flex w-full items-center justify-between rounded-xl border border-emerald-200 bg-white px-4 py-2 text-left text-sm font-medium text-emerald-700 shadow-sm transition hover:border-emerald-300 hover:bg-emerald-100 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-emerald-600/50 dark:bg-emerald-900/40 dark:text-emerald-100 dark:hover:bg-emerald-800/40"
+              data-active={isActive ? "true" : "false"}
+            >
+              <span>{source}</span>
+              {!isMobile ? (
+                <span className="text-xs font-semibold uppercase tracking-wide text-emerald-500">D&D</span>
+              ) : (
+                <span className="text-xs font-medium text-emerald-500">Справка</span>
+              )}
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  </div>
+);
+
+export default IncomeSources;

--- a/app/wallets/components/TransactionModal.tsx
+++ b/app/wallets/components/TransactionModal.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { useEffect } from "react";
+
+type TransactionType = "INCOME" | "EXPENSE";
+
+type TransactionFormState = {
+  amount: string;
+  category: string;
+  description: string;
+  source: string;
+};
+
+type TransactionModalProps = {
+  isOpen: boolean;
+  type: TransactionType | null;
+  walletName?: string;
+  sources: string[];
+  formData: TransactionFormState;
+  onChange: <Field extends keyof TransactionFormState>(field: Field, value: TransactionFormState[Field]) => void;
+  onClose: () => void;
+  onSubmit: () => void;
+  error?: string | null;
+  submitting?: boolean;
+};
+
+const TransactionModal = ({
+  isOpen,
+  type,
+  walletName,
+  sources,
+  formData,
+  onChange,
+  onClose,
+  onSubmit,
+  error,
+  submitting
+}: TransactionModalProps) => {
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown, { passive: false });
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen || !type) {
+    return null;
+  }
+
+  const modalTitle = type === "INCOME" ? "Добавить приход" : "Добавить расход";
+  const submitLabel = submitting ? "Сохраняем..." : "Сохранить";
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 px-4 py-6">
+      <div className="relative w-full max-w-md rounded-2xl bg-white p-6 shadow-xl dark:bg-slate-900">
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute right-3 top-3 rounded-full p-1 text-slate-500 transition hover:bg-slate-100 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:text-slate-400 dark:hover:bg-slate-800"
+          aria-label="Закрыть модальное окно"
+        >
+          ×
+        </button>
+
+        <div className="mb-4 space-y-1">
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-white">{modalTitle}</h2>
+          {walletName ? (
+            <p className="text-sm text-slate-500 dark:text-slate-400">Кошелёк: {walletName}</p>
+          ) : null}
+        </div>
+
+        <form
+          className="space-y-4"
+          onSubmit={(event) => {
+            event.preventDefault();
+            onSubmit();
+          }}
+        >
+          <label className="flex flex-col gap-2 text-sm text-slate-700 dark:text-slate-200">
+            <span>Сумма</span>
+            <input
+              type="number"
+              min="0.01"
+              step="0.01"
+              value={formData.amount}
+              onChange={(event) => onChange("amount", event.target.value)}
+              className="w-full rounded-lg border border-slate-200 px-3 py-2 text-base text-slate-900 shadow-sm transition focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/40 dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+              placeholder="0.00"
+              required
+            />
+          </label>
+
+          {type === "EXPENSE" ? (
+            <label className="flex flex-col gap-2 text-sm text-slate-700 dark:text-slate-200">
+              <span>Категория расхода</span>
+              <input
+                type="text"
+                value={formData.category}
+                onChange={(event) => onChange("category", event.target.value)}
+                className="w-full rounded-lg border border-slate-200 px-3 py-2 text-base text-slate-900 shadow-sm transition focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/40 dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+                placeholder="Например, продукты"
+                required
+              />
+            </label>
+          ) : (
+            <label className="flex flex-col gap-2 text-sm text-slate-700 dark:text-slate-200">
+              <span>Источник дохода</span>
+              <select
+                value={formData.source}
+                onChange={(event) => onChange("source", event.target.value)}
+                className="w-full rounded-lg border border-slate-200 px-3 py-2 text-base text-slate-900 shadow-sm transition focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/40 dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+                required
+              >
+                <option value="" disabled>
+                  Выберите источник
+                </option>
+                {sources.map((source) => (
+                  <option key={source} value={source}>
+                    {source}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+
+          <label className="flex flex-col gap-2 text-sm text-slate-700 dark:text-slate-200">
+            <span>Описание (необязательно)</span>
+            <textarea
+              value={formData.description}
+              onChange={(event) => onChange("description", event.target.value)}
+              className="h-24 w-full rounded-lg border border-slate-200 px-3 py-2 text-base text-slate-900 shadow-sm transition focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/40 dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+              placeholder={type === "INCOME" ? "Комментарий к приходу" : "Комментарий к расходу"}
+            />
+          </label>
+
+          {error ? <p className="text-sm text-rose-500">{error}</p> : null}
+
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-emerald-500/40 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
+            >
+              Отмена
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-500/60 disabled:cursor-not-allowed disabled:bg-emerald-400"
+            >
+              {submitLabel}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export type { TransactionFormState, TransactionType };
+export default TransactionModal;

--- a/app/wallets/components/WalletList.tsx
+++ b/app/wallets/components/WalletList.tsx
@@ -1,0 +1,294 @@
+"use client";
+
+import { useState, type CSSProperties } from "react";
+
+import type { Wallet } from "@/lib/types";
+
+type WalletCard = {
+  id: string;
+  name: Wallet;
+  icon: string;
+  baseAmountFormatted: string;
+  walletCurrencyAmountFormatted?: string | null;
+  rubAmountFormatted?: string | null;
+  isActive: boolean;
+};
+
+type WalletListProps = {
+  wallets: WalletCard[];
+  canManage: boolean;
+  draggingWallet: Wallet | null;
+  dragTargetWallet: Wallet | null;
+  dragOriginPosition: { x: number; y: number } | null;
+  dragPointerPosition: { x: number; y: number } | null;
+  dragVisualOffset: { x: number; y: number } | null;
+  activeIncomeSource: string | null;
+  incomeDropTarget: string | null;
+  onWalletPointerDown: (
+    wallet: Wallet,
+    origin: { x: number; y: number },
+    pointer: { x: number; y: number }
+  ) => void;
+  onWalletPointerEnter: (wallet: Wallet) => void;
+  onWalletPointerLeave: (wallet: Wallet) => void;
+  onWalletPointerUp: () => void;
+  onIncomeDrop: (walletId: string) => void;
+  onIncomeDragEnter: (walletId: string) => void;
+  onIncomeDragLeave: (walletId: string) => void;
+  onAddIncomeClick: (walletId: string) => void;
+  isMobile: boolean;
+};
+
+const WalletList = ({
+  wallets,
+  canManage,
+  draggingWallet,
+  dragTargetWallet,
+  dragOriginPosition,
+  dragPointerPosition,
+  dragVisualOffset,
+  activeIncomeSource,
+  incomeDropTarget,
+  onWalletPointerDown,
+  onWalletPointerEnter,
+  onWalletPointerLeave,
+  onWalletPointerUp,
+  onIncomeDrop,
+  onIncomeDragEnter,
+  onIncomeDragLeave,
+  onAddIncomeClick,
+  isMobile
+}: WalletListProps) => {
+  const [localIncomeDropTarget, setLocalIncomeDropTarget] = useState<string | null>(null);
+
+  const handleIncomeDragEnter = (walletId: string) => {
+    setLocalIncomeDropTarget(walletId);
+    onIncomeDragEnter(walletId);
+  };
+
+  const handleIncomeDragLeave = (walletId: string) => {
+    setLocalIncomeDropTarget((current) => (current === walletId ? null : current));
+    onIncomeDragLeave(walletId);
+  };
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: "0.75rem",
+        gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))"
+      }}
+    >
+      {wallets.map((wallet) => {
+        const isInteractive = canManage && wallet.isActive;
+        const isDragSource = draggingWallet === wallet.name;
+        const isDropTarget = dragTargetWallet === wallet.name && draggingWallet !== wallet.name;
+        const isIncomeTarget =
+          !!activeIncomeSource && (incomeDropTarget === wallet.id || localIncomeDropTarget === wallet.id);
+
+        const cardStyle: CSSProperties = {
+          display: "flex",
+          flexDirection: "column",
+          gap: "0.5rem",
+          padding: "0.85rem",
+          borderRadius: "0.85rem",
+          border: "1px solid var(--surface-muted)",
+          backgroundColor: wallet.isActive ? "var(--surface-base)" : "var(--surface-subtle)",
+          transition: "transform 150ms ease, box-shadow 150ms ease, border-color 150ms ease",
+          cursor: isInteractive ? "grab" : "default",
+          position: "relative",
+          minHeight: "160px"
+        };
+
+        if (!wallet.isActive) {
+          cardStyle.opacity = 0.85;
+        }
+
+        if (isIncomeTarget) {
+          cardStyle.border = "1px solid rgba(16, 185, 129, 0.65)";
+          cardStyle.boxShadow = "0 0 0 3px rgba(16, 185, 129, 0.2)";
+        }
+
+        if (isDropTarget) {
+          cardStyle.transform = "translateY(-3px) scale(1.04)";
+          cardStyle.boxShadow = "0 0 0 2px rgba(13, 148, 136, 0.2)";
+        }
+
+        const dragOffset =
+          isDragSource && dragOriginPosition && dragPointerPosition
+            ? dragVisualOffset ?? {
+                x: dragPointerPosition.x - dragOriginPosition.x,
+                y: dragPointerPosition.y - dragOriginPosition.y
+              }
+            : null;
+
+        if (dragOffset) {
+          const transforms: string[] = [];
+          transforms.push(`translate(${dragOffset.x}px, ${dragOffset.y}px) scale(1.05)`);
+          cardStyle.transform = transforms.join(" ");
+          cardStyle.boxShadow = "0 14px 28px rgba(12, 181, 154, 0.3)";
+          cardStyle.transformOrigin = "center";
+          cardStyle.zIndex = 10;
+          cardStyle.opacity = 1;
+          cardStyle.willChange = "transform";
+        }
+
+        return (
+          <article
+            key={wallet.id}
+            style={cardStyle}
+            data-wallet-card={wallet.name}
+            data-wallet-id={wallet.id}
+            data-wallet-interactive={isInteractive ? "true" : "false"}
+            onPointerDown={(event) => {
+              if (!isInteractive) {
+                return;
+              }
+
+              if (event.pointerType !== "touch" && event.button !== 0) {
+                return;
+              }
+
+              event.preventDefault();
+              const element = event.currentTarget as HTMLElement;
+              element.setPointerCapture?.(event.pointerId);
+              const rect = element.getBoundingClientRect();
+              onWalletPointerDown(
+                wallet.name,
+                {
+                  x: rect.left + rect.width / 2,
+                  y: rect.top + rect.height / 2
+                },
+                {
+                  x: event.clientX,
+                  y: event.clientY
+                }
+              );
+            }}
+            onPointerEnter={() => {
+              if (!isInteractive) {
+                return;
+              }
+
+              onWalletPointerEnter(wallet.name);
+            }}
+            onPointerLeave={() => {
+              if (!isInteractive) {
+                return;
+              }
+
+              onWalletPointerLeave(wallet.name);
+            }}
+            onPointerUp={(event) => {
+              if (!isInteractive) {
+                return;
+              }
+
+              if (event.pointerType !== "touch" && event.button !== 0) {
+                return;
+              }
+
+              event.preventDefault();
+              (event.currentTarget as HTMLElement).releasePointerCapture?.(event.pointerId);
+              onWalletPointerUp();
+            }}
+            onDragOver={(event) => {
+              if (!activeIncomeSource) {
+                return;
+              }
+
+              event.preventDefault();
+              handleIncomeDragEnter(wallet.id);
+            }}
+            onDragEnter={(event) => {
+              if (!activeIncomeSource) {
+                return;
+              }
+
+              event.preventDefault();
+              handleIncomeDragEnter(wallet.id);
+            }}
+            onDragLeave={() => {
+              if (!activeIncomeSource) {
+                return;
+              }
+
+              handleIncomeDragLeave(wallet.id);
+            }}
+            onDrop={(event) => {
+              if (!activeIncomeSource) {
+                return;
+              }
+
+              event.preventDefault();
+              handleIncomeDragLeave(wallet.id);
+              onIncomeDrop(wallet.id);
+            }}
+          >
+            <span
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                width: "1.75rem",
+                height: "1.75rem",
+                borderRadius: "999px",
+                backgroundColor: "var(--surface-subtle)",
+                fontSize: "0.95rem"
+              }}
+            >
+              {wallet.icon}
+            </span>
+            <span
+              style={{
+                fontSize: "0.68rem",
+                fontWeight: 600,
+                lineHeight: 1.2,
+                color: wallet.isActive ? "var(--text-primary)" : "var(--text-secondary)",
+                wordBreak: "break-word"
+              }}
+            >
+              {wallet.name}
+            </span>
+            <strong
+              style={{
+                fontSize: "0.82rem",
+                fontWeight: 600,
+                color: wallet.baseAmountFormatted.startsWith("-")
+                  ? "var(--accent-danger)"
+                  : "var(--accent-teal-strong)"
+              }}
+            >
+              {wallet.baseAmountFormatted}
+            </strong>
+            {wallet.walletCurrencyAmountFormatted ? (
+              <span style={{ fontSize: "0.64rem", color: "var(--text-secondary)" }}>
+                {wallet.walletCurrencyAmountFormatted}
+              </span>
+            ) : null}
+            {wallet.rubAmountFormatted ? (
+              <span style={{ fontSize: "0.64rem", color: "var(--text-secondary)" }}>
+                {wallet.rubAmountFormatted}
+              </span>
+            ) : null}
+            {!wallet.isActive ? (
+              <span style={{ fontSize: "0.62rem", color: "var(--text-muted)" }}>Архивный кошелёк</span>
+            ) : null}
+            {isMobile ? (
+              <button
+                type="button"
+                onClick={() => onAddIncomeClick(wallet.id)}
+                className="mt-auto inline-flex items-center justify-center rounded-lg border border-emerald-200 px-3 py-1.5 text-xs font-semibold text-emerald-600 transition hover:bg-emerald-50 focus:outline-none focus:ring-2 focus:ring-emerald-500/40 dark:border-emerald-700/50 dark:text-emerald-200 dark:hover:bg-emerald-900/40"
+              >
+                Добавить доход
+              </button>
+            ) : null}
+          </article>
+        );
+      })}
+    </div>
+  );
+};
+
+export type { WalletCard };
+export default WalletList;

--- a/components/PageContainer.tsx
+++ b/components/PageContainer.tsx
@@ -3,11 +3,11 @@ import type { ReactNode } from "react";
 import AppNavigation, { type AppTabKey } from "@/components/AppNavigation";
 
 type PageContainerProps = {
-  activeTab: AppTabKey;
+  activeTab?: AppTabKey;
   children: ReactNode;
 };
 
-const PageContainer = ({ activeTab, children }: PageContainerProps) => (
+const PageContainer = ({ activeTab = "home", children }: PageContainerProps) => (
   <main className="page-shell">
     <div className="flex w-full flex-col gap-10">
       <AppNavigation activeTab={activeTab} />


### PR DESCRIPTION
## Summary
- add dedicated wallet dashboard components for drag-and-drop income sources and expense handling with a shared transaction modal
- ensure mobile flows fall back to tap interactions while preserving existing wallet transfer behaviour
- expose a transactions API endpoint for income/expense persistence and make the page container tab optional by default

## Testing
- npm run lint *(fails: ESLint is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2f05da248331a16b4e1c281caa5c