### PR TITLE
Refresh dashboard shell styling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -129,13 +129,30 @@
 
 body {
   min-height: 100vh;
-  background-color: var(--page-background);
+  background: radial-gradient(
+      circle at 10% -10%,
+      rgba(59, 130, 246, 0.28) 0%,
+      transparent 55%
+    ),
+    radial-gradient(circle at 80% 0%, rgba(129, 140, 248, 0.22) 0%, transparent 60%),
+    var(--page-background);
+  background-attachment: fixed;
   color: var(--text-primary);
   display: flex;
   justify-content: center;
   align-items: flex-start;
   padding: 2.5rem 1.5rem 4rem;
-  transition: background-color 0.3s ease, color 0.3s ease;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.dark body {
+  background: radial-gradient(
+      circle at 12% -10%,
+      rgba(59, 130, 246, 0.24) 0%,
+      transparent 55%
+    ),
+    radial-gradient(circle at 85% 0%, rgba(167, 139, 250, 0.2) 0%, transparent 65%),
+    var(--page-background);
 }
 
 h1,
@@ -282,27 +299,51 @@ label {
 
 .page-shell {
   width: min(100%, 980px);
-  background-color: var(--surface-primary);
+  background: linear-gradient(
+    135deg,
+    rgba(248, 250, 255, 0.88) 0%,
+    rgba(241, 245, 255, 0.72) 100%
+  );
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
   color: var(--text-primary);
-  border-radius: 1.25rem;
-  box-shadow: var(--shadow-strong);
+  border-radius: 1.5rem;
+  box-shadow: 0 35px 80px rgba(15, 23, 42, 0.16);
   padding: 2.75rem 2.5rem;
   display: flex;
   flex-direction: column;
   gap: 2.25rem;
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  transition: background-color 0.3s ease, color 0.3s ease, box-shadow 0.3s ease,
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  transition: background 0.3s ease, color 0.3s ease, box-shadow 0.3s ease,
     border-color 0.3s ease;
 }
 
 .page-shell section {
-  background-color: var(--surface-subtle);
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
   border-radius: var(--radius-2xl) !important;
   padding: var(--card-padding) !important;
-  box-shadow: var(--shadow-card) !important;
-  border: 1px solid var(--border-strong);
-  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease,
+  box-shadow: 0 28px 60px rgba(15, 23, 42, 0.12) !important;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  transition: background 0.3s ease, color 0.3s ease, border-color 0.3s ease,
     box-shadow 0.3s ease;
+}
+
+.dark .page-shell {
+  background: linear-gradient(
+    135deg,
+    rgba(15, 23, 42, 0.92) 0%,
+    rgba(15, 23, 42, 0.72) 100%
+  );
+  border-color: rgba(148, 163, 184, 0.12);
+  box-shadow: 0 50px 90px rgba(8, 15, 35, 0.5);
+}
+
+.dark .page-shell section {
+  background: rgba(15, 23, 42, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  box-shadow: 0 40px 70px rgba(8, 15, 35, 0.45) !important;
 }
 
 .page-shell section[data-variant="plain"] {
@@ -316,31 +357,46 @@ label {
   color: var(--text-muted);
 }
 
+
 .tab-pill {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem 1.25rem;
+  gap: 0.6rem;
+  padding: 0.85rem 1.35rem;
   border-radius: var(--radius-2xl);
-  background-color: var(--surface-muted);
+  background: linear-gradient(
+    140deg,
+    rgba(148, 163, 184, 0.18) 0%,
+    rgba(255, 255, 255, 0.4) 100%
+  );
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
   color: var(--accent-primary);
   font-weight: 600;
-  border: 1px solid var(--border-subtle);
-  box-shadow: var(--shadow-soft);
-  transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease,
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: none;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease,
     box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
 .tab-pill[data-active="true"] {
-  background-color: var(--accent-primary);
+  background: linear-gradient(
+    135deg,
+    rgba(37, 99, 235, 0.9) 0%,
+    rgba(37, 99, 235, 0.65) 100%
+  );
   color: var(--surface-primary);
   border-color: transparent;
   box-shadow: var(--shadow-button);
 }
 
 .tab-pill[data-active="false"]:hover {
-  background-color: var(--surface-subtle);
-  box-shadow: var(--shadow-card);
+  background: linear-gradient(
+    140deg,
+    rgba(148, 163, 184, 0.24) 0%,
+    rgba(255, 255, 255, 0.52) 100%
+  );
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
 }
 
 .tab-pill__icon {
@@ -349,12 +405,18 @@ label {
 }
 
 .dark .tab-pill {
-  background-color: rgba(51, 65, 85, 0.55);
-  border-color: rgba(148, 163, 184, 0.2);
+  background: linear-gradient(
+    140deg,
+    rgba(148, 163, 184, 0.18) 0%,
+    rgba(15, 23, 42, 0.65) 100%
+  );
+  border-color: rgba(148, 163, 184, 0.16);
+  color: var(--accent-primary);
 }
 
 .dark .tab-pill[data-active="true"] {
   color: var(--text-strong);
+  box-shadow: 0 28px 55px rgba(96, 165, 250, 0.35);
 }
 
 .theme-toggle {

--- a/components/AuthGate.tsx
+++ b/components/AuthGate.tsx
@@ -144,15 +144,22 @@ const AuthGate = ({ children }: { children: ReactNode }) => {
     >
       <div
         style={{
-          backgroundColor: "var(--surface-subtle)",
-          color: "var(--text-secondary)",
-          padding: "0.75rem 1.5rem",
-          display: "flex",
           alignItems: "center",
+          alignSelf: "center",
+          backdropFilter: "blur(18px)",
+          WebkitBackdropFilter: "blur(18px)",
+          backgroundColor: "transparent",
+          border: "1px solid rgba(148, 163, 184, 0.18)",
+          borderRadius: "1.25rem",
+          boxShadow: "0 20px 45px rgba(15, 23, 42, 0.12)",
+          color: "var(--text-secondary)",
+          display: "flex",
+          gap: "1.25rem",
           justifyContent: "space-between",
-          gap: "1rem",
-          flexWrap: "wrap",
-          borderBottom: "1px solid var(--border-strong)"
+          margin: "1.5rem 0 1rem",
+          padding: "1rem 1.75rem",
+          width: "min(100%, 980px)",
+          flexWrap: "wrap"
         }}
       >
         <span style={{ fontWeight: 600 }}>


### PR DESCRIPTION
## Summary
- lighten the authenticated header with a transparent, blurred card treatment
- introduce glassmorphism-inspired backgrounds for the overall dashboard shell and navigation pills
- add ambient gradients to the global background for a lighter, airier visual hierarchy

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68dc786a3fa88331993c564751455abf