### PR TITLE
Make recent operations collapsible

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -100,6 +100,7 @@ const Dashboard = () => {
   const [showBalanceDetails, setShowBalanceDetails] = useState(false);
   const [showCommentField, setShowCommentField] = useState(false);
   const [activeQuickAmount, setActiveQuickAmount] = useState<number | null>(null);
+  const [expandedOperationId, setExpandedOperationId] = useState<string | null>(null);
 
   const {
     data: operationsData,
@@ -621,6 +622,10 @@ const Dashboard = () => {
     }
   };
 
+  const toggleOperationDetails = useCallback((id: string) => {
+    setExpandedOperationId((prev) => (prev === id ? null : id));
+  }, []);
+
   const handleDelete = async (id: string) => {
     if (!canManage) {
       setError("Недостаточно прав для удаления операции");
@@ -628,6 +633,7 @@ const Dashboard = () => {
     }
 
     setError(null);
+    setExpandedOperationId((prev) => (prev === id ? null : prev));
     setDeletingId(id);
 
     try {
@@ -1377,84 +1383,144 @@ const Dashboard = () => {
             </p>
           ) : (
             <ul style={{ display: "flex", flexDirection: "column", gap: "0.85rem" }}>
-              {operations.map((operation) => (
-                <li
-                  key={operation.id}
-                  data-card="split"
-                  style={{
-                    padding: "clamp(0.95rem, 3vw, 1.15rem)",
-                    borderRadius: "1.35rem",
-                    border: "none",
-                    display: "flex",
-                    justifyContent: "space-between",
-                    alignItems: "flex-start",
-                    gap: "1.25rem",
-                    background: "rgba(15, 23, 42, 0.55)",
-                    boxShadow: "0 24px 48px -36px rgba(8, 47, 73, 0.85)",
-                    backdropFilter: "blur(18px)",
-                    flexWrap: "wrap"
-                  }}
-                >
-                  <div
+              {operations.map((operation) => {
+                const isExpanded = expandedOperationId === operation.id;
+                const detailsId = `operation-details-${operation.id}`;
+
+                return (
+                  <li
+                    key={operation.id}
+                    data-card="split"
                     style={{
+                      padding: "clamp(0.95rem, 3vw, 1.15rem)",
+                      borderRadius: "1.35rem",
+                      border: "none",
                       display: "flex",
                       flexDirection: "column",
-                      gap: "0.35rem",
-                      minWidth: "min(220px, 100%)"
+                      gap: "0.75rem",
+                      background: "rgba(15, 23, 42, 0.55)",
+                      boxShadow: "0 24px 48px -36px rgba(8, 47, 73, 0.85)",
+                      backdropFilter: "blur(18px)",
+                      flexWrap: "wrap"
                     }}
                   >
-                    <p style={{ fontWeight: 600, color: "var(--text-primary)" }}>
-                      {operation.type === "income" ? "Приход" : "Расход"} — {operation.category}
-                    </p>
-                    <p style={{ color: "var(--text-muted)", fontSize: "0.9rem" }}>
-                      {new Date(operation.date).toLocaleString("ru-RU")}
-                    </p>
-                    <p style={{ color: "var(--text-secondary)", fontSize: "0.9rem" }}>
-                      Кошелёк: {operation.wallet}
-                    </p>
-                    {operation.comment ? (
-                      <p style={{ color: "var(--text-secondary)", lineHeight: 1.5 }}>{operation.comment}</p>
-                    ) : null}
-                  </div>
-                  <div
-                    data-card-section="meta"
-                    style={{
-                      display: "flex",
-                      flexDirection: "column",
-                      alignItems: canManage ? "flex-end" : "flex-start",
-                      gap: "0.65rem",
-                      minWidth: "min(140px, 100%)"
-                    }}
-                  >
-                    <span
+                    <button
+                      type="button"
+                      onClick={() => toggleOperationDetails(operation.id)}
+                      aria-expanded={isExpanded}
+                      aria-controls={detailsId}
                       style={{
-                        fontWeight: 700,
-                        color: operation.type === "income" ? "var(--accent-success)" : "var(--accent-danger)",
-                        fontSize: "clamp(1rem, 3.5vw, 1.1rem)"
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "space-between",
+                        gap: "1rem",
+                        width: "100%",
+                        background: "transparent",
+                        border: "none",
+                        padding: 0,
+                        margin: 0,
+                        cursor: "pointer",
+                        textAlign: "left",
+                        color: "inherit"
                       }}
                     >
-                      {`${operation.type === "income" ? "+" : "-"}${operation.amount.toLocaleString(
-                        "ru-RU",
-                        {
-                          minimumFractionDigits: 2,
-                          maximumFractionDigits: 2
-                        }
-                      )} ${operation.currency}`}
-                    </span>
-                    {canManage ? (
-                      <button
-                        type="button"
-                        onClick={() => handleDelete(operation.id)}
-                        disabled={deletingId === operation.id}
-                        data-variant="danger"
-                        className="w-full"
+                      <div
+                        style={{
+                          display: "flex",
+                          flexDirection: "column",
+                          gap: "0.35rem"
+                        }}
                       >
-                        {deletingId === operation.id ? "Удаляем..." : "Удалить"}
-                      </button>
+                        <span style={{ fontWeight: 600, color: "var(--text-primary)" }}>
+                          {operation.type === "income" ? "Приход" : "Расход"} — {operation.category}
+                        </span>
+                      </div>
+                      <div
+                        style={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: "0.75rem"
+                        }}
+                      >
+                        <span
+                          style={{
+                            fontWeight: 700,
+                            color:
+                              operation.type === "income"
+                                ? "var(--accent-success)"
+                                : "var(--accent-danger)",
+                            fontSize: "clamp(1rem, 3.5vw, 1.1rem)"
+                          }}
+                        >
+                          {`${operation.type === "income" ? "+" : "-"}${operation.amount.toLocaleString(
+                            "ru-RU",
+                            {
+                              minimumFractionDigits: 2,
+                              maximumFractionDigits: 2
+                            }
+                          )} ${operation.currency}`}
+                        </span>
+                        <span
+                          aria-hidden
+                          style={{
+                            display: "inline-flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            fontSize: "1rem",
+                            color: "var(--text-muted)",
+                            transform: isExpanded ? "rotate(180deg)" : "rotate(0deg)",
+                            transition: "transform 0.2s ease"
+                          }}
+                        >
+                          ⌄
+                        </span>
+                      </div>
+                    </button>
+
+                    {isExpanded ? (
+                      <div
+                        id={detailsId}
+                        style={{
+                          display: "flex",
+                          justifyContent: canManage ? "space-between" : "flex-start",
+                          alignItems: "flex-start",
+                          gap: "1.25rem",
+                          flexWrap: "wrap",
+                          borderTop: "1px solid rgba(148, 163, 184, 0.18)",
+                          paddingTop: "0.75rem"
+                        }}
+                      >
+                        <div
+                          style={{
+                            display: "flex",
+                            flexDirection: "column",
+                            gap: "0.35rem",
+                            color: "var(--text-secondary)",
+                            fontSize: "0.9rem",
+                            lineHeight: 1.5
+                          }}
+                        >
+                          <span style={{ color: "var(--text-muted)" }}>
+                            Дата и время: {new Date(operation.date).toLocaleString("ru-RU")}
+                          </span>
+                          <span>Кошелёк: {operation.wallet || "Не указан"}</span>
+                          {operation.comment ? <span>Комментарий: {operation.comment}</span> : null}
+                        </div>
+                        {canManage ? (
+                          <button
+                            type="button"
+                            onClick={() => handleDelete(operation.id)}
+                            disabled={deletingId === operation.id}
+                            data-variant="danger"
+                          >
+                            {deletingId === operation.id ? "Удаляем..." : "Удалить"}
+                          </button>
+                        ) : null}
+                      </div>
                     ) : null}
-                  </div>
-                </li>
-              ))}
+                  </li>
+                );
+              })}
             </ul>
           )}
           </section>


### PR DESCRIPTION
## Summary
- track which recent operation card is expanded so the list can collapse by default
- replace the operations list layout with a compact summary button and expandable details section
- collapse an operation card automatically after deletion to keep the view tidy

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68dc659d22688331a0952244e9ebf62c