### PR TITLE
feat: redesign wallet dashboard with transactions

### DIFF
--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -1,0 +1,212 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { Prisma, type Operation as PrismaOperation } from "@prisma/client";
+
+import { ensureAccountant } from "@/lib/auth";
+import { sanitizeCurrency } from "@/lib/currency";
+import { appendDebtPaymentSource } from "@/lib/debtPayments";
+import prisma from "@/lib/prisma";
+import { recalculateGoalProgress } from "@/lib/goals";
+import { loadSettings } from "@/lib/settingsService";
+import { serializeOperation } from "@/lib/serializers";
+
+const normalize = (value: unknown) => (typeof value === "string" ? value.trim() : "");
+
+const errorResponse = (message: string, status = 400) =>
+  NextResponse.json({ error: message }, { status });
+
+type TransactionPayload = {
+  walletId?: string;
+  type?: "INCOME" | "EXPENSE";
+  amount?: number;
+  date?: string;
+  description?: string;
+  sourceOrCategory?: string;
+};
+
+const toOperationType = (type: TransactionPayload["type"]) => {
+  if (type === "INCOME") {
+    return "income" as const;
+  }
+
+  if (type === "EXPENSE") {
+    return "expense" as const;
+  }
+
+  return null;
+};
+
+const parseDateValue = (value: string | undefined) => {
+  if (!value) {
+    return new Date();
+  }
+
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+
+  return parsed;
+};
+
+const applyExpenseToDebts = async (
+  tx: Prisma.TransactionClient,
+  operation: PrismaOperation,
+  category: string
+) => {
+  if (operation.type !== "expense") {
+    return new Prisma.Decimal(0);
+  }
+
+  const debts = await tx.debt.findMany({
+    where: {
+      status: "open",
+      currency: operation.currency,
+      OR: [
+        {
+          from_contact: {
+            equals: category,
+            mode: "insensitive"
+          }
+        },
+        {
+          to_contact: {
+            equals: category,
+            mode: "insensitive"
+          }
+        }
+      ]
+    },
+    orderBy: { registered_at: "asc" }
+  });
+
+  if (debts.length === 0) {
+    return new Prisma.Decimal(0);
+  }
+
+  const originalAmount = new Prisma.Decimal(operation.amount);
+  let remainingPayment = new Prisma.Decimal(operation.amount);
+
+  for (const debt of debts) {
+    if (remainingPayment.lte(0)) {
+      break;
+    }
+
+    const debtAmount = new Prisma.Decimal(debt.amount);
+    const placeholderSource = `debt:${debt.id}`;
+
+    const paymentToApply = remainingPayment.gte(debtAmount)
+      ? debtAmount
+      : remainingPayment;
+    const updatedAmount = debtAmount.minus(paymentToApply);
+
+    if (updatedAmount.lte(0)) {
+      await tx.debt.delete({ where: { id: debt.id } });
+    } else {
+      await tx.debt.update({
+        where: { id: debt.id },
+        data: { amount: updatedAmount }
+      });
+    }
+
+    await tx.operation.deleteMany({ where: { source: placeholderSource } });
+
+    remainingPayment = remainingPayment.minus(paymentToApply);
+  }
+
+  return originalAmount.minus(remainingPayment);
+};
+
+export const POST = async (request: NextRequest) => {
+  const auth = await ensureAccountant(request);
+
+  if (auth.response) {
+    return auth.response;
+  }
+
+  const payload = (await request.json().catch(() => null)) as TransactionPayload | null;
+
+  if (!payload) {
+    return errorResponse("Некорректные данные");
+  }
+
+  const walletId = normalize(payload.walletId);
+
+  if (!walletId) {
+    return errorResponse("Укажите кошелёк");
+  }
+
+  const operationType = toOperationType(payload.type);
+
+  if (!operationType) {
+    return errorResponse("Некорректный тип транзакции");
+  }
+
+  if (typeof payload.amount !== "number" || !Number.isFinite(payload.amount) || payload.amount <= 0) {
+    return errorResponse("Введите корректную сумму");
+  }
+
+  const category = normalize(payload.sourceOrCategory);
+
+  if (!category) {
+    return errorResponse(
+      operationType === "income"
+        ? "Выберите источник дохода"
+        : "Выберите категорию расхода"
+    );
+  }
+
+  const occurredAt = parseDateValue(payload.date);
+
+  if (!occurredAt) {
+    return errorResponse("Укажите корректную дату");
+  }
+
+  const wallet = await prisma.wallet.findUnique({ where: { wallet: walletId } });
+
+  if (!wallet) {
+    return errorResponse("Кошелёк не найден", 404);
+  }
+
+  const settings = await loadSettings();
+  const currency = sanitizeCurrency(wallet.currency, settings.baseCurrency);
+  const comment = normalize(payload.description);
+
+  const operation = await prisma.$transaction(async (tx) => {
+    let created = await tx.operation.create({
+      data: {
+        id: crypto.randomUUID(),
+        type: operationType,
+        amount: payload.amount,
+        currency,
+        category,
+        wallet: wallet.display_name,
+        comment: comment || null,
+        source: operationType === "income" ? category : null,
+        occurred_at: occurredAt
+      }
+    });
+
+    if (created.type === "expense") {
+      const appliedAmount = await applyExpenseToDebts(tx, created, category);
+
+      if (appliedAmount.gt(0)) {
+        const updatedSource = appendDebtPaymentSource(created.source, appliedAmount.toString());
+
+        created = await tx.operation.update({
+          where: { id: created.id },
+          data: { source: updatedSource || null }
+        });
+      }
+    }
+
+    return created;
+  });
+
+  await recalculateGoalProgress();
+
+  return NextResponse.json(
+    { transaction: serializeOperation(operation) },
+    { status: 201 }
+  );
+};

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,1229 +1,338 @@
 "use client";
 
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  type ChangeEvent,
-  type FormEvent
-} from "react";
+import { useMemo, useState, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
 import useSWR from "swr";
+
 import AuthGate from "@/components/AuthGate";
 import PageContainer from "@/components/PageContainer";
+import TransactionModal from "@/components/TransactionModal";
+import { type TransactionFormState, type TransactionType } from "@/components/TransactionForm";
+import WalletTable, { type WalletRow } from "@/components/WalletTable";
 import { useSession } from "@/components/SessionProvider";
-import {
-  convertToBase,
-  DEFAULT_SETTINGS,
-  SUPPORTED_CURRENCIES
-} from "@/lib/currency";
-import {
-  type Currency,
-  type Debt,
-  type Goal,
-  type Operation,
-  type Settings,
-  type Wallet,
-  type WalletWithCurrency
-} from "@/lib/types";
-import { extractDebtPaymentAmount } from "@/lib/debtPayments";
+import type { Operation, WalletWithCurrency } from "@/lib/types";
 
-const fetcher = (url: string) => fetch(url).then((res) => res.json());
+const fetcher = async (url: string) => {
+  const response = await fetch(url);
 
-type CategoriesResponse = {
-  income: string[];
-  expense: string[];
+  if (!response.ok) {
+    throw new Error("Не удалось загрузить данные");
+  }
+
+  return response.json() as Promise<unknown>;
 };
 
 type WalletsResponse = {
   wallets: WalletWithCurrency[];
 };
 
-const getWalletIcon = (walletName: string) => {
-  const normalized = walletName.toLowerCase();
+type OperationsResponse = Operation[];
 
-  if (/(карта|card)/.test(normalized)) {
-    return "💳";
+const categorizeWallet = (name: string) => {
+  const normalized = name.toLowerCase();
+
+  if (/карта|card|visa|master|дебет|credit/.test(normalized)) {
+    return "Карта";
   }
 
-  if (/(банк|account|сч[её]т|bank)/.test(normalized)) {
-    return "🏦";
+  if (/банк|account|сч[её]т|депозит/.test(normalized)) {
+    return "Счёт";
   }
 
-  if (/(нал|cash)/.test(normalized)) {
-    return "💵";
+  if (/нал|cash/.test(normalized)) {
+    return "Наличные";
   }
 
-  if (/(crypto|крипт)/.test(normalized)) {
-    return "🪙";
+  if (/крипт|crypto|btc|eth/.test(normalized)) {
+    return "Крипто";
   }
 
-  return "👛";
+  return "Кошелёк";
+};
+
+const createInitialFormState = (type: TransactionType): TransactionFormState => ({
+  amount: "",
+  date: new Date().toISOString().slice(0, 10),
+  description: "",
+  sourceOrCategory: type === "INCOME" ? "Зарплата" : "Еда"
+});
+
+const formatAmount = (value: number, currency: string) => {
+  const formatter = new Intl.NumberFormat("ru-RU", {
+    style: "currency",
+    currency
+  });
+
+  return formatter.format(value);
+};
+
+const formatDate = (dateString: string) => {
+  const date = new Date(dateString);
+
+  if (Number.isNaN(date.getTime())) {
+    return "-";
+  }
+
+  return date.toLocaleDateString("ru-RU", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric"
+  });
 };
 
 const Dashboard = () => {
-  const { user, refresh } = useSession();
-  const canManage = (user?.role ?? "") === "admin";
+  const router = useRouter();
+  const { user } = useSession();
 
-  const [operations, setOperations] = useState<Operation[]>([]);
-  const [goals, setGoals] = useState<Goal[]>([]);
-  const [amount, setAmount] = useState<string>("");
-  const [type, setType] = useState<Operation["type"]>("income");
-  const [category, setCategory] = useState<string>("");
-  const [comment, setComment] = useState<string>("");
-  const [currency, setCurrency] = useState<Currency>(DEFAULT_SETTINGS.baseCurrency);
-  const [wallets, setWallets] = useState<WalletWithCurrency[]>([]);
-  const [wallet, setWallet] = useState<Wallet>("");
-  const [debts, setDebts] = useState<Debt[]>([]);
-  const [settings, setSettings] = useState<Settings | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [deletingId, setDeletingId] = useState<string | null>(null);
-  const [isCommentModalOpen, setIsCommentModalOpen] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [incomeCategories, setIncomeCategories] = useState<string[]>([]);
-  const [expenseBaseCategories, setExpenseBaseCategories] = useState<string[]>([]);
-  const [showBalanceDetails, setShowBalanceDetails] = useState(false);
+  const { data: walletsData, isLoading: walletsLoading } = useSWR<WalletsResponse>(
+    user ? "/api/wallets" : null,
+    fetcher,
+    { revalidateOnFocus: true }
+  );
 
   const {
     data: operationsData,
-    error: operationsError,
     isLoading: operationsLoading,
     mutate: mutateOperations
-  } = useSWR<Operation[]>(user ? "/api/operations" : null, fetcher, {
-    revalidateOnFocus: true,
-    refreshInterval: 60000
-  });
-
-  const {
-    data: debtsData,
-    error: debtsError,
-    isLoading: debtsLoading
-  } = useSWR<Debt[]>(user ? "/api/debts" : null, fetcher, {
-    revalidateOnFocus: true,
-    refreshInterval: 60000
-  });
-
-  const {
-    data: goalsData,
-    error: goalsError,
-    isLoading: goalsLoading,
-    mutate: mutateGoals
-  } = useSWR<Goal[]>(user ? "/api/goals" : null, fetcher, {
+  } = useSWR<OperationsResponse>(user ? "/api/operations" : null, fetcher, {
+    refreshInterval: 60000,
     revalidateOnFocus: true
   });
 
-  const {
-    data: settingsData,
-    error: settingsError,
-    isLoading: settingsLoading
-  } = useSWR<Settings>(user ? "/api/settings" : null, fetcher, {
-    revalidateOnFocus: true
-  });
+  const [selectedWalletId, setSelectedWalletId] = useState<string | null>(null);
+  const [selectedWalletName, setSelectedWalletName] = useState<string | null>(null);
+  const [transactionType, setTransactionType] = useState<TransactionType | null>(null);
+  const [formState, setFormState] = useState<TransactionFormState>(() => createInitialFormState("INCOME"));
+  const [formError, setFormError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
 
-  const {
-    data: categoriesData,
-    error: categoriesError,
-    isLoading: categoriesLoading
-  } = useSWR<CategoriesResponse>(user ? "/api/categories" : null, fetcher, {
-    revalidateOnFocus: true
-  });
+  const walletMap = useMemo(() => {
+    const map = new Map<string, WalletWithCurrency>();
 
-  const {
-    data: walletsData,
-    error: walletsError,
-    isLoading: walletsLoading
-  } = useSWR<WalletsResponse>(user ? "/api/wallets" : null, fetcher, {
-    revalidateOnFocus: true
-  });
-
-  const initialLoading =
-    operationsLoading ||
-    debtsLoading ||
-    goalsLoading ||
-    settingsLoading ||
-    categoriesLoading ||
-    walletsLoading;
-
-  const hasDataError = Boolean(
-    operationsError ||
-      debtsError ||
-      goalsError ||
-      settingsError ||
-      categoriesError ||
-      walletsError
-  );
-
-  useEffect(() => {
-    if (operationsData) {
-      setOperations(operationsData);
-    }
-  }, [operationsData]);
-
-  useEffect(() => {
-    if (debtsData) {
-      setDebts(debtsData);
-    }
-  }, [debtsData]);
-
-  useEffect(() => {
-    if (goalsData) {
-      setGoals(goalsData);
-    }
-  }, [goalsData]);
-
-  useEffect(() => {
-    if (settingsData) {
-      setSettings(settingsData);
-      setCurrency(settingsData.baseCurrency);
-    }
-  }, [settingsData]);
-
-  useEffect(() => {
-    if (categoriesData) {
-      setIncomeCategories(categoriesData.income);
-      setExpenseBaseCategories(categoriesData.expense);
-    }
-  }, [categoriesData]);
-
-  useEffect(() => {
-    if (!walletsData) {
-      return;
-    }
-
-    const walletList = Array.isArray(walletsData.wallets) ? walletsData.wallets : [];
-    setWallets(walletList);
-    setWallet((current) => {
-      if (walletList.length === 0) {
-        return "";
-      }
-
-      if (current) {
-        const matched = walletList.find(
-          (item) => item.name.toLowerCase() === current.toLowerCase()
-        );
-
-        if (matched) {
-          return matched.name;
-        }
-      }
-
-      return walletList[0].name;
+    walletsData?.wallets.forEach((wallet) => {
+      map.set(wallet.id, wallet);
+      map.set(wallet.name.toLowerCase(), wallet);
     });
+
+    return map;
   }, [walletsData]);
 
-  const reloadGoals = useCallback(async () => {
-    try {
-      const data = await mutateGoals();
+  const wallets: WalletRow[] = useMemo(() => {
+    if (!walletsData?.wallets) {
+      return [];
+    }
 
-      if (!data) {
-        throw new Error("Ошибка загрузки");
+    const balances = new Map<string, number>();
+    const operations = operationsData ?? [];
+
+    for (const operation of operations) {
+      const wallet = walletMap.get(operation.wallet.toLowerCase());
+
+      if (!wallet) {
+        continue;
       }
 
-      setGoals(data);
-      return data;
-    } catch (err) {
-      setError("Ошибка загрузки");
-      throw err;
+      if (operation.currency !== wallet.currency) {
+        continue;
+      }
+
+      const current = balances.get(wallet.id) ?? 0;
+      const delta = operation.type === "income" ? operation.amount : -operation.amount;
+
+      balances.set(wallet.id, current + delta);
     }
-  }, [mutateGoals]);
 
-  const expenseOptions = useMemo(
-    () =>
-      Array.from(
-        new Set([
-          ...expenseBaseCategories,
-          ...goals.map((goal) => goal.title)
-        ])
-      ),
-    [expenseBaseCategories, goals]
-  );
+    return walletsData.wallets.map<WalletRow>((wallet) => ({
+      id: wallet.id,
+      name: wallet.name,
+      currency: wallet.currency,
+      balance: Number((balances.get(wallet.id) ?? 0).toFixed(2)),
+      category: categorizeWallet(wallet.name)
+    }));
+  }, [operationsData, walletMap, walletsData]);
 
-  const categorySuggestions = useMemo(() => {
-    const baseCategories = type === "income" ? incomeCategories : expenseOptions;
-    const relevantOperations = operations.filter((operation) => operation.type === type);
-    const seen = new Set<string>();
-    const addUnique = (list: string[], acc: string[]) => {
-      list.forEach((item) => {
-        const normalized = item.trim();
-        if (!normalized) {
-          return;
-        }
+  const latestTransactions = useMemo(() => {
+    if (!operationsData) {
+      return [];
+    }
 
-        const key = normalized.toLowerCase();
-        if (seen.has(key)) {
-          return;
-        }
+    return operationsData.slice(0, 6);
+  }, [operationsData]);
 
-        seen.add(key);
-        acc.push(normalized);
-      });
+  const handleOpenTransaction = (walletId: string, type: TransactionType) => {
+    const wallet = walletMap.get(walletId) ?? walletMap.get(walletId.toLowerCase());
 
-      return acc;
-    };
-
-    const recentCategories = relevantOperations.map((operation) => operation.category);
-    const combined = addUnique(recentCategories, []);
-    addUnique(baseCategories, combined);
-
-    return combined.slice(0, 10);
-  }, [type, incomeCategories, expenseOptions, operations]);
-
-  useEffect(() => {
-    if (categorySuggestions.length === 0) {
-      setCategory("");
+    if (!wallet) {
       return;
     }
 
-    setCategory((current) => {
-      if (current) {
-        const matched = categorySuggestions.find(
-          (item) => item.toLowerCase() === current.toLowerCase()
-        );
+    setSelectedWalletId(wallet.id);
+    setSelectedWalletName(wallet.name);
+    setTransactionType(type);
+    setFormState(createInitialFormState(type));
+    setFormError(null);
+  };
 
-        if (matched) {
-          return matched;
-        }
-      }
+  const handleCloseModal = () => {
+    setSelectedWalletId(null);
+    setSelectedWalletName(null);
+    setTransactionType(null);
+    setFormError(null);
+  };
 
-      return categorySuggestions[0];
-    });
-  }, [categorySuggestions]);
-
-  const handleAmountChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
-    const rawValue = event.target.value.replace(",", ".");
-
-    if (rawValue === "") {
-      setAmount("");
-      return;
-    }
-
-    if (rawValue.startsWith("-")) {
-      return;
-    }
-
-    if (!/^\d*\.?\d*$/.test(rawValue)) {
-      return;
-    }
-
-    setAmount(rawValue);
-  }, []);
-
-  const handleQuickAmount = useCallback((increment: number) => {
-    setAmount((current) => {
-      const normalizedCurrent = current.replace(",", ".");
-      const currentValue = Number.parseFloat(normalizedCurrent);
-      const baseValue = Number.isFinite(currentValue) ? currentValue : 0;
-      const nextValue = Math.max(0, baseValue + increment);
-
-      if (nextValue === 0) {
-        return "";
-      }
-
-      return nextValue.toFixed(2);
-    });
-  }, []);
-
-  useEffect(() => {
-    if (wallets.length === 0) {
-      if (wallet !== "") {
-        setWallet("");
-      }
-      return;
-    }
-
-    if (!wallets.some((item) => item.name.toLowerCase() === wallet.toLowerCase())) {
-      setWallet(wallets[0]?.name ?? "");
-    }
-  }, [wallets, wallet]);
-
-  const goalCategorySet = useMemo(
-    () => new Set(goals.map((goal) => goal.title.toLowerCase())),
-    [goals]
-  );
-
-  const debtSummary = useMemo(() => {
-    const activeSettings = settings ?? DEFAULT_SETTINGS;
-
-    return debts.reduce(
-      (acc, debt) => {
-        if (debt.status === "closed") {
-          return acc;
-        }
-
-        const amountInBase = convertToBase(debt.amount, debt.currency, activeSettings);
-        const affectsBalance = debt.existing !== true;
-
-        if (debt.type === "borrowed") {
-          return {
-            ...acc,
-            borrowed: acc.borrowed + amountInBase,
-            balanceEffect: affectsBalance
-              ? acc.balanceEffect + amountInBase
-              : acc.balanceEffect
-          };
-        }
-
-        return {
-          ...acc,
-          lent: acc.lent + amountInBase,
-          balanceEffect: affectsBalance
-            ? acc.balanceEffect + amountInBase
-            : acc.balanceEffect
-        };
-      },
-      { borrowed: 0, lent: 0, balanceEffect: 0 }
-    );
-  }, [debts, settings]);
-
-  const { balanceEffect, borrowed, lent } = debtSummary;
-
-  const balance = useMemo(() => {
-    const activeSettings = settings ?? DEFAULT_SETTINGS;
-
-    const operationsBalance = operations.reduce((acc, operation) => {
-      if (operation.type === "expense" && goalCategorySet.has(operation.category.toLowerCase())) {
-        return acc;
-      }
-
-      const amountInBase = convertToBase(operation.amount, operation.currency, activeSettings);
-
-      if (operation.type === "income") {
-        return acc + amountInBase;
-      }
-
-      let nextValue = acc - amountInBase;
-      const debtPaymentAmount = extractDebtPaymentAmount(operation.source);
-
-      if (debtPaymentAmount > 0) {
-        const paymentInBase = convertToBase(debtPaymentAmount, operation.currency, activeSettings);
-        nextValue += paymentInBase;
-      }
-
-      return nextValue;
-    }, 0);
-
-    return operationsBalance + balanceEffect;
-  }, [operations, balanceEffect, goalCategorySet, settings]);
-
-  const netBalance = useMemo(
-    () => balance - borrowed + lent,
-    [balance, borrowed, lent]
-  );
-
-  const activeSettings = settings ?? DEFAULT_SETTINGS;
-  const balanceFormatter = useMemo(
-    () =>
-      new Intl.NumberFormat("ru-RU", {
-        style: "currency",
-        currency: activeSettings.baseCurrency
-      }),
-    [activeSettings.baseCurrency]
-  );
+  const handleFieldChange = <Key extends keyof TransactionFormState>(
+    key: Key,
+    value: TransactionFormState[Key]
+  ) => {
+    setFormState((prev) => ({ ...prev, [key]: value }));
+  };
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    setError(null);
 
-    if (!canManage) {
-      setError("Недостаточно прав для добавления операции");
+    if (!selectedWalletId || !transactionType) {
       return;
     }
 
-    if (!category) {
-      setError("Выберите категорию");
-      return;
-    }
-
-    if (!wallet) {
-      setError("Выберите кошелёк");
-      return;
-    }
-
-    const numericAmount = Number(amount);
-    const selectedType = type;
-    const selectedCategory = category;
+    const numericAmount = Number.parseFloat(formState.amount);
 
     if (!Number.isFinite(numericAmount) || numericAmount <= 0) {
-      setError("Введите корректную сумму больше нуля");
+      setFormError("Введите корректную сумму");
       return;
     }
 
-    setLoading(true);
+    if (!formState.sourceOrCategory) {
+      setFormError(
+        transactionType === "INCOME"
+          ? "Выберите источник дохода"
+          : "Выберите категорию расхода"
+      );
+      return;
+    }
+
+    setIsSaving(true);
+    setFormError(null);
 
     try {
-      const response = await fetch("/api/operations", {
+      const response = await fetch("/api/transactions", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json"
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          type: selectedType,
+          walletId: selectedWalletId,
+          type: transactionType,
           amount: numericAmount,
-          currency,
-          category: selectedCategory,
-          wallet,
-          comment: comment.trim() ? comment.trim() : null,
-          source: null
+          date: formState.date || undefined,
+          description: formState.description.trim() ? formState.description.trim() : undefined,
+          sourceOrCategory: formState.sourceOrCategory
         })
       });
 
-      if (response.status === 401) {
-        setError("Сессия истекла, войдите заново.");
-        await refresh();
-        return;
-      }
-
-      if (response.status === 403) {
-        setError("Недостаточно прав для добавления операции");
-        return;
-      }
-
       if (!response.ok) {
-        throw new Error("Не удалось сохранить операцию");
+        const data = (await response.json().catch(() => null)) as { error?: unknown } | null;
+        const message =
+          data && typeof data.error === "string"
+            ? data.error
+            : "Не удалось сохранить транзакцию";
+
+        setFormError(message);
+        return;
       }
 
-      const operationsData = await mutateOperations();
-      if (operationsData) {
-        setOperations(operationsData);
-      }
-      setAmount("");
-      setType("income");
-      setComment("");
-
-      if (selectedType === "expense" && goalCategorySet.has(selectedCategory.toLowerCase())) {
-        try {
-          await reloadGoals();
-        } catch {
-          // Ошибка уже отображается пользователю через setError
-        }
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Произошла ошибка");
+      await mutateOperations();
+      router.refresh();
+      handleCloseModal();
+    } catch (error) {
+      console.error(error);
+      setFormError("Не удалось сохранить транзакцию");
     } finally {
-      setLoading(false);
+      setIsSaving(false);
     }
   };
-
-  const handleDelete = async (id: string) => {
-    if (!canManage) {
-      setError("Недостаточно прав для удаления операции");
-      return;
-    }
-
-    setError(null);
-    setDeletingId(id);
-
-    try {
-      const response = await fetch(`/api/operations/${id}`, {
-        method: "DELETE"
-      });
-
-      if (response.status === 401) {
-        setError("Сессия истекла, войдите заново.");
-        await refresh();
-        return;
-      }
-
-      if (response.status === 403) {
-        setError("Недостаточно прав для удаления операции");
-        return;
-      }
-
-      if (!response.ok) {
-        throw new Error("Не удалось удалить операцию");
-      }
-
-      const deleted = (await response.json()) as Operation;
-
-      setOperations((prev) => prev.filter((operation) => operation.id !== id));
-      void mutateOperations();
-
-      if (deleted.type === "expense" && goalCategorySet.has(deleted.category.toLowerCase())) {
-        void reloadGoals().catch(() => undefined);
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Произошла ошибка");
-    } finally {
-      setDeletingId(null);
-    }
-  };
-  if (!user) {
-    return null;
-  }
 
   return (
-    <PageContainer activeTab="home">
-      <header
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          gap: "0.75rem"
-        }}
-      >
-        <h1 style={{ fontSize: "clamp(1.75rem, 5vw, 2.25rem)", fontWeight: 700 }}>
-          Бухгалтерия ISCKON Batumi
-        </h1>
-      </header>
-
-      {initialLoading ? (
-        <p style={{ color: "var(--text-muted)" }}>Загрузка...</p>
-      ) : hasDataError ? (
-        <p style={{ color: "var(--accent-danger)" }}>Ошибка загрузки</p>
-      ) : (
-        <>
-          <section style={{ display: "flex", flexDirection: "column", gap: "1.75rem" }}>
-            <div
-              style={{
-                display: "flex",
-                justifyContent: "space-between",
-                alignItems: "center",
-                flexWrap: "wrap",
-                gap: "1rem"
-              }}
-            >
-              <h2 style={{ fontSize: "clamp(1.25rem, 4.5vw, 1.5rem)", fontWeight: 600 }}>
-                Текущий баланс
-              </h2>
-              <strong
-                style={{
-                  fontSize: "clamp(2rem, 5.5vw, 2.75rem)",
-                  fontWeight: 700,
-                  color: balance >= 0 ? "var(--accent-success)" : "var(--accent-danger)"
-                }}
-              >
-                {balanceFormatter.format(balance)}
-              </strong>
-            </div>
-
-            <details
-              className="rounded-2xl shadow-lg"
-              style={{
-                backgroundColor: "var(--surface-subtle)",
-                overflow: "hidden"
-              }}
-              open={showBalanceDetails}
-              onToggle={(event) => {
-                setShowBalanceDetails(event.currentTarget.open);
-              }}
-            >
-              <summary
-                style={{
-                  cursor: "pointer",
-                  listStyle: "none",
-                  padding: "1rem 1.25rem",
-                  fontWeight: 600,
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "space-between",
-                  gap: "0.5rem"
-                }}
-                aria-expanded={showBalanceDetails}
-              >
-                Подробнее
-                <span
-                  aria-hidden="true"
-                  style={{
-                    fontSize: "1.25rem",
-                    lineHeight: 1,
-                    transform: showBalanceDetails ? "rotate(180deg)" : "rotate(0deg)",
-                    transition: "transform 0.2s ease"
-                  }}
-                >
-                  ⌄
-                </span>
-              </summary>
-              <div
-                style={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  alignItems: "center",
-                  gap: "1rem",
-                  padding: "1rem 1.25rem",
-                  borderTop: "1px solid var(--border-muted)"
-                }}
-              >
-                <h3 style={{ fontSize: "1.1rem", fontWeight: 600 }}>
-                  Чистый баланс (учитывает долги и активы)
-                </h3>
-                <strong
-                  style={{
-                    fontSize: "clamp(1.45rem, 4.5vw, 1.75rem)",
-                    color:
-                      netBalance >= 0
-                        ? "var(--accent-success)"
-                        : "var(--accent-danger)"
-                  }}
-                >
-                  {balanceFormatter.format(netBalance)}
-                </strong>
+    <AuthGate>
+      <PageContainer>
+        <div className="flex flex-col gap-10">
+          <section className="flex flex-col gap-6">
+            <header className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+              <div className="flex flex-col gap-1">
+                <h1 className="text-3xl font-semibold text-[var(--text-strong)]">Мои кошельки</h1>
+                <p className="text-sm text-[var(--text-muted)]">
+                  Управляйте балансом счетов и добавляйте транзакции в пару кликов.
+                </p>
               </div>
-            </details>
-
-            <form
-            onSubmit={handleSubmit}
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              gap: "1.75rem",
-              background: "rgba(12, 15, 35, 0.9)",
-              padding: "2rem",
-              borderRadius: "1.5rem",
-              border: "1px solid rgba(99, 102, 241, 0.25)",
-              boxShadow: "0 24px 60px rgba(8, 12, 30, 0.55)",
-              position: "relative",
-              overflow: "hidden"
-            }}
-          >
-            <label style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
-              <span style={{ fontSize: "0.95rem", color: "var(--text-muted)" }}>Тип операции</span>
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "space-between",
-                  gap: "1rem",
-                  padding: "0.9rem 1.1rem",
-                  borderRadius: "1.25rem",
-                  background: "rgba(30, 41, 59, 0.65)",
-                  border: "1px solid rgba(79, 70, 229, 0.35)",
-                  boxShadow: "inset 0 0 0 1px rgba(15, 23, 42, 0.4)",
-                  backdropFilter: "blur(14px)",
-                  transition: "border 0.3s ease, background 0.3s ease"
-                }}
-              >
-                <span style={{ color: "var(--text-muted)", fontWeight: 500 }}>Приход / расход</span>
-                <button
-                  type="button"
-                  onClick={() => setType(type === "income" ? "expense" : "income")}
-                  disabled={!canManage || loading}
-                  aria-pressed={type === "income"}
-                  style={{
-                    position: "relative",
-                    width: "7rem",
-                    height: "2.8rem",
-                    borderRadius: "9999px",
-                    border: "1px solid rgba(255, 255, 255, 0.12)",
-                    background:
-                      type === "income"
-                        ? "linear-gradient(135deg, rgba(52, 211, 153, 0.9), rgba(110, 231, 183, 0.45))"
-                        : "linear-gradient(135deg, rgba(248, 113, 113, 0.9), rgba(248, 113, 113, 0.4))",
-                    color: "var(--text-on-primary)",
-                    fontSize: "0.75rem",
-                    fontWeight: 700,
-                    letterSpacing: "0.03em",
-                    cursor: !canManage || loading ? "not-allowed" : "pointer",
-                    transition: "background 0.3s ease, transform 0.3s ease"
-                  }}
-                >
-                  <span
-                    style={{
-                      position: "absolute",
-                      inset: "6px",
-                      width: "calc(50% - 6px)",
-                      borderRadius: "9999px",
-                      background: "rgba(15, 23, 42, 0.35)",
-                      transform: type === "income" ? "translateX(0)" : "translateX(100%)",
-                      transition: "transform 0.3s ease"
-                    }}
-                  />
-                  <span
-                    style={{
-                      position: "absolute",
-                      top: "50%",
-                      left: "20%",
-                      transform: "translate(-50%, -50%)",
-                      fontSize: "0.85rem"
-                    }}
-                  >
-                    🟢
-                  </span>
-                  <span
-                    style={{
-                      position: "absolute",
-                      top: "50%",
-                      right: "18%",
-                      transform: "translate(50%, -50%)",
-                      fontSize: "0.85rem"
-                    }}
-                  >
-                    🔴
-                  </span>
-                </button>
-              </div>
-            </label>
-
-            <label style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
-              <span style={{ fontSize: "0.95rem", color: "var(--text-muted)" }}>Сумма</span>
-              <div
-                style={{
-                  background: "rgba(15, 23, 42, 0.8)",
-                  borderRadius: "1.75rem",
-                  padding: "1.6rem 1.25rem",
-                  border: "1px solid rgba(59, 130, 246, 0.25)",
-                  display: "flex",
-                  flexDirection: "column",
-                  gap: "1.3rem",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  backdropFilter: "blur(18px)",
-                  boxShadow: "0 14px 45px rgba(30, 64, 175, 0.35)",
-                  transition: "border 0.3s ease, box-shadow 0.3s ease"
-                }}
-              >
-                <input
-                  type="number"
-                  min="0"
-                  step="0.01"
-                  value={amount}
-                  onChange={handleAmountChange}
-                  disabled={!canManage || loading}
-                  placeholder="Сумма"
-                  inputMode="decimal"
-                  style={{
-                    width: "100%",
-                    textAlign: "center",
-                    fontSize: "2.6rem",
-                    fontWeight: 700,
-                    background: "transparent",
-                    border: "none",
-                    color: "var(--text-primary)",
-                    outline: "none",
-                    letterSpacing: "0.03em"
-                  }}
-                />
-                <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap", justifyContent: "center" }}>
-                  {[10, 50, 100].map((value) => (
-                    <button
-                      key={value}
-                      type="button"
-                      onClick={() => handleQuickAmount(value)}
-                      disabled={!canManage || loading}
-                      style={{
-                        padding: "0.45rem 1.2rem",
-                        borderRadius: "9999px",
-                        border: "1px solid rgba(148, 163, 184, 0.35)",
-                        backgroundColor: "rgba(30, 41, 59, 0.65)",
-                        color: "var(--text-muted)",
-                        fontSize: "0.9rem",
-                        fontWeight: 600,
-                        cursor: !canManage || loading ? "not-allowed" : "pointer",
-                        transition: "transform 0.2s ease, box-shadow 0.2s ease, border 0.2s ease"
-                      }}
-                      aria-label={`Добавить ${value}`}
-                      onMouseEnter={(event) => {
-                        event.currentTarget.style.transform = "translateY(-2px)";
-                        event.currentTarget.style.border = "1px solid rgba(129, 140, 248, 0.7)";
-                        event.currentTarget.style.boxShadow = "0 8px 20px rgba(129, 140, 248, 0.25)";
-                        event.currentTarget.style.color = "var(--text-primary)";
-                      }}
-                      onMouseLeave={(event) => {
-                        event.currentTarget.style.transform = "translateY(0)";
-                        event.currentTarget.style.border = "1px solid rgba(148, 163, 184, 0.35)";
-                        event.currentTarget.style.boxShadow = "none";
-                        event.currentTarget.style.color = "var(--text-muted)";
-                      }}
-                    >
-                      +{value}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            </label>
-
-            <label style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
-              <span style={{ fontSize: "0.95rem", color: "var(--text-muted)" }}>Валюта</span>
-              <div
-                style={{
-                  display: "flex",
-                  gap: "0.4rem",
-                  padding: "0.3rem",
-                  borderRadius: "9999px",
-                  background: "rgba(15, 23, 42, 0.8)",
-                  border: "1px solid rgba(139, 92, 246, 0.35)",
-                  backdropFilter: "blur(12px)",
-                  transition: "border 0.3s ease"
-                }}
-              >
-                {SUPPORTED_CURRENCIES.map((item) => {
-                  const isActive = currency === item;
-
-                  return (
-                    <button
-                      key={item}
-                      type="button"
-                      onClick={() => setCurrency(item)}
-                      disabled={!canManage || loading}
-                      style={{
-                        flex: 1,
-                        padding: "0.55rem 1.15rem",
-                        borderRadius: "9999px",
-                        border: isActive ? "1px solid transparent" : "1px solid rgba(148, 163, 184, 0.35)",
-                        background: isActive
-                          ? "linear-gradient(135deg, rgba(129, 140, 248, 0.95), rgba(56, 189, 248, 0.85))"
-                          : "transparent",
-                        color: isActive ? "#0f172a" : "var(--text-muted)",
-                        fontSize: "0.9rem",
-                        fontWeight: 700,
-                        cursor: !canManage || loading ? "not-allowed" : "pointer",
-                        transition: "all 0.25s ease"
-                      }}
-                      aria-pressed={isActive}
-                    >
-                      {item}
-                    </button>
-                  );
-                })}
-              </div>
-            </label>
-
-            <div style={{ display: "flex", flexDirection: "column", gap: "1.2rem" }}>
-              <label style={{ display: "flex", flexDirection: "column", gap: "0.55rem" }}>
-                <span style={{ fontSize: "0.95rem", color: "var(--text-muted)" }}>Кошелёк</span>
-                <div
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: "0.75rem",
-                    padding: "0.75rem 1rem",
-                    borderRadius: "1.1rem",
-                    background: "rgba(15, 23, 42, 0.75)",
-                    border: "1px solid rgba(148, 163, 184, 0.25)"
-                  }}
-                >
-                  <span aria-hidden style={{ fontSize: "1.1rem" }}>
-                    {wallet ? getWalletIcon(wallet) : "👛"}
-                  </span>
-                  <select
-                    value={wallet}
-                    onChange={(event) => setWallet(event.target.value)}
-                    disabled={!canManage || loading || wallets.length === 0}
-                    style={{
-                      flex: 1,
-                      background: "transparent",
-                      border: "none",
-                      color: "var(--text-primary)",
-                      fontSize: "1rem",
-                      fontWeight: 500,
-                      outline: "none"
-                    }}
-                  >
-                    {wallets.length === 0 ? (
-                      <option value="">Нет доступных кошельков</option>
-                    ) : (
-                      wallets.map((item) => (
-                        <option key={item.id} value={item.name}>
-                          {`${getWalletIcon(item.name)} ${item.name}`}
-                        </option>
-                      ))
-                    )}
-                  </select>
-                </div>
-              </label>
-
-              <label style={{ display: "flex", flexDirection: "column", gap: "0.55rem" }}>
-                <span style={{ fontSize: "0.95rem", color: "var(--text-muted)" }}>Категория</span>
-                <div
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: "0.75rem",
-                    padding: "0.75rem 1rem",
-                    borderRadius: "1.1rem",
-                    background: "rgba(15, 23, 42, 0.75)",
-                    border: "1px solid rgba(148, 163, 184, 0.25)"
-                  }}
-                >
-                  <span aria-hidden style={{ fontSize: "1.1rem" }}>📂</span>
-                  <select
-                    value={category}
-                    onChange={(event) => setCategory(event.target.value)}
-                    disabled={!canManage || loading || categorySuggestions.length === 0}
-                    style={{
-                      flex: 1,
-                      background: "transparent",
-                      border: "none",
-                      color: "var(--text-primary)",
-                      fontSize: "1rem",
-                      fontWeight: 500,
-                      outline: "none"
-                    }}
-                  >
-                    {categorySuggestions.length === 0 ? (
-                      <option value="">Нет доступных категорий</option>
-                    ) : (
-                      categorySuggestions.map((item) => (
-                        <option key={item} value={item}>
-                          {item}
-                        </option>
-                      ))
-                    )}
-                  </select>
-                </div>
-              </label>
-            </div>
-
-            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-              <span style={{ fontSize: "0.95rem", color: "var(--text-muted)" }}>Комментарий</span>
-              <button
-                type="button"
-                onClick={() => setIsCommentModalOpen(true)}
-                disabled={!canManage || loading}
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: "0.5rem",
-                  padding: "0.55rem 1.05rem",
-                  borderRadius: "9999px",
-                  border: "1px solid rgba(148, 163, 184, 0.35)",
-                  background: comment
-                    ? "linear-gradient(135deg, rgba(56, 189, 248, 0.35), rgba(129, 140, 248, 0.35))"
-                    : "transparent",
-                  color: comment ? "var(--text-primary)" : "var(--text-muted)",
-                  fontWeight: 600,
-                  cursor: !canManage || loading ? "not-allowed" : "pointer",
-                  transition: "all 0.2s ease"
-                }}
-              >
-                <span aria-hidden>📝</span>
-                {comment ? "Изменить" : "Добавить"}
-              </button>
-            </div>
-
-            <div
-              style={{
-                position: "sticky",
-                bottom: "-2rem",
-                margin: "0 -2rem -2rem",
-                padding: "1.35rem 2rem 2rem",
-                background:
-                  "linear-gradient(180deg, rgba(12, 15, 35, 0) 0%, rgba(12, 15, 35, 0.88) 45%, rgba(12, 15, 35, 0.98) 100%)",
-                backdropFilter: "blur(18px)",
-                borderBottomLeftRadius: "1.5rem",
-                borderBottomRightRadius: "1.5rem"
-              }}
-            >
-              <button
-                type="submit"
-                disabled={!canManage || loading || !wallet || !category}
-                style={{
-                  width: "100%",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  gap: "0.75rem",
-                  padding: "1.05rem 1.5rem",
-                  borderRadius: "1.1rem",
-                  border: "none",
-                  background: "linear-gradient(135deg, #1d4ed8, #06b6d4)",
-                  color: "white",
-                  fontWeight: 700,
-                  fontSize: "1.05rem",
-                  cursor: !canManage || loading || !wallet || !category ? "not-allowed" : "pointer",
-                  boxShadow: "0 18px 45px rgba(6, 182, 212, 0.35)",
-                  transition: "transform 0.2s ease, box-shadow 0.2s ease"
-                }}
-              >
-                <span aria-hidden>➕</span>
-                {loading ? "Добавляем..." : "Добавить"}
-              </button>
-            </div>
-          </form>
-
-          {isCommentModalOpen ? (
-            <div
-              role="dialog"
-              aria-modal="true"
-              aria-label="Комментарий к операции"
-              style={{
-                position: "fixed",
-                inset: 0,
-                backgroundColor: "rgba(2, 6, 23, 0.65)",
-                backdropFilter: "blur(10px)",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                zIndex: 50
-              }}
-            >
-              <div
-                style={{
-                  width: "min(90vw, 420px)",
-                  background: "rgba(12, 15, 35, 0.96)",
-                  borderRadius: "1.5rem",
-                  padding: "1.9rem",
-                  display: "flex",
-                  flexDirection: "column",
-                  gap: "1.25rem",
-                  border: "1px solid rgba(129, 140, 248, 0.35)",
-                  boxShadow: "0 24px 70px rgba(8, 12, 30, 0.65)"
-                }}
-              >
-                <h3 style={{ margin: 0, fontSize: "1.25rem", fontWeight: 700 }}>Комментарий</h3>
-                <textarea
-                  value={comment}
-                  onChange={(event: ChangeEvent<HTMLTextAreaElement>) => setComment(event.target.value)}
-                  placeholder="Добавьте заметку"
-                  rows={4}
-                  style={{
-                    width: "100%",
-                    borderRadius: "1rem",
-                    padding: "1rem",
-                    background: "rgba(15, 23, 42, 0.75)",
-                    border: "1px solid rgba(148, 163, 184, 0.35)",
-                    color: "var(--text-primary)",
-                    resize: "vertical",
-                    minHeight: "6rem"
-                  }}
-                />
-                <div style={{ display: "flex", justifyContent: "flex-end", gap: "0.75rem" }}>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setComment("");
-                      setIsCommentModalOpen(false);
-                    }}
-                    style={{
-                      padding: "0.6rem 1.1rem",
-                      borderRadius: "0.85rem",
-                      border: "1px solid rgba(148, 163, 184, 0.35)",
-                      background: "transparent",
-                      color: "var(--text-muted)",
-                      fontWeight: 600,
-                      cursor: "pointer"
-                    }}
-                  >
-                    Очистить
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setIsCommentModalOpen(false)}
-                    style={{
-                      padding: "0.6rem 1.25rem",
-                      borderRadius: "0.85rem",
-                      border: "none",
-                      background: "linear-gradient(135deg, #1d4ed8, #06b6d4)",
-                      color: "white",
-                      fontWeight: 700,
-                      cursor: "pointer",
-                      boxShadow: "0 14px 30px rgba(6, 182, 212, 0.35)"
-                    }}
-                  >
-                    Готово
-                  </button>
-                </div>
-              </div>
-            </div>
-          ) : null}
-          {!canManage ? (
-            <p style={{ color: "var(--text-muted)" }}>
-              Вы вошли как наблюдатель — операции доступны только для просмотра.
-            </p>
-          ) : null}
-
-          {error ? <p style={{ color: "var(--accent-danger)" }}>{error}</p> : null}
-        </section>
-
-
-        <section style={{ display: "flex", flexDirection: "column", gap: "1.25rem" }}>
-          <h2 style={{ fontSize: "clamp(1.25rem, 4.5vw, 1.5rem)", fontWeight: 600 }}>
-            Последние операции
-          </h2>
-          {operations.length === 0 ? (
-            <p style={{ color: "var(--text-muted)" }}>
-              Пока нет данных — добавьте первую операцию.
-            </p>
-          ) : (
-            <ul style={{ display: "flex", flexDirection: "column", gap: "0.85rem" }}>
-              {operations.map((operation) => (
-                <li
-                  key={operation.id}
-                  data-card="split"
-                  style={{
-                    padding: "clamp(0.85rem, 2.5vw, 1rem)",
-                    borderRadius: "var(--radius-2xl)",
-                    border: "1px solid var(--border-strong)",
-                    display: "flex",
-                    justifyContent: "space-between",
-                    alignItems: "flex-start",
-                    gap: "1.25rem",
-                    backgroundColor: "var(--surface-subtle)",
-                    boxShadow: "var(--shadow-card)",
-                    flexWrap: "wrap"
-                  }}
-                >
-                  <div
-                    style={{
-                      display: "flex",
-                      flexDirection: "column",
-                      gap: "0.35rem",
-                      minWidth: "min(220px, 100%)"
-                    }}
-                  >
-                    <p style={{ fontWeight: 600, color: "var(--text-primary)" }}>
-                      {operation.type === "income" ? "Приход" : "Расход"} — {operation.category}
-                    </p>
-                    <p style={{ color: "var(--text-muted)", fontSize: "0.9rem" }}>
-                      {new Date(operation.date).toLocaleString("ru-RU")}
-                    </p>
-                    <p style={{ color: "var(--text-secondary)", fontSize: "0.9rem" }}>
-                      Кошелёк: {operation.wallet}
-                    </p>
-                    {operation.comment ? (
-                      <p style={{ color: "var(--text-secondary)", lineHeight: 1.5 }}>{operation.comment}</p>
-                    ) : null}
-                  </div>
-                  <div
-                    data-card-section="meta"
-                    style={{
-                      display: "flex",
-                      flexDirection: "column",
-                      alignItems: canManage ? "flex-end" : "flex-start",
-                      gap: "0.65rem",
-                      minWidth: "min(140px, 100%)"
-                    }}
-                  >
-                    <span
-                      style={{
-                        fontWeight: 700,
-                        color: operation.type === "income" ? "var(--accent-success)" : "var(--accent-danger)",
-                        fontSize: "clamp(1rem, 3.5vw, 1.1rem)"
-                      }}
-                    >
-                      {`${operation.type === "income" ? "+" : "-"}${operation.amount.toLocaleString(
-                        "ru-RU",
-                        {
-                          minimumFractionDigits: 2,
-                          maximumFractionDigits: 2
-                        }
-                      )} ${operation.currency}`}
-                    </span>
-                    {canManage ? (
-                      <button
-                        type="button"
-                        onClick={() => handleDelete(operation.id)}
-                        disabled={deletingId === operation.id}
-                        data-variant="danger"
-                        className="w-full"
-                      >
-                        {deletingId === operation.id ? "Удаляем..." : "Удалить"}
-                      </button>
-                    ) : null}
-                  </div>
-                </li>
-              ))}
-            </ul>
-          )}
+            </header>
+            <WalletTable
+              wallets={wallets}
+              loading={walletsLoading || operationsLoading}
+              onAddTransaction={handleOpenTransaction}
+            />
           </section>
-        </>
-      )}
-    </PageContainer>
+
+          <section className="flex flex-col gap-4">
+            <header className="flex items-center justify-between">
+              <h2 className="text-xl font-semibold text-[var(--text-strong)]">
+                Последние транзакции
+              </h2>
+              <span className="text-sm text-[var(--text-muted)]">
+                Обновлено автоматически каждые 60 секунд
+              </span>
+            </header>
+            <div className="flex flex-col gap-3">
+              {operationsLoading && latestTransactions.length === 0 ? (
+                <div className="h-24 rounded-2xl border border-[var(--border-strong)] bg-[var(--surface-subtle)]" />
+              ) : null}
+              {latestTransactions.length === 0 && !operationsLoading ? (
+                <div className="rounded-2xl border border-dashed border-[var(--border-strong)] bg-[var(--surface-subtle)] p-6 text-center text-sm text-[var(--text-muted)]">
+                  У этого кошелька пока нет транзакций. Создайте первую, чтобы увидеть историю.
+                </div>
+              ) : null}
+              {latestTransactions.map((transaction) => {
+                const wallet = walletMap.get(transaction.wallet.toLowerCase());
+                const currency = wallet?.currency ?? transaction.currency;
+                const amount = formatAmount(transaction.amount, currency);
+                const isIncome = transaction.type === "income";
+
+                return (
+                  <div
+                    key={transaction.id}
+                    className="flex flex-col gap-2 rounded-2xl border border-[var(--border-strong)] bg-[var(--surface-primary)] px-5 py-4 shadow-[var(--shadow-card)] sm:flex-row sm:items-center sm:justify-between"
+                  >
+                    <div className="flex flex-col gap-1">
+                      <span className="text-base font-semibold text-[var(--text-strong)]">
+                        {transaction.category}
+                      </span>
+                      <span className="text-sm text-[var(--text-muted)]">
+                        {transaction.wallet} • {formatDate(transaction.date)}
+                      </span>
+                    </div>
+                    <span
+                      className={`text-lg font-semibold ${isIncome ? "text-[var(--accent-success)]" : "text-[var(--accent-danger)]"}`}
+                    >
+                      {isIncome ? "+" : "-"}
+                      {amount}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        </div>
+      </PageContainer>
+
+      <TransactionModal
+        isOpen={Boolean(selectedWalletId && transactionType)}
+        walletName={selectedWalletName}
+        type={transactionType}
+        state={formState}
+        error={formError}
+        isSaving={isSaving}
+        onFieldChange={handleFieldChange}
+        onClose={handleCloseModal}
+        onSubmit={handleSubmit}
+      />
+    </AuthGate>
   );
 };
 
-const Page = () => (
-  <AuthGate>
-    <Dashboard />
-  </AuthGate>
-);
-
-export default Page;
+export default Dashboard;

--- a/components/PageContainer.tsx
+++ b/components/PageContainer.tsx
@@ -3,11 +3,11 @@ import type { ReactNode } from "react";
 import AppNavigation, { type AppTabKey } from "@/components/AppNavigation";
 
 type PageContainerProps = {
-  activeTab: AppTabKey;
+  activeTab?: AppTabKey;
   children: ReactNode;
 };
 
-const PageContainer = ({ activeTab, children }: PageContainerProps) => (
+const PageContainer = ({ activeTab = "home", children }: PageContainerProps) => (
   <main className="page-shell">
     <div className="flex w-full flex-col gap-10">
       <AppNavigation activeTab={activeTab} />

--- a/components/TransactionForm.tsx
+++ b/components/TransactionForm.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import type { FormEvent } from "react";
+
+export type TransactionType = "INCOME" | "EXPENSE";
+
+export type TransactionFormState = {
+  amount: string;
+  date: string;
+  description: string;
+  sourceOrCategory: string;
+};
+
+type TransactionFormProps = {
+  walletName: string;
+  type: TransactionType;
+  state: TransactionFormState;
+  error?: string | null;
+  isSaving: boolean;
+  onFieldChange: <Key extends keyof TransactionFormState>(key: Key, value: TransactionFormState[Key]) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onCancel: () => void;
+};
+
+const INCOME_OPTIONS = [
+  { value: "зарплата", label: "Зарплата" },
+  { value: "пожертвование", label: "Пожертвование" },
+  { value: "другое", label: "Другое" }
+];
+
+const EXPENSE_OPTIONS = [
+  { value: "еда", label: "Еда" },
+  { value: "транспорт", label: "Транспорт" },
+  { value: "другое", label: "Другое" }
+];
+
+const TransactionForm = ({
+  walletName,
+  type,
+  state,
+  error,
+  isSaving,
+  onFieldChange,
+  onSubmit,
+  onCancel
+}: TransactionFormProps) => {
+  const headline = type === "INCOME" ? "Добавление дохода" : "Добавление расхода";
+
+  const options = type === "INCOME" ? INCOME_OPTIONS : EXPENSE_OPTIONS;
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1 text-left">
+        <span className="text-sm font-medium uppercase tracking-wide text-[var(--text-muted)]">{walletName}</span>
+        <h2 className="text-2xl font-semibold text-[var(--text-strong)]">{headline}</h2>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <label className="flex flex-col gap-2">
+          <span className="text-sm font-medium text-[var(--text-secondary)]">Сумма</span>
+          <input
+            type="number"
+            min="0"
+            step="0.01"
+            required
+            value={state.amount}
+            onChange={(event) => onFieldChange("amount", event.target.value)}
+            className="rounded-2xl border border-[var(--border-strong)] bg-[var(--surface-primary)] px-4 py-3 text-base font-semibold text-[var(--text-strong)] shadow-[var(--shadow-soft)] focus:border-[var(--accent-primary)] focus:outline-none"
+            placeholder="0.00"
+          />
+        </label>
+
+        <label className="flex flex-col gap-2">
+          <span className="text-sm font-medium text-[var(--text-secondary)]">Дата</span>
+          <input
+            type="date"
+            value={state.date}
+            onChange={(event) => onFieldChange("date", event.target.value)}
+            className="rounded-2xl border border-[var(--border-strong)] bg-[var(--surface-primary)] px-4 py-3 text-base text-[var(--text-strong)] shadow-[var(--shadow-soft)] focus:border-[var(--accent-primary)] focus:outline-none"
+          />
+        </label>
+      </div>
+
+      <label className="flex flex-col gap-2">
+        <span className="text-sm font-medium text-[var(--text-secondary)]">
+          {type === "INCOME" ? "Источник дохода" : "Категория расхода"}
+        </span>
+        <select
+          required
+          value={state.sourceOrCategory}
+          onChange={(event) => onFieldChange("sourceOrCategory", event.target.value)}
+          className="rounded-2xl border border-[var(--border-strong)] bg-[var(--surface-primary)] px-4 py-3 text-base text-[var(--text-strong)] shadow-[var(--shadow-soft)] focus:border-[var(--accent-primary)] focus:outline-none"
+        >
+          <option value="" disabled>
+            Выберите вариант
+          </option>
+          {options.map((option) => (
+            <option key={option.value} value={option.label}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-2">
+        <span className="text-sm font-medium text-[var(--text-secondary)]">Описание (необязательно)</span>
+        <textarea
+          rows={3}
+          value={state.description}
+          onChange={(event) => onFieldChange("description", event.target.value)}
+          placeholder="Комментарий к транзакции"
+          className="rounded-2xl border border-[var(--border-strong)] bg-[var(--surface-primary)] px-4 py-3 text-base text-[var(--text-secondary)] shadow-[var(--shadow-soft)] focus:border-[var(--accent-primary)] focus:outline-none"
+        />
+      </label>
+
+      {error ? (
+        <div className="rounded-2xl border border-[var(--accent-danger)] bg-[var(--surface-danger)] px-4 py-3 text-sm font-medium text-[var(--accent-danger-strong)]">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-2xl border border-[var(--border-strong)] bg-transparent px-6 py-3 text-sm font-semibold text-[var(--text-secondary)] shadow-[var(--shadow-button-outline)] transition hover:border-[var(--accent-primary)] hover:text-[var(--accent-primary)]"
+        >
+          Отмена
+        </button>
+        <button
+          type="submit"
+          disabled={isSaving}
+          className="rounded-2xl bg-[var(--accent-primary)] px-6 py-3 text-sm font-semibold text-white shadow-[var(--shadow-button)] transition hover:bg-[var(--accent-primary-hover)] disabled:opacity-70"
+        >
+          {isSaving ? "Сохраняем..." : "Сохранить"}
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default TransactionForm;

--- a/components/TransactionModal.tsx
+++ b/components/TransactionModal.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect, type FormEvent } from "react";
+
+import TransactionForm, {
+  type TransactionFormState,
+  type TransactionType
+} from "@/components/TransactionForm";
+
+type TransactionModalProps = {
+  isOpen: boolean;
+  walletName: string | null;
+  type: TransactionType | null;
+  state: TransactionFormState;
+  error?: string | null;
+  isSaving: boolean;
+  onFieldChange: <Key extends keyof TransactionFormState>(key: Key, value: TransactionFormState[Key]) => void;
+  onClose: () => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+};
+
+const TransactionModal = ({
+  isOpen,
+  walletName,
+  type,
+  state,
+  error,
+  isSaving,
+  onFieldChange,
+  onClose,
+  onSubmit
+}: TransactionModalProps) => {
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const { style } = document.body;
+    const originalOverflow = style.overflow;
+    style.overflow = "hidden";
+
+    return () => {
+      style.overflow = originalOverflow;
+    };
+  }, [isOpen]);
+
+  if (!isOpen || !walletName || !type) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/50 px-4 py-10">
+      <div className="relative w-full max-w-xl rounded-3xl border border-[var(--border-strong)] bg-[var(--surface-primary)] p-6 shadow-[var(--shadow-strong)]">
+        <button
+          type="button"
+          aria-label="Закрыть"
+          onClick={onClose}
+          className="absolute right-4 top-4 h-10 w-10 rounded-full border border-[var(--border-strong)] bg-transparent text-lg font-semibold text-[var(--text-secondary)] transition hover:border-[var(--accent-primary)] hover:text-[var(--accent-primary)]"
+        >
+          ×
+        </button>
+        <TransactionForm
+          walletName={walletName}
+          type={type}
+          state={state}
+          error={error}
+          isSaving={isSaving}
+          onFieldChange={onFieldChange}
+          onSubmit={onSubmit}
+          onCancel={onClose}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default TransactionModal;

--- a/components/WalletTable.tsx
+++ b/components/WalletTable.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+type WalletRow = {
+  id: string;
+  name: string;
+  currency: string;
+  balance: number;
+  category: string;
+};
+
+type WalletTableProps = {
+  wallets: WalletRow[];
+  loading?: boolean;
+  onAddTransaction: (walletId: string, type: "INCOME" | "EXPENSE") => void;
+};
+
+const WalletTable = ({ wallets, loading = false, onAddTransaction }: WalletTableProps) => {
+  const [openWalletId, setOpenWalletId] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!openWalletId) {
+      return;
+    }
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (!containerRef.current) {
+        return;
+      }
+
+      if (event.target instanceof Node && containerRef.current.contains(event.target)) {
+        return;
+      }
+
+      setOpenWalletId(null);
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [openWalletId]);
+
+  const rows = useMemo(() => {
+    if (loading) {
+      return Array.from({ length: 4 }, (_, index) => (
+        <div
+          key={`skeleton-${index}`}
+          className="animate-pulse rounded-2xl border border-[var(--border-strong)] bg-[var(--surface-subtle)] p-4"
+        >
+          <div className="mb-3 h-4 w-1/3 rounded-full bg-[var(--border-strong)]/60" />
+          <div className="flex items-center justify-between gap-3">
+            <div className="h-6 w-1/4 rounded-full bg-[var(--border-strong)]/60" />
+            <div className="h-8 w-8 rounded-full bg-[var(--border-strong)]/40" />
+          </div>
+        </div>
+      ));
+    }
+
+    return wallets.map((wallet) => {
+      const formatter = new Intl.NumberFormat("ru-RU", {
+        style: "currency",
+        currency: wallet.currency
+      });
+
+      const formattedBalance = formatter.format(wallet.balance);
+      const isMenuOpen = openWalletId === wallet.id;
+
+      return (
+        <div
+          key={wallet.id}
+          className="relative flex flex-col gap-1 rounded-2xl border border-[var(--border-strong)] bg-[var(--surface-primary)] p-4 shadow-[var(--shadow-card)] transition hover:shadow-[var(--shadow-strong)]"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex flex-col gap-1">
+              <span className="text-sm font-medium uppercase tracking-wide text-[var(--text-muted)]">
+                {wallet.category}
+              </span>
+              <span className="text-lg font-semibold text-[var(--text-strong)]">
+                {wallet.name}
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                aria-label={`Добавить транзакцию для ${wallet.name}`}
+                onClick={() => {
+                  setOpenWalletId((current) => (current === wallet.id ? null : wallet.id));
+                }}
+                className="flex h-10 w-10 items-center justify-center rounded-full bg-[var(--accent-primary)] text-xl font-bold text-white shadow-[var(--shadow-button)] transition hover:bg-[var(--accent-primary-hover)]"
+              >
+                +
+              </button>
+            </div>
+          </div>
+          <div className="flex items-baseline justify-between gap-3">
+            <span className="text-2xl font-semibold text-[var(--text-strong)]">{formattedBalance}</span>
+            <span className="text-sm font-medium text-[var(--text-muted)]">{wallet.currency}</span>
+          </div>
+
+          {isMenuOpen ? (
+            <div className="absolute right-4 top-16 z-20 w-44 rounded-xl border border-[var(--border-strong)] bg-[var(--surface-primary)] py-2 shadow-[var(--shadow-card)]">
+              <button
+                type="button"
+                onClick={() => {
+                  onAddTransaction(wallet.id, "INCOME");
+                  setOpenWalletId(null);
+                }}
+                className="block w-full px-4 py-2 text-left text-sm font-medium text-[var(--text-secondary)] transition hover:bg-[var(--surface-subtle)] hover:text-[var(--text-strong)]"
+              >
+                Добавить доход
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  onAddTransaction(wallet.id, "EXPENSE");
+                  setOpenWalletId(null);
+                }}
+                className="block w-full px-4 py-2 text-left text-sm font-medium text-[var(--text-secondary)] transition hover:bg-[var(--surface-subtle)] hover:text-[var(--accent-danger)]"
+              >
+                Добавить расход
+              </button>
+            </div>
+          ) : null}
+        </div>
+      );
+    });
+  }, [loading, onAddTransaction, openWalletId, wallets]);
+
+  return (
+    <div ref={containerRef} className="flex flex-col gap-4">
+      <div className="hidden flex-col gap-3 md:flex">
+        <div className="grid grid-cols-4 gap-3 text-sm font-medium uppercase tracking-wide text-[var(--text-muted)]">
+          <span>Кошелёк</span>
+          <span>Баланс</span>
+          <span>Валюта</span>
+          <span className="text-right">Действия</span>
+        </div>
+        <div className="flex flex-col gap-3">
+          {wallets.length === 0 && !loading ? (
+            <div className="rounded-2xl border border-dashed border-[var(--border-strong)] bg-[var(--surface-subtle)] p-6 text-center text-sm text-[var(--text-muted)]">
+              Кошельки не найдены. Добавьте первый кошелёк, чтобы начать работу.
+            </div>
+          ) : (
+            wallets.map((wallet) => {
+              const formatter = new Intl.NumberFormat("ru-RU", {
+                style: "currency",
+                currency: wallet.currency
+              });
+              const formattedBalance = formatter.format(wallet.balance);
+              const isMenuOpen = openWalletId === wallet.id;
+
+              return (
+                <div
+                  key={`table-${wallet.id}`}
+                  className="relative grid grid-cols-4 items-center gap-3 rounded-2xl border border-[var(--border-strong)] bg-[var(--surface-primary)] px-6 py-4 shadow-[var(--shadow-card)] transition hover:shadow-[var(--shadow-strong)]"
+                >
+                  <div className="flex flex-col gap-1">
+                    <span className="text-xs font-medium uppercase tracking-wide text-[var(--text-muted)]">
+                      {wallet.category}
+                    </span>
+                    <span className="text-base font-semibold text-[var(--text-strong)]">{wallet.name}</span>
+                  </div>
+                  <span className="text-lg font-semibold text-[var(--text-strong)]">{formattedBalance}</span>
+                  <span className="text-sm font-medium text-[var(--text-secondary)]">{wallet.currency}</span>
+                  <div className="flex justify-end">
+                    <button
+                      type="button"
+                      aria-label={`Добавить транзакцию для ${wallet.name}`}
+                      onClick={() => {
+                        setOpenWalletId((current) => (current === wallet.id ? null : wallet.id));
+                      }}
+                      className="flex h-10 w-10 items-center justify-center rounded-full bg-[var(--accent-primary)] text-xl font-bold text-white shadow-[var(--shadow-button)] transition hover:bg-[var(--accent-primary-hover)]"
+                    >
+                      +
+                    </button>
+                  </div>
+                  {isMenuOpen ? (
+                    <div className="absolute right-6 top-16 z-20 w-48 rounded-xl border border-[var(--border-strong)] bg-[var(--surface-primary)] py-2 shadow-[var(--shadow-card)]">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          onAddTransaction(wallet.id, "INCOME");
+                          setOpenWalletId(null);
+                        }}
+                        className="block w-full px-4 py-2 text-left text-sm font-medium text-[var(--text-secondary)] transition hover:bg-[var(--surface-subtle)] hover:text-[var(--text-strong)]"
+                      >
+                        Добавить доход
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          onAddTransaction(wallet.id, "EXPENSE");
+                          setOpenWalletId(null);
+                        }}
+                        className="block w-full px-4 py-2 text-left text-sm font-medium text-[var(--text-secondary)] transition hover:bg-[var(--surface-subtle)] hover:text-[var(--accent-danger)]"
+                      >
+                        Добавить расход
+                      </button>
+                    </div>
+                  ) : null}
+                </div>
+              );
+            })
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-3 md:hidden">
+        {rows}
+        {wallets.length === 0 && !loading ? (
+          <div className="rounded-2xl border border-dashed border-[var(--border-strong)] bg-[var(--surface-subtle)] p-6 text-center text-sm text-[var(--text-muted)]">
+            Кошельки не найдены. Добавьте первый кошелёк, чтобы начать работу.
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+export type { WalletRow };
+export default WalletTable;


### PR DESCRIPTION
## Summary
- replace the home page dashboard with a banking-style wallet table and recent transaction list
- add reusable wallet table, transaction form, and modal components for creating income/expense records
- introduce a transactions API endpoint backed by Prisma and make the PageContainer tab optional with a default

## Testing
- npm run lint *(fails: ESLint is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68dc340bb6c48331a95fdc5d7f235c8a