### PR TITLE
Add collapsible navigation menu on home page

### DIFF
--- a/components/AppNavigation.tsx
+++ b/components/AppNavigation.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from "next/link";
 import type { LucideIcon } from "lucide-react";
 import { BarChart3, HandCoins, LayoutDashboard, ListChecks, Settings, Wallet } from "lucide-react";

--- a/components/HomeNavigation.tsx
+++ b/components/HomeNavigation.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+
+import AppNavigation, { type AppTabKey } from "@/components/AppNavigation";
+
+type HomeNavigationProps = {
+  activeTab: AppTabKey;
+};
+
+const HomeNavigation = ({ activeTab }: HomeNavigationProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggleMenu = () => {
+    setIsOpen((prev) => !prev);
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-4">
+      <button
+        type="button"
+        className="tab-pill flex items-center justify-center gap-2"
+        onClick={toggleMenu}
+        aria-expanded={isOpen}
+        aria-controls="home-navigation-menu"
+      >
+        {isOpen ? (
+          <ChevronUp aria-hidden className="tab-pill__icon" />
+        ) : (
+          <ChevronDown aria-hidden className="tab-pill__icon" />
+        )}
+        <span>Меню</span>
+      </button>
+      {isOpen ? (
+        <div id="home-navigation-menu">
+          <AppNavigation activeTab={activeTab} />
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default HomeNavigation;

--- a/components/PageContainer.tsx
+++ b/components/PageContainer.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 import AppNavigation, { type AppTabKey } from "@/components/AppNavigation";
+import HomeNavigation from "@/components/HomeNavigation";
 
 type PageContainerProps = {
   activeTab: AppTabKey;
@@ -10,7 +11,11 @@ type PageContainerProps = {
 const PageContainer = ({ activeTab, children }: PageContainerProps) => (
   <main className="page-shell">
     <div className="flex w-full flex-col gap-10">
-      <AppNavigation activeTab={activeTab} />
+      {activeTab === "home" ? (
+        <HomeNavigation activeTab={activeTab} />
+      ) : (
+        <AppNavigation activeTab={activeTab} />
+      )}
       {children}
     </div>
   </main>


### PR DESCRIPTION
## Summary
- convert the shared navigation into a client component to support interaction
- add a dedicated HomeNavigation wrapper that collapses all tab links behind a “Меню” toggle
- render the collapsible menu on the home tab while keeping the existing navigation on other pages

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68de15feeb1483318db38261a602d282