### PR TITLE
Fix session cookie security detection for auth

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -67,7 +67,7 @@ export const POST = async (request: NextRequest) => {
 
     // ✅ Теперь возвращаем и токен, и юзера
     const response = NextResponse.json({ token, user: sessionUser });
-setSessionCookie(response, token, expiresAt);
+    setSessionCookie(response, token, expiresAt, request);
 
     return response;
   } catch (err: any) {

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -10,7 +10,7 @@ export const POST = (request: NextRequest) => {
 
   const response = NextResponse.json({ success: true });
 
-  clearSessionCookie(response);
+  clearSessionCookie(response, request);
 
   return response;
 };


### PR DESCRIPTION
## Summary
- derive the session cookie secure flag from the incoming request so HTTP deployments still receive cookies
- update the login/logout handlers to forward the request when setting or clearing the session cookie

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68dedb8cf2f08331a0eac98843a11aa3