### PR TITLE
Fix wallet balance reduction for debt payments

### DIFF
--- a/app/api/balance/route.ts
+++ b/app/api/balance/route.ts
@@ -2,7 +2,6 @@
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { convertToBase } from "@/lib/currency";
-import { extractDebtPaymentAmount } from "@/lib/debtPayments";
 import { loadSettings } from "@/lib/settingsService";
 
 export async function GET() {
@@ -79,23 +78,7 @@ export async function GET() {
         operationsBalance += amountInBase;
       } else {
         // expense
-        let nextValue = operationsBalance - amountInBase;
-
-        // Корректировка: если это платёж по долгу — возвращаем эффект
-        const sourceStr =
-          typeof operation.source === "string" ? operation.source : "";
-        const debtPaymentAmount = extractDebtPaymentAmount(sourceStr);
-
-        if (debtPaymentAmount > 0) {
-          const paymentInBase = convertToBase(
-            debtPaymentAmount,
-            currency,
-            settings
-          );
-          nextValue += paymentInBase;
-        }
-
-        operationsBalance = nextValue;
+        operationsBalance -= amountInBase;
       }
     }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,7 +22,6 @@ import {
   type Wallet,
   type WalletWithCurrency
 } from "@/lib/types";
-import { extractDebtPaymentAmount } from "@/lib/debtPayments";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
@@ -490,15 +489,7 @@ const Dashboard = () => {
         return acc + amountInBase;
       }
 
-      let nextValue = acc - amountInBase;
-      const debtPaymentAmount = extractDebtPaymentAmount(operation.source);
-
-      if (debtPaymentAmount > 0) {
-        const paymentInBase = convertToBase(debtPaymentAmount, operation.currency, activeSettings);
-        nextValue += paymentInBase;
-      }
-
-      return nextValue;
+      return acc - amountInBase;
     }, 0);
 
     return operationsBalance + balanceEffect;

--- a/app/wallets/page.tsx
+++ b/app/wallets/page.tsx
@@ -14,7 +14,6 @@ import AuthGate from "@/components/AuthGate";
 import PageContainer from "@/components/PageContainer";
 import { useSession } from "@/components/SessionProvider";
 import { convertFromBase, convertToBase, DEFAULT_SETTINGS, SUPPORTED_CURRENCIES } from "@/lib/currency";
-import { extractDebtPaymentAmount } from "@/lib/debtPayments";
 import {
   type Currency,
   type Debt,
@@ -397,19 +396,11 @@ const WalletsContent = () => {
       }
 
       entry.base -= amountInBase;
-      updateCurrencyAmount(entry.byCurrency, operation.currency, (previous) => previous - operation.amount);
-
-      const debtPaymentAmount = extractDebtPaymentAmount(operation.source);
-
-      if (debtPaymentAmount > 0) {
-        const paymentInBase = convertToBase(
-          debtPaymentAmount,
-          operation.currency,
-          activeSettings
-        );
-        entry.base += paymentInBase;
-        updateCurrencyAmount(entry.byCurrency, operation.currency, (previous) => previous + debtPaymentAmount);
-      }
+      updateCurrencyAmount(
+        entry.byCurrency,
+        operation.currency,
+        (previous) => previous - operation.amount
+      );
     }
 
     for (const debt of debts) {


### PR DESCRIPTION
## Summary
- remove the debt payment compensation when calculating wallet and overall balances so wallet totals decrease on repayment
- drop unused imports that supported the incorrect adjustment logic

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68df897925208331a88152fdda98292d