### PR TITLE
Make header logout button transparent

### DIFF
--- a/components/AuthGate.tsx
+++ b/components/AuthGate.tsx
@@ -164,7 +164,7 @@ const AuthGate = ({ children }: { children: ReactNode }) => {
             void logout();
           }}
           disabled={authenticating}
-          data-variant="outline"
+          data-variant="ghost"
         >
           {authenticating ? "Выходим..." : "Выйти"}
         </button>


### PR DESCRIPTION
## Summary
- switch the authenticated header logout button to the ghost variant to remove its border and background

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc7ca0a428833180de969261811cf1