### PR TITLE
feat: allow changing base currency

### DIFF
--- a/app/api/currencies/[code]/route.ts
+++ b/app/api/currencies/[code]/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { ensureAccountant } from "@/lib/auth";
+import { removeCurrency } from "@/lib/settingsService";
+
+const PASSWORD = "108";
+
+export const DELETE = async (
+  request: NextRequest,
+  { params }: { params: { code: string } }
+) => {
+  const auth = await ensureAccountant(request);
+
+  if (auth.response) {
+    return auth.response;
+  }
+
+  const payload = (await request.json()) as { password?: string } | null;
+
+  if (payload?.password !== PASSWORD) {
+    return NextResponse.json({ error: "Неверный пароль" }, { status: 403 });
+  }
+
+  try {
+    const settings = await removeCurrency(params.code);
+
+    return NextResponse.json(settings);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Не удалось удалить валюту";
+
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+};

--- a/app/api/currencies/route.ts
+++ b/app/api/currencies/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { ensureAccountant } from "@/lib/auth";
+import { findPopularCurrency } from "@/lib/currencyCatalog";
+import { addCurrency, loadSettings } from "@/lib/settingsService";
+
+export const GET = async () => {
+  const settings = await loadSettings();
+
+  return NextResponse.json({ currencies: settings.availableCurrencies });
+};
+
+export const POST = async (request: NextRequest) => {
+  const auth = await ensureAccountant(request);
+
+  if (auth.response) {
+    return auth.response;
+  }
+
+  const payload = (await request.json()) as { code?: string } | null;
+
+  if (!payload?.code) {
+    return NextResponse.json({ error: "Не указана валюта" }, { status: 400 });
+  }
+
+  const candidate = findPopularCurrency(payload.code);
+
+  if (!candidate) {
+    return NextResponse.json({ error: "Валюта не найдена" }, { status: 404 });
+  }
+
+  try {
+    const settings = await addCurrency(candidate.code, candidate.rateToUSD);
+
+    return NextResponse.json(settings);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Не удалось добавить валюту";
+
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+};

--- a/app/api/rates/route.ts
+++ b/app/api/rates/route.ts
@@ -1,11 +1,12 @@
 // app/api/rates/route.ts
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
+import { POPULAR_CURRENCIES } from "@/lib/currencyCatalog";
 
 export const revalidate = 0; // отключаем кеш
 
 // список валют, которые нужны
-const TARGETS = ["RUB", "GEL", "EUR"] as const;
+const TARGETS = Array.from(new Set(POPULAR_CURRENCIES.map((item) => item.code)));
 
 export async function GET(request: Request) {
   const url = new URL(request.url);

--- a/app/api/rates/route.ts
+++ b/app/api/rates/route.ts
@@ -1,18 +1,19 @@
 // app/api/rates/route.ts
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
-import { POPULAR_CURRENCIES } from "@/lib/currencyCatalog";
+import { loadSettings } from "@/lib/settingsService";
 
 export const revalidate = 0; // отключаем кеш
-
-// список валют, которые нужны
-const TARGETS = Array.from(new Set(POPULAR_CURRENCIES.map((item) => item.code)));
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
   const force = url.searchParams.has("force");
 
   try {
+    const settings = await loadSettings();
+    const targetSet = new Set<string>(settings.availableCurrencies);
+    const targets = Array.from(targetSet);
+
     // запрос к бесплатному API
     const res = await fetch("https://open.er-api.com/v6/latest/USD", {
       cache: "no-store",
@@ -29,7 +30,7 @@ export async function GET(request: Request) {
     const updates: any[] = [];
     const now = new Date();
 
-    for (const cur of TARGETS) {
+    for (const cur of targets) {
       if (data.rates[cur]) {
         const rawRate = Number(data.rates[cur]);
 

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { ensureAccountant } from "@/lib/auth";
-import { SUPPORTED_CURRENCIES } from "@/lib/currency";
 import { recalculateGoalProgress } from "@/lib/goals";
 import { loadSettings, updateSettings } from "@/lib/settingsService";
 import type { Currency } from "@/lib/types";
@@ -25,14 +24,20 @@ export const PATCH = async (request: NextRequest) => {
     return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
   }
 
+  const currentSettings = await loadSettings();
   const nextRates: Partial<Record<Currency, number>> = {};
 
   if (payload.rates) {
-    for (const currency of SUPPORTED_CURRENCIES) {
-      const rawRate = payload.rates[currency];
-
+    for (const [currency, rawRate] of Object.entries(payload.rates)) {
       if (rawRate === undefined) {
         continue;
+      }
+
+      if (!currentSettings.availableCurrencies.includes(currency)) {
+        return NextResponse.json(
+          { error: `Валюта ${currency} недоступна` },
+          { status: 400 }
+        );
       }
 
       const numericRate = typeof rawRate === "number" ? rawRate : Number(rawRate);
@@ -53,7 +58,7 @@ export const PATCH = async (request: NextRequest) => {
   let nextBaseCurrency: Currency | undefined;
 
   if (payload.baseCurrency !== undefined) {
-    if (!SUPPORTED_CURRENCIES.includes(payload.baseCurrency)) {
+    if (!currentSettings.availableCurrencies.includes(payload.baseCurrency)) {
       return NextResponse.json(
         { error: "Unsupported base currency" },
         { status: 400 }

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -2,10 +2,11 @@ import { NextResponse, type NextRequest } from "next/server";
 import { ensureAccountant } from "@/lib/auth";
 import { SUPPORTED_CURRENCIES } from "@/lib/currency";
 import { recalculateGoalProgress } from "@/lib/goals";
-import { applyRatesUpdate, loadSettings } from "@/lib/settingsService";
+import { loadSettings, updateSettings } from "@/lib/settingsService";
 import type { Currency } from "@/lib/types";
 
 type SettingsPayload = {
+  baseCurrency?: Currency;
   rates?: Partial<Record<Currency, number>>;
 };
 
@@ -20,35 +21,63 @@ export const PATCH = async (request: NextRequest) => {
 
   const payload = (await request.json()) as SettingsPayload | null;
 
-  if (!payload || typeof payload !== "object" || !payload.rates) {
+  if (!payload || typeof payload !== "object") {
     return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
   }
 
-  const newRates: Partial<Record<Currency, number>> = {};
+  const nextRates: Partial<Record<Currency, number>> = {};
 
-  for (const currency of SUPPORTED_CURRENCIES) {
-    const rawRate = payload.rates[currency];
+  if (payload.rates) {
+    for (const currency of SUPPORTED_CURRENCIES) {
+      const rawRate = payload.rates[currency];
 
-    if (rawRate === undefined) {
-      continue;
+      if (rawRate === undefined) {
+        continue;
+      }
+
+      const numericRate = typeof rawRate === "number" ? rawRate : Number(rawRate);
+
+      if (!Number.isFinite(numericRate) || numericRate <= 0) {
+        return NextResponse.json(
+          {
+            error: `Invalid rate for ${currency}`
+          },
+          { status: 400 }
+        );
+      }
+
+      nextRates[currency] = numericRate;
     }
+  }
 
-    const numericRate = typeof rawRate === "number" ? rawRate : Number(rawRate);
+  let nextBaseCurrency: Currency | undefined;
 
-    if (!Number.isFinite(numericRate) || numericRate <= 0) {
+  if (payload.baseCurrency !== undefined) {
+    if (!SUPPORTED_CURRENCIES.includes(payload.baseCurrency)) {
       return NextResponse.json(
-        {
-          error: `Invalid rate for ${currency}`
-        },
+        { error: "Unsupported base currency" },
         { status: 400 }
       );
     }
 
-    newRates[currency] = numericRate;
+    nextBaseCurrency = payload.baseCurrency;
   }
 
-  const settings = await applyRatesUpdate(newRates);
-  await recalculateGoalProgress();
+  if (!nextBaseCurrency && Object.keys(nextRates).length === 0) {
+    return NextResponse.json({ error: "Nothing to update" }, { status: 400 });
+  }
 
-  return NextResponse.json(settings);
+  try {
+    const settings = await updateSettings({
+      baseCurrency: nextBaseCurrency,
+      rates: Object.keys(nextRates).length > 0 ? nextRates : undefined
+    });
+    await recalculateGoalProgress();
+
+    return NextResponse.json(settings);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Не удалось обновить настройки";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
 };

--- a/app/debts/page.tsx
+++ b/app/debts/page.tsx
@@ -5,11 +5,7 @@ import useSWR from "swr";
 import AuthGate from "@/components/AuthGate";
 import PageContainer from "@/components/PageContainer";
 import { useSession } from "@/components/SessionProvider";
-import {
-  convertToBase,
-  DEFAULT_SETTINGS,
-  SUPPORTED_CURRENCIES
-} from "@/lib/currency";
+import { convertToBase, DEFAULT_SETTINGS } from "@/lib/currency";
 import {
   type Currency,
   type Debt,
@@ -80,6 +76,24 @@ const DebtsContent = () => {
       setCurrency(settingsData.baseCurrency);
     }
   }, [settingsData]);
+
+  useEffect(() => {
+    if (!settings) {
+      return;
+    }
+
+    setCurrency((current) => {
+      if (settings.availableCurrencies.includes(current)) {
+        return current;
+      }
+
+      return (
+        settings.availableCurrencies[0] ??
+        settings.baseCurrency ??
+        DEFAULT_SETTINGS.baseCurrency
+      );
+    });
+  }, [settings]);
 
   useEffect(() => {
     if (!walletsData) {
@@ -173,14 +187,20 @@ const DebtsContent = () => {
 
   const { borrowed, lent } = totals;
   const activeSettings = settings ?? DEFAULT_SETTINGS;
-  const baseFormatter = useMemo(
-    () =>
-      new Intl.NumberFormat("ru-RU", {
+  const availableCurrencies = activeSettings.availableCurrencies;
+  const baseFormatter = useMemo(() => {
+    try {
+      return new Intl.NumberFormat("ru-RU", {
         style: "currency",
         currency: activeSettings.baseCurrency
-      }),
-    [activeSettings.baseCurrency]
-  );
+      });
+    } catch {
+      return new Intl.NumberFormat("ru-RU", {
+        style: "currency",
+        currency: "USD"
+      });
+    }
+  }, [activeSettings.baseCurrency]);
 
   const handleDelete = async (id: string) => {
     if (!canManage) {
@@ -430,7 +450,7 @@ const DebtsContent = () => {
               border: "1px solid var(--border-muted)"
             }}
           >
-            {SUPPORTED_CURRENCIES.map((item) => (
+            {availableCurrencies.map((item) => (
               <option key={item} value={item}>
                 {item}
               </option>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -501,14 +501,19 @@ const Dashboard = () => {
   );
 
   const activeSettings = settings ?? DEFAULT_SETTINGS;
-  const balanceFormatter = useMemo(
-    () =>
-      new Intl.NumberFormat("ru-RU", {
+  const balanceFormatter = useMemo(() => {
+    try {
+      return new Intl.NumberFormat("ru-RU", {
         style: "currency",
         currency: activeSettings.baseCurrency
-      }),
-    [activeSettings.baseCurrency]
-  );
+      });
+    } catch {
+      return new Intl.NumberFormat("ru-RU", {
+        style: "currency",
+        currency: "USD"
+      });
+    }
+  }, [activeSettings.baseCurrency]);
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/app/planning/page.tsx
+++ b/app/planning/page.tsx
@@ -5,7 +5,7 @@ import useSWR from "swr";
 import AuthGate from "@/components/AuthGate";
 import PageContainer from "@/components/PageContainer";
 import { useSession } from "@/components/SessionProvider";
-import { convertFromBase, DEFAULT_SETTINGS, SUPPORTED_CURRENCIES } from "@/lib/currency";
+import { convertFromBase, DEFAULT_SETTINGS } from "@/lib/currency";
 import type { Currency, Goal, Settings } from "@/lib/types";
 import { fetcher, type FetcherError } from "@/lib/fetcher";
 
@@ -61,6 +61,24 @@ const PlanningContent = () => {
   }, [settingsData]);
 
   useEffect(() => {
+    if (!settings) {
+      return;
+    }
+
+    setCurrency((current) => {
+      if (settings.availableCurrencies.includes(current)) {
+        return current;
+      }
+
+      return (
+        settings.availableCurrencies[0] ??
+        settings.baseCurrency ??
+        DEFAULT_SETTINGS.baseCurrency
+      );
+    });
+  }, [settings]);
+
+  useEffect(() => {
     const currentError = goalsError || settingsError;
 
     if (!currentError) {
@@ -96,14 +114,20 @@ const PlanningContent = () => {
   );
 
   const activeSettings = settings ?? DEFAULT_SETTINGS;
-  const baseCurrencyFormatter = useMemo(
-    () =>
-      new Intl.NumberFormat("ru-RU", {
+  const availableCurrencies = activeSettings.availableCurrencies;
+  const baseCurrencyFormatter = useMemo(() => {
+    try {
+      return new Intl.NumberFormat("ru-RU", {
         style: "currency",
         currency: activeSettings.baseCurrency
-      }),
-    [activeSettings.baseCurrency]
-  );
+      });
+    } catch {
+      return new Intl.NumberFormat("ru-RU", {
+        style: "currency",
+        currency: "USD"
+      });
+    }
+  }, [activeSettings.baseCurrency]);
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -325,7 +349,7 @@ const PlanningContent = () => {
               onChange={(event) => setCurrency(event.target.value as Currency)}
               disabled={!canManage || loading}
             >
-              {SUPPORTED_CURRENCIES.map((item) => (
+              {availableCurrencies.map((item) => (
                 <option key={item} value={item}>
                   {item}
                 </option>

--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -252,14 +252,19 @@ const ReportsContent = () => {
 
   const activeSettings = settings ?? DEFAULT_SETTINGS;
 
-  const currencyFormatter = useMemo(
-    () =>
-      new Intl.NumberFormat("ru-RU", {
+  const currencyFormatter = useMemo(() => {
+    try {
+      return new Intl.NumberFormat("ru-RU", {
         style: "currency",
         currency: activeSettings.baseCurrency
-      }),
-    [activeSettings.baseCurrency]
-  );
+      });
+    } catch {
+      return new Intl.NumberFormat("ru-RU", {
+        style: "currency",
+        currency: "USD"
+      });
+    }
+  }, [activeSettings.baseCurrency]);
 
   const totals = useMemo(() => {
     const summary = filteredOperations.reduce(

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ChangeEvent
+} from "react";
 import useSWR from "swr";
 import AuthGate from "@/components/AuthGate";
 import PageContainer from "@/components/PageContainer";
@@ -142,11 +148,19 @@ const SettingsContent = () => {
     { login: string; password: string } | null
   >(null);
   const [userError, setUserError] = useState<string | null>(null);
+  const [baseCurrencyDraft, setBaseCurrencyDraft] = useState<Currency>(
+    DEFAULT_SETTINGS.baseCurrency
+  );
+  const [baseCurrencySaving, setBaseCurrencySaving] = useState(false);
+  const [baseCurrencyError, setBaseCurrencyError] = useState<string | null>(
+    null
+  );
 
   const {
     data: settingsData,
     error: settingsFetchError,
-    isLoading: settingsLoading
+    isLoading: settingsLoading,
+    mutate: mutateSettings
   } = useSWR<Settings>(user ? "/api/settings" : null, fetcher, {
     revalidateOnFocus: true
   });
@@ -163,6 +177,8 @@ const SettingsContent = () => {
     }
 
     setSettings(settingsData);
+    setBaseCurrencyDraft(settingsData.baseCurrency);
+    setBaseCurrencyError(null);
   }, [settingsData]);
 
   useEffect(() => {
@@ -237,6 +253,71 @@ const SettingsContent = () => {
       }),
     [baseCurrency]
   );
+
+  const handleBaseCurrencyChange = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => {
+      setBaseCurrencyDraft(event.target.value as Currency);
+      setBaseCurrencyError(null);
+    },
+    []
+  );
+
+  const handleSaveBaseCurrency = useCallback(async () => {
+    if (!canManage || baseCurrencySaving || baseCurrencyDraft === baseCurrency) {
+      return;
+    }
+
+    setBaseCurrencySaving(true);
+    setBaseCurrencyError(null);
+    setMessage(null);
+
+    try {
+      const response = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ baseCurrency: baseCurrencyDraft })
+      });
+
+      const data = (await response.json().catch(() => null)) as
+        | Settings
+        | { error?: string }
+        | null;
+
+      if (response.status === 401) {
+        setBaseCurrencyError("Сессия истекла, войдите заново.");
+        await refresh();
+        return;
+      }
+
+      if (response.status === 403) {
+        setBaseCurrencyError("Недостаточно прав для обновления настроек.");
+        return;
+      }
+
+      if (!response.ok || !data || !isSettings(data)) {
+        const message = (data as { error?: string } | null)?.error;
+        throw new Error(message ?? "Не удалось обновить базовую валюту");
+      }
+
+      setSettings(data);
+      setBaseCurrencyDraft(data.baseCurrency);
+      void mutateSettings(data, { revalidate: false });
+      setMessage("Базовая валюта обновлена");
+    } catch (err) {
+      setBaseCurrencyError(
+        err instanceof Error ? err.message : "Не удалось обновить базовую валюту"
+      );
+    } finally {
+      setBaseCurrencySaving(false);
+    }
+  }, [
+    baseCurrency,
+    baseCurrencyDraft,
+    baseCurrencySaving,
+    canManage,
+    mutateSettings,
+    refresh
+  ]);
 
   const handleForceUpdate = () => {
     if (!canManage) {
@@ -410,6 +491,63 @@ const SettingsContent = () => {
               <p style={{ color: "var(--text-secondary)", marginTop: "0.5rem" }}>
                 Все суммы приводятся к этой валюте для расчётов.
               </p>
+              {canManage ? (
+                <div
+                  style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: "0.75rem",
+                    marginTop: "1.25rem"
+                  }}
+                >
+                  <label
+                    style={{
+                      display: "flex",
+                      flexDirection: "column",
+                      gap: "0.5rem"
+                    }}
+                  >
+                    <span style={{ fontWeight: 600, color: "var(--text-strong)" }}>
+                      Выберите новую базовую валюту
+                    </span>
+                    <select
+                      value={baseCurrencyDraft}
+                      onChange={handleBaseCurrencyChange}
+                      disabled={baseCurrencySaving}
+                      style={{
+                        padding: "0.85rem 1rem",
+                        borderRadius: "0.75rem",
+                        border: "1px solid var(--surface-muted)",
+                        backgroundColor: "var(--surface-base)",
+                        fontWeight: 600,
+                        color: "var(--text-strong)",
+                        cursor: baseCurrencySaving ? "not-allowed" : "pointer"
+                      }}
+                    >
+                      {SUPPORTED_CURRENCIES.map((code) => (
+                        <option key={code} value={code}>
+                          {code}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <button
+                    type="button"
+                    onClick={handleSaveBaseCurrency}
+                    disabled={
+                      baseCurrencySaving || baseCurrencyDraft === baseCurrency
+                    }
+                    className="inline-flex w-fit items-center justify-center rounded-xl bg-indigo-600 px-4 py-2 font-semibold text-white shadow transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-indigo-400"
+                  >
+                    {baseCurrencySaving ? "Сохраняем..." : "Сохранить"}
+                  </button>
+                </div>
+              ) : null}
+              {baseCurrencyError ? (
+                <p style={{ color: "var(--accent-danger)", marginTop: "0.5rem" }}>
+                  {baseCurrencyError}
+                </p>
+              ) : null}
             </article>
           </section>
 

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -13,11 +13,8 @@ import AuthGate from "@/components/AuthGate";
 import PageContainer from "@/components/PageContainer";
 import ThemeToggle from "@/components/ThemeToggle";
 import { useSession } from "@/components/SessionProvider";
-import {
-  DEFAULT_SETTINGS,
-  SUPPORTED_CURRENCIES,
-  convertToBase
-} from "@/lib/currency";
+import { DEFAULT_SETTINGS, convertToBase } from "@/lib/currency";
+import { POPULAR_CURRENCIES } from "@/lib/currencyCatalog";
 import type { Currency, Settings } from "@/lib/types";
 import { fetcher, type FetcherError } from "@/lib/fetcher";
 
@@ -30,7 +27,8 @@ const isSettings = (value: unknown): value is Settings => {
 
   return (
     typeof candidate.baseCurrency === "string" &&
-    SUPPORTED_CURRENCIES.includes(candidate.baseCurrency as Currency) &&
+    Array.isArray(candidate.availableCurrencies) &&
+    candidate.availableCurrencies.every((item) => typeof item === "string") &&
     !!candidate.rates &&
     typeof candidate.rates === "object"
   );
@@ -41,8 +39,6 @@ type RateInfo = {
   updatedAt: string | null;
 };
 
-const RATE_CURRENCIES: readonly Currency[] = ["RUB", "GEL", "EUR"];
-
 const RATE_PLACEHOLDERS: Partial<Record<Currency, string>> = {
   USD: "1",
   RUB: "0.012",
@@ -50,8 +46,10 @@ const RATE_PLACEHOLDERS: Partial<Record<Currency, string>> = {
   EUR: "1.18"
 };
 
-const buildInitialRates = () =>
-  RATE_CURRENCIES.reduce<Partial<Record<Currency, RateInfo>>>((acc, code) => {
+const buildInitialRates = (): Partial<Record<Currency, RateInfo>> =>
+  DEFAULT_SETTINGS.availableCurrencies.reduce<
+    Partial<Record<Currency, RateInfo>>
+  >((acc, code: Currency) => {
     const rawRate = DEFAULT_SETTINGS.rates[code];
 
     if (typeof rawRate === "number" && Number.isFinite(rawRate) && rawRate > 0) {
@@ -93,10 +91,6 @@ const normalizeRatesResponse = (rows: unknown[]): Partial<Record<Currency, RateI
     };
 
     if (typeof currency !== "string") {
-      continue;
-    }
-
-    if (!RATE_CURRENCIES.includes(currency as Currency)) {
       continue;
     }
 
@@ -160,6 +154,17 @@ const SettingsContent = () => {
   const [baseCurrencyError, setBaseCurrencyError] = useState<string | null>(
     null
   );
+  const [showAddCurrency, setShowAddCurrency] = useState(false);
+  const [addCurrencyError, setAddCurrencyError] = useState<string | null>(null);
+  const [addCurrencyLoading, setAddCurrencyLoading] = useState<Currency | null>(
+    null
+  );
+  const [removalCandidate, setRemovalCandidate] = useState<Currency | null>(
+    null
+  );
+  const [removalPassword, setRemovalPassword] = useState("");
+  const [removalLoading, setRemovalLoading] = useState(false);
+  const [removalError, setRemovalError] = useState<string | null>(null);
 
   const {
     data: settingsData,
@@ -184,6 +189,13 @@ const SettingsContent = () => {
     setSettings(settingsData);
     setBaseCurrencyDraft(settingsData.baseCurrency);
     setBaseCurrencyError(null);
+    setShowAddCurrency(false);
+    setAddCurrencyLoading(null);
+    setAddCurrencyError(null);
+    setRemovalCandidate(null);
+    setRemovalPassword("");
+    setRemovalLoading(false);
+    setRemovalError(null);
   }, [settingsData]);
 
   useEffect(() => {
@@ -250,18 +262,39 @@ const SettingsContent = () => {
   }, [loadRates]);
 
   const baseCurrency = settings.baseCurrency;
-  const baseFormatter = useMemo(
-    () =>
-      new Intl.NumberFormat("ru-RU", {
+  const baseFormatter = useMemo(() => {
+    try {
+      return new Intl.NumberFormat("ru-RU", {
         style: "currency",
         currency: baseCurrency
-      }),
-    [baseCurrency]
+      });
+    } catch {
+      return new Intl.NumberFormat("ru-RU", {
+        style: "currency",
+        currency: "USD"
+      });
+    }
+  }, [baseCurrency]);
+
+  const availableCurrencyOptions = useMemo(
+    () => Array.from(new Set(settings.availableCurrencies)),
+    [settings.availableCurrencies]
   );
 
   const displayCurrencies = useMemo(
-    () => SUPPORTED_CURRENCIES.filter((code) => code !== baseCurrency),
-    [baseCurrency]
+    () =>
+      availableCurrencyOptions.filter(
+        (code) => typeof code === "string" && code !== baseCurrency
+      ),
+    [availableCurrencyOptions, baseCurrency]
+  );
+
+  const addableCurrencies = useMemo(
+    () =>
+      POPULAR_CURRENCIES.filter(
+        ({ code }) => !availableCurrencyOptions.includes(code)
+      ),
+    [availableCurrencyOptions]
   );
 
   const handleBaseCurrencyChange = useCallback(
@@ -271,6 +304,148 @@ const SettingsContent = () => {
     },
     []
   );
+
+  const handleAddCurrency = useCallback(
+    async (code: Currency) => {
+      if (!canManage || addCurrencyLoading) {
+        return;
+      }
+
+      setAddCurrencyLoading(code);
+      setAddCurrencyError(null);
+      setMessage(null);
+
+      try {
+        const response = await fetch("/api/currencies", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ code })
+        });
+
+        const data = (await response.json().catch(() => null)) as
+          | Settings
+          | { error?: string }
+          | null;
+
+        if (response.status === 401) {
+          setAddCurrencyError("Сессия истекла, войдите заново.");
+          await refresh();
+          return;
+        }
+
+        if (response.status === 403) {
+          setAddCurrencyError("Недостаточно прав для добавления валюты.");
+          return;
+        }
+
+        if (!response.ok || !data || !isSettings(data)) {
+          const message = (data as { error?: string } | null)?.error;
+          throw new Error(message ?? "Не удалось добавить валюту");
+        }
+
+        setSettings(data);
+        setBaseCurrencyDraft(data.baseCurrency);
+        void mutateSettings(data, { revalidate: false });
+        setShowAddCurrency(false);
+        setMessage(`Валюта ${code} добавлена`);
+      } catch (err) {
+        setAddCurrencyError(
+          err instanceof Error ? err.message : "Не удалось добавить валюту"
+        );
+      } finally {
+        setAddCurrencyLoading(null);
+      }
+    },
+    [addCurrencyLoading, canManage, mutateSettings, refresh]
+  );
+
+  const startRemoval = useCallback(
+    (code: Currency) => {
+      if (!canManage) {
+        return;
+      }
+
+      setRemovalCandidate(code);
+      setRemovalPassword("");
+      setRemovalError(null);
+      setMessage(null);
+    },
+    [canManage]
+  );
+
+  const cancelRemoval = useCallback(() => {
+    setRemovalCandidate(null);
+    setRemovalPassword("");
+    setRemovalError(null);
+  }, []);
+
+  const handleRemovalPasswordChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setRemovalPassword(event.target.value);
+    },
+    []
+  );
+
+  const confirmRemoval = useCallback(async () => {
+    if (!canManage || !removalCandidate || removalLoading) {
+      return;
+    }
+
+    setRemovalLoading(true);
+    setRemovalError(null);
+    setMessage(null);
+
+    try {
+      const response = await fetch(`/api/currencies/${removalCandidate}`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password: removalPassword })
+      });
+
+      const data = (await response.json().catch(() => null)) as
+        | Settings
+        | { error?: string }
+        | null;
+
+      if (response.status === 401) {
+        setRemovalError("Сессия истекла, войдите заново.");
+        await refresh();
+        return;
+      }
+
+      if (response.status === 403) {
+        setRemovalError("Неверный пароль или недостаточно прав.");
+        return;
+      }
+
+      if (!response.ok || !data || !isSettings(data)) {
+        const message = (data as { error?: string } | null)?.error;
+        throw new Error(message ?? "Не удалось удалить валюту");
+      }
+
+      const removedCurrency = removalCandidate;
+
+      setSettings(data);
+      setBaseCurrencyDraft(data.baseCurrency);
+      void mutateSettings(data, { revalidate: false });
+      setRemovalCandidate(null);
+      setRemovalPassword("");
+      setMessage(`Валюта ${removedCurrency} удалена`);
+    } catch (err) {
+      setRemovalError(
+        err instanceof Error ? err.message : "Не удалось удалить валюту"
+      );
+    } finally {
+      setRemovalLoading(false);
+    }
+  }, [
+    canManage,
+    mutateSettings,
+    refresh,
+    removalCandidate,
+    removalLoading,
+    removalPassword
+  ]);
 
   const handleSaveBaseCurrency = useCallback(async () => {
     if (!canManage || baseCurrencySaving || baseCurrencyDraft === baseCurrency) {
@@ -534,7 +709,7 @@ const SettingsContent = () => {
                         cursor: baseCurrencySaving ? "not-allowed" : "pointer"
                       }}
                     >
-                      {SUPPORTED_CURRENCIES.map((code) => (
+                      {availableCurrencyOptions.map((code) => (
                         <option key={code} value={code}>
                           {code}
                         </option>
@@ -560,6 +735,106 @@ const SettingsContent = () => {
               ) : null}
             </article>
           </section>
+
+          {canManage ? (
+            <article
+              style={{
+                backgroundColor: "var(--surface-base)",
+                borderRadius: "1rem",
+                padding: "1.5rem",
+                border: "1px solid var(--border-muted)",
+                display: "flex",
+                flexDirection: "column",
+                gap: "1rem"
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "0.5rem"
+                }}
+              >
+                <h3 style={{ fontWeight: 600, fontSize: "1.1rem" }}>
+                  Новые популярные валюты
+                </h3>
+                <p style={{ color: "var(--text-secondary)" }}>
+                  Выберите код, чтобы добавить валюту в список доступных. Курсы
+                  указаны относительно доллара США.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => setShowAddCurrency((prev) => !prev)}
+                  className="inline-flex w-fit items-center justify-center rounded-xl border border-indigo-300 px-4 py-2 font-semibold text-indigo-700 transition hover:bg-indigo-50"
+                >
+                  {showAddCurrency ? "Скрыть список" : "Добавить валюту"}
+                </button>
+              </div>
+
+              {showAddCurrency ? (
+                <div
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+                    gap: "1rem"
+                  }}
+                >
+                  {addableCurrencies.length === 0 ? (
+                    <p style={{ color: "var(--text-muted)" }}>
+                      Все популярные валюты уже добавлены.
+                    </p>
+                  ) : (
+                    addableCurrencies.map(({ code, title, rateToUSD }) => {
+                      const formattedRate = formatRateValue(rateToUSD);
+
+                      return (
+                        <div
+                          key={code}
+                          style={{
+                            border: "1px solid var(--border-muted)",
+                            borderRadius: "0.75rem",
+                            padding: "1rem",
+                            display: "flex",
+                            flexDirection: "column",
+                            gap: "0.5rem",
+                            backgroundColor: "var(--surface-muted)"
+                          }}
+                        >
+                          <div
+                            style={{
+                              display: "flex",
+                              flexDirection: "column",
+                              gap: "0.25rem"
+                            }}
+                          >
+                            <strong style={{ fontSize: "1.1rem" }}>{code}</strong>
+                            <span style={{ color: "var(--text-secondary)" }}>
+                              {title}
+                            </span>
+                            <span style={{ color: "var(--text-muted)", fontSize: "0.875rem" }}>
+                              1 {code} = {formattedRate} USD
+                            </span>
+                          </div>
+                          <button
+                            type="button"
+                            onClick={() => void handleAddCurrency(code)}
+                            disabled={addCurrencyLoading === code}
+                            className="inline-flex items-center justify-center rounded-lg bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-emerald-700 disabled:cursor-not-allowed disabled:bg-emerald-400"
+                          >
+                            {addCurrencyLoading === code ? "Добавляем..." : "Добавить"}
+                          </button>
+                        </div>
+                      );
+                    })
+                  )}
+                </div>
+              ) : null}
+
+              {addCurrencyError ? (
+                <p style={{ color: "var(--accent-danger)" }}>{addCurrencyError}</p>
+              ) : null}
+            </article>
+          ) : null}
 
           <div
             data-layout="toolbar"
@@ -624,6 +899,157 @@ const SettingsContent = () => {
                 </label>
               );
             })}
+          </section>
+
+          <section
+            style={{
+              marginTop: "1.5rem",
+              display: "flex",
+              flexDirection: "column",
+              gap: "1rem",
+              border: "1px solid var(--border-muted)",
+              borderRadius: "1rem",
+              padding: "1.5rem",
+              backgroundColor: "var(--surface-base)"
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: "0.5rem"
+              }}
+            >
+              <h3 style={{ fontWeight: 600, fontSize: "1.1rem" }}>Доступные валюты</h3>
+              <p style={{ color: "var(--text-secondary)", fontSize: "0.9rem" }}>
+                Удаление валюты потребует пароль 108. При удалении базовой валюты
+                система автоматически выберет другую доступную валюту.
+              </p>
+            </div>
+            <ul
+              style={{
+                listStyle: "none",
+                margin: 0,
+                padding: 0,
+                display: "flex",
+                flexDirection: "column",
+                gap: "0.75rem"
+              }}
+            >
+              {availableCurrencyOptions.length === 0 ? (
+                <li style={{ color: "var(--text-muted)" }}>
+                  Пока нет доступных валют.
+                </li>
+              ) : (
+                availableCurrencyOptions.map((code) => {
+                  const isRemoving = removalCandidate === code;
+
+                  return (
+                    <li
+                      key={code}
+                      style={{
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: "0.5rem",
+                        border: "1px solid var(--border-muted)",
+                        borderRadius: "0.75rem",
+                        padding: "1rem"
+                      }}
+                    >
+                      <div
+                        style={{
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "space-between",
+                          gap: "1rem",
+                          flexWrap: "wrap"
+                        }}
+                      >
+                        <div
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: "0.5rem"
+                          }}
+                        >
+                          <strong style={{ fontSize: "1.05rem" }}>{code}</strong>
+                          {code === baseCurrency ? (
+                            <span
+                              style={{
+                                color: "var(--text-secondary)",
+                                fontSize: "0.85rem"
+                              }}
+                            >
+                              базовая
+                            </span>
+                          ) : null}
+                        </div>
+                        {canManage ? (
+                          isRemoving ? null : (
+                            <button
+                              type="button"
+                              onClick={() => startRemoval(code)}
+                              className="inline-flex items-center justify-center rounded-lg bg-rose-600 px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-rose-700"
+                            >
+                              Удалить
+                            </button>
+                          )
+                        ) : null}
+                      </div>
+                      {isRemoving ? (
+                        <div
+                          style={{
+                            display: "flex",
+                            flexDirection: "column",
+                            gap: "0.5rem"
+                          }}
+                        >
+                          <input
+                            type="password"
+                            value={removalPassword}
+                            onChange={handleRemovalPasswordChange}
+                            placeholder="Введите пароль 108"
+                            style={{
+                              padding: "0.75rem 1rem",
+                              borderRadius: "0.75rem",
+                              border: "1px solid var(--border-muted)"
+                            }}
+                          />
+                          <div
+                            style={{
+                              display: "flex",
+                              gap: "0.5rem",
+                              flexWrap: "wrap"
+                            }}
+                          >
+                            <button
+                              type="button"
+                              onClick={() => void confirmRemoval()}
+                              disabled={removalLoading}
+                              className="inline-flex items-center justify-center rounded-lg bg-rose-600 px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-rose-700 disabled:cursor-not-allowed disabled:bg-rose-400"
+                            >
+                              {removalLoading ? "Удаляем..." : "Подтвердить"}
+                            </button>
+                            <button
+                              type="button"
+                              onClick={cancelRemoval}
+                              className="inline-flex items-center justify-center rounded-lg border border-slate-300 px-3 py-1.5 text-sm font-semibold text-slate-600 transition hover:bg-slate-100"
+                            >
+                              Отмена
+                            </button>
+                          </div>
+                          {removalError ? (
+                            <p style={{ color: "var(--accent-danger)" }}>
+                              {removalError}
+                            </p>
+                          ) : null}
+                        </div>
+                      ) : null}
+                    </li>
+                  );
+                })
+              )}
+            </ul>
           </section>
         </div>
 

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -13,7 +13,11 @@ import AuthGate from "@/components/AuthGate";
 import PageContainer from "@/components/PageContainer";
 import ThemeToggle from "@/components/ThemeToggle";
 import { useSession } from "@/components/SessionProvider";
-import { DEFAULT_SETTINGS, SUPPORTED_CURRENCIES } from "@/lib/currency";
+import {
+  DEFAULT_SETTINGS,
+  SUPPORTED_CURRENCIES,
+  convertToBase
+} from "@/lib/currency";
 import type { Currency, Settings } from "@/lib/types";
 import { fetcher, type FetcherError } from "@/lib/fetcher";
 
@@ -40,6 +44,7 @@ type RateInfo = {
 const RATE_CURRENCIES: readonly Currency[] = ["RUB", "GEL", "EUR"];
 
 const RATE_PLACEHOLDERS: Partial<Record<Currency, string>> = {
+  USD: "1",
   RUB: "0.012",
   GEL: "0.367",
   EUR: "1.18"
@@ -251,6 +256,11 @@ const SettingsContent = () => {
         style: "currency",
         currency: baseCurrency
       }),
+    [baseCurrency]
+  );
+
+  const displayCurrencies = useMemo(
+    () => SUPPORTED_CURRENCIES.filter((code) => code !== baseCurrency),
     [baseCurrency]
   );
 
@@ -582,9 +592,10 @@ const SettingsContent = () => {
               gap: "1.25rem"
             }}
           >
-            {RATE_CURRENCIES.map((code) => {
+            {displayCurrencies.map((code) => {
               const info = rates[code];
-              const value = info ? formatRateValue(info.rate) : "";
+              const converted = convertToBase(1, code, settings);
+              const value = formatRateValue(converted);
               const placeholder = RATE_PLACEHOLDERS[code] ?? "1";
               const updatedLabel = formatUpdatedAt(info?.updatedAt ?? null);
 
@@ -594,7 +605,7 @@ const SettingsContent = () => {
                   style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}
                 >
                   <span style={{ fontWeight: 600, color: "var(--text-strong)" }}>
-                    USD за 1 {code}
+                    {baseCurrency} за 1 {code}
                   </span>
                   <input
                     type="number"

--- a/app/settings/wallets/page.tsx
+++ b/app/settings/wallets/page.tsx
@@ -5,8 +5,8 @@ import { useEffect, useMemo, useState, type FormEvent } from "react";
 import useSWR from "swr";
 import AuthGate from "@/components/AuthGate";
 import { useSession } from "@/components/SessionProvider";
-import { SUPPORTED_CURRENCIES } from "@/lib/currency";
-import type { Currency, WalletWithCurrency } from "@/lib/types";
+import { DEFAULT_SETTINGS } from "@/lib/currency";
+import type { Currency, Settings, WalletWithCurrency } from "@/lib/types";
 import { fetcher, type FetcherError } from "@/lib/fetcher";
 
 type WalletsResponse = {
@@ -21,12 +21,14 @@ const WalletSettings = () => {
   }
 
   const canManage = user.role === "admin";
+  const [settings, setSettings] = useState<Settings>(DEFAULT_SETTINGS);
   const [wallets, setWallets] = useState<WalletWithCurrency[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
-  const defaultCurrency = useMemo(() => SUPPORTED_CURRENCIES[0], []);
   const [newWallet, setNewWallet] = useState("");
-  const [newWalletCurrency, setNewWalletCurrency] = useState<Currency>(defaultCurrency);
+  const [newWalletCurrency, setNewWalletCurrency] = useState<Currency>(
+    DEFAULT_SETTINGS.baseCurrency
+  );
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState<string | null>(null);
   const [editingWalletId, setEditingWalletId] = useState<string | null>(null);
@@ -41,6 +43,13 @@ const WalletSettings = () => {
     revalidateOnFocus: true
   });
 
+  const {
+    data: settingsData,
+    error: settingsFetchError
+  } = useSWR<Settings>(user ? "/api/settings" : null, fetcher, {
+    revalidateOnFocus: true
+  });
+
   const loading = walletsLoading;
 
   useEffect(() => {
@@ -50,6 +59,14 @@ const WalletSettings = () => {
 
     setWallets(Array.isArray(walletsData.wallets) ? walletsData.wallets : []);
   }, [walletsData]);
+
+  useEffect(() => {
+    if (!settingsData) {
+      return;
+    }
+
+    setSettings(settingsData);
+  }, [settingsData]);
 
   useEffect(() => {
     if (!walletsError) {
@@ -65,6 +82,31 @@ const WalletSettings = () => {
 
     setError("Не удалось загрузить кошельки");
   }, [walletsError, refresh]);
+
+  useEffect(() => {
+    if (!settingsFetchError) {
+      return;
+    }
+
+    if ((settingsFetchError as FetcherError).status === 401) {
+      void refresh();
+    }
+  }, [settingsFetchError, refresh]);
+
+  const availableCurrencies = useMemo(
+    () => settings.availableCurrencies,
+    [settings.availableCurrencies]
+  );
+  const defaultCurrency = useMemo(
+    () => availableCurrencies[0] ?? DEFAULT_SETTINGS.baseCurrency,
+    [availableCurrencies]
+  );
+
+  useEffect(() => {
+    if (!availableCurrencies.includes(newWalletCurrency)) {
+      setNewWalletCurrency(defaultCurrency);
+    }
+  }, [availableCurrencies, defaultCurrency, newWalletCurrency]);
 
   const handleAdd = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -368,7 +410,7 @@ const WalletSettings = () => {
             className="w-full rounded-xl border px-4 py-3 sm:w-[160px]"
             aria-label="Валюта кошелька"
           >
-            {SUPPORTED_CURRENCIES.map((currency) => (
+            {availableCurrencies.map((currency) => (
               <option key={currency} value={currency}>
                 {currency}
               </option>

--- a/app/wallets/page.tsx
+++ b/app/wallets/page.tsx
@@ -13,7 +13,7 @@ import useSWR from "swr";
 import AuthGate from "@/components/AuthGate";
 import PageContainer from "@/components/PageContainer";
 import { useSession } from "@/components/SessionProvider";
-import { convertFromBase, convertToBase, DEFAULT_SETTINGS, SUPPORTED_CURRENCIES } from "@/lib/currency";
+import { convertFromBase, convertToBase, DEFAULT_SETTINGS } from "@/lib/currency";
 import {
   type Currency,
   type Debt,
@@ -58,7 +58,7 @@ const inferWalletCurrencyFromName = (wallet: Wallet): Currency | null => {
 
 const isRussianWallet = (wallet: Wallet) => /рус/.test(wallet.toLowerCase());
 
-const currencyIcons: Record<Currency, string> = {
+const currencyIcons: Record<string, string> = {
   USD: "🇺🇸",
   RUB: "🇷🇺",
   GEL: "🇬🇪",
@@ -67,6 +67,11 @@ const currencyIcons: Record<Currency, string> = {
 
 const WalletsContent = () => {
   const { user, refresh } = useSession();
+  const defaultAvailable = DEFAULT_SETTINGS.availableCurrencies;
+  const initialPrimaryCurrency =
+    defaultAvailable[0] ?? DEFAULT_SETTINGS.baseCurrency;
+  const initialSecondaryCurrency =
+    defaultAvailable[1] ?? initialPrimaryCurrency;
   const [operations, setOperations] = useState<Operation[]>([]);
   const [goals, setGoals] = useState<Goal[]>([]);
   const [debts, setDebts] = useState<Debt[]>([]);
@@ -74,13 +79,20 @@ const WalletsContent = () => {
   const [error, setError] = useState<string | null>(null);
   const [wallets, setWallets] = useState<WalletWithCurrency[]>([]);
   const [conversionAmount, setConversionAmount] = useState("1");
-  const [convertFromCurrency, setConvertFromCurrency] = useState<Currency>("USD");
-  const [convertToCurrency, setConvertToCurrency] = useState<Currency>("GEL");
+  const [convertFromCurrency, setConvertFromCurrency] =
+    useState<Currency>(initialPrimaryCurrency);
+  const [convertToCurrency, setConvertToCurrency] = useState<Currency>(
+    initialSecondaryCurrency
+  );
   const [transferAmount, setTransferAmount] = useState("");
   const [transferFromWallet, setTransferFromWallet] = useState<Wallet>("");
   const [transferToWallet, setTransferToWallet] = useState<Wallet>("");
-  const [transferFromCurrency, setTransferFromCurrency] = useState<Currency>("USD");
-  const [transferToCurrency, setTransferToCurrency] = useState<Currency>("GEL");
+  const [transferFromCurrency, setTransferFromCurrency] = useState<Currency>(
+    initialPrimaryCurrency
+  );
+  const [transferToCurrency, setTransferToCurrency] = useState<Currency>(
+    initialSecondaryCurrency
+  );
   const [transferComment, setTransferComment] = useState("");
   const [transferError, setTransferError] = useState<string | null>(null);
   const [transferSuccess, setTransferSuccess] = useState<string | null>(null);
@@ -197,6 +209,57 @@ const WalletsContent = () => {
       setSettings(settingsData);
     }
   }, [settingsData]);
+
+  useEffect(() => {
+    if (!settings) {
+      return;
+    }
+
+    const list = settings.availableCurrencies;
+    const fallback =
+      list[0] ?? settings.baseCurrency ?? DEFAULT_SETTINGS.baseCurrency;
+
+    setConvertFromCurrency((current) =>
+      list.includes(current) ? current : fallback
+    );
+    setTransferFromCurrency((current) =>
+      list.includes(current) ? current : fallback
+    );
+  }, [settings]);
+
+  useEffect(() => {
+    if (!settings) {
+      return;
+    }
+
+    const list = settings.availableCurrencies;
+    const fallback =
+      list.find((code) => code !== convertFromCurrency) ??
+      list[0] ??
+      settings.baseCurrency ??
+      DEFAULT_SETTINGS.baseCurrency;
+
+    setConvertToCurrency((current) =>
+      list.includes(current) ? current : fallback
+    );
+  }, [settings, convertFromCurrency]);
+
+  useEffect(() => {
+    if (!settings) {
+      return;
+    }
+
+    const list = settings.availableCurrencies;
+    const fallback =
+      list.find((code) => code !== transferFromCurrency) ??
+      list[0] ??
+      settings.baseCurrency ??
+      DEFAULT_SETTINGS.baseCurrency;
+
+    setTransferToCurrency((current) =>
+      list.includes(current) ? current : fallback
+    );
+  }, [settings, transferFromCurrency]);
 
   useEffect(() => {
     if (transferFromCurrencyManuallySet) {
@@ -335,6 +398,7 @@ const WalletsContent = () => {
   }, [wallets, operations, debts]);
 
   const activeSettings = settings ?? DEFAULT_SETTINGS;
+  const availableCurrencies = activeSettings.availableCurrencies;
 
   const transferBaseAmountOverrides = useMemo(() => {
     const transfers = new Map<string, { income?: Operation; expense?: Operation }>();
@@ -522,30 +586,68 @@ const WalletsContent = () => {
     transferBaseAmountOverrides
   ]);
 
-  const baseCurrencyFormatter = useMemo(
-    () =>
-      new Intl.NumberFormat("ru-RU", {
+  const baseCurrencyFormatter = useMemo(() => {
+    try {
+      return new Intl.NumberFormat("ru-RU", {
         style: "currency",
         currency: activeSettings.baseCurrency
-      }),
-    [activeSettings.baseCurrency]
-  );
+      });
+    } catch {
+      return new Intl.NumberFormat("ru-RU", {
+        style: "currency",
+        currency: "USD"
+      });
+    }
+  }, [activeSettings.baseCurrency]);
 
   const walletCurrencyFormatters = useMemo(() => {
     const formatters = new Map<Currency, Intl.NumberFormat>();
 
-    for (const currency of SUPPORTED_CURRENCIES) {
-      formatters.set(
-        currency,
-        new Intl.NumberFormat("ru-RU", {
-          style: "currency",
-          currency
-        })
-      );
+    for (const currency of availableCurrencies) {
+      try {
+        formatters.set(
+          currency,
+          new Intl.NumberFormat("ru-RU", {
+            style: "currency",
+            currency
+          })
+        );
+      } catch {
+        formatters.set(
+          currency,
+          new Intl.NumberFormat("ru-RU", {
+            style: "currency",
+            currency: "USD"
+          })
+        );
+      }
     }
 
     return formatters;
-  }, []);
+  }, [availableCurrencies]);
+
+  const formatCurrencyValue = useCallback(
+    (value: number, currency: Currency) => {
+      const formatter = walletCurrencyFormatters.get(currency);
+
+      if (formatter) {
+        return formatter.format(value);
+      }
+
+      try {
+        return new Intl.NumberFormat("ru-RU", {
+          style: "currency",
+          currency
+        }).format(value);
+      } catch {
+        return new Intl.NumberFormat("ru-RU", {
+          style: "currency",
+          currency: "USD"
+        }).format(value);
+      }
+    },
+    [walletCurrencyFormatters]
+  );
 
   const rubFormatter = useMemo(
     () =>
@@ -600,14 +702,8 @@ const WalletsContent = () => {
       return null;
     }
 
-    return (
-      walletCurrencyFormatters.get(convertToCurrency) ??
-      new Intl.NumberFormat("ru-RU", {
-        style: "currency",
-        currency: convertToCurrency
-      })
-    ).format(convertedAmount);
-  }, [convertedAmount, convertToCurrency, walletCurrencyFormatters]);
+    return formatCurrencyValue(convertedAmount, convertToCurrency);
+  }, [convertedAmount, convertToCurrency, formatCurrencyValue]);
 
   const conversionRate = useMemo(() => {
     if (!Number.isFinite(conversionAmountNumber)) {
@@ -617,28 +713,22 @@ const WalletsContent = () => {
     const amountInBase = convertToBase(1, convertFromCurrency, activeSettings);
     const targetAmount = convertFromBase(amountInBase, convertToCurrency, activeSettings);
 
-    return (
-      walletCurrencyFormatters.get(convertToCurrency) ??
-      new Intl.NumberFormat("ru-RU", {
-        style: "currency",
-        currency: convertToCurrency
-      })
-    ).format(targetAmount);
-  }, [convertFromCurrency, convertToCurrency, activeSettings, walletCurrencyFormatters, conversionAmountNumber]);
+    return formatCurrencyValue(targetAmount, convertToCurrency);
+  }, [
+    convertFromCurrency,
+    convertToCurrency,
+    activeSettings,
+    conversionAmountNumber,
+    formatCurrencyValue
+  ]);
 
   const formattedSourceAmount = useMemo(() => {
     if (!Number.isFinite(conversionAmountNumber)) {
       return null;
     }
 
-    return (
-      walletCurrencyFormatters.get(convertFromCurrency) ??
-      new Intl.NumberFormat("ru-RU", {
-        style: "currency",
-        currency: convertFromCurrency
-      })
-    ).format(conversionAmountNumber);
-  }, [conversionAmountNumber, convertFromCurrency, walletCurrencyFormatters]);
+    return formatCurrencyValue(conversionAmountNumber, convertFromCurrency);
+  }, [conversionAmountNumber, convertFromCurrency, formatCurrencyValue]);
 
   const transferAmountNumber = useMemo(() => {
     const normalized = Number.parseFloat(transferAmount.replace(",", "."));
@@ -674,28 +764,16 @@ const WalletsContent = () => {
       return null;
     }
 
-    return (
-      walletCurrencyFormatters.get(transferFromCurrency) ??
-      new Intl.NumberFormat("ru-RU", {
-        style: "currency",
-        currency: transferFromCurrency
-      })
-    ).format(transferAmountNumber);
-  }, [transferAmountNumber, transferFromCurrency, walletCurrencyFormatters]);
+    return formatCurrencyValue(transferAmountNumber, transferFromCurrency);
+  }, [transferAmountNumber, transferFromCurrency, formatCurrencyValue]);
 
   const formattedTransferTargetAmount = useMemo(() => {
     if (transferConvertedAmount === null) {
       return null;
     }
 
-    return (
-      walletCurrencyFormatters.get(transferToCurrency) ??
-      new Intl.NumberFormat("ru-RU", {
-        style: "currency",
-        currency: transferToCurrency
-      })
-    ).format(transferConvertedAmount);
-  }, [transferConvertedAmount, transferToCurrency, walletCurrencyFormatters]);
+    return formatCurrencyValue(transferConvertedAmount, transferToCurrency);
+  }, [transferConvertedAmount, transferToCurrency, formatCurrencyValue]);
 
   const transferRate = useMemo(() => {
     if (!Number.isFinite(transferAmountNumber)) {
@@ -705,14 +783,14 @@ const WalletsContent = () => {
     const amountInBase = convertToBase(1, transferFromCurrency, activeSettings);
     const targetAmount = convertFromBase(amountInBase, transferToCurrency, activeSettings);
 
-    return (
-      walletCurrencyFormatters.get(transferToCurrency) ??
-      new Intl.NumberFormat("ru-RU", {
-        style: "currency",
-        currency: transferToCurrency
-      })
-    ).format(targetAmount);
-  }, [transferFromCurrency, transferToCurrency, activeSettings, walletCurrencyFormatters, transferAmountNumber]);
+    return formatCurrencyValue(targetAmount, transferToCurrency);
+  }, [
+    transferFromCurrency,
+    transferToCurrency,
+    activeSettings,
+    transferAmountNumber,
+    formatCurrencyValue
+  ]);
 
   const canSubmitTransfer =
     canManage &&
@@ -1443,7 +1521,7 @@ const WalletsContent = () => {
                 fontSize: "0.85rem"
               }}
             >
-              {SUPPORTED_CURRENCIES.map((currency) => (
+              {availableCurrencies.map((currency) => (
                 <option key={currency} value={currency}>
                   {currency}
                 </option>
@@ -1489,7 +1567,7 @@ const WalletsContent = () => {
                 fontSize: "0.85rem"
               }}
             >
-              {SUPPORTED_CURRENCIES.map((currency) => (
+              {availableCurrencies.map((currency) => (
                 <option key={currency} value={currency}>
                   {currency}
                 </option>
@@ -1557,7 +1635,7 @@ const WalletsContent = () => {
                         handleTransferFromCurrencyChange(event.target.value as Currency)
                       }
                     >
-                      {SUPPORTED_CURRENCIES.map((currency) => (
+                      {availableCurrencies.map((currency) => (
                         <option key={currency} value={currency}>
                           {currency}
                         </option>
@@ -1573,7 +1651,7 @@ const WalletsContent = () => {
                         handleTransferToCurrencyChange(event.target.value as Currency)
                       }
                     >
-                      {SUPPORTED_CURRENCIES.map((currency) => (
+                      {availableCurrencies.map((currency) => (
                         <option key={currency} value={currency}>
                           {currency}
                         </option>

--- a/lib/currency.ts
+++ b/lib/currency.ts
@@ -1,7 +1,7 @@
 import { fromUSD, toUSD } from "@/lib/rates";
-import { CURRENCIES, type Currency, type Settings } from "@/lib/types";
+import { DEFAULT_CURRENCIES, type Currency, type Settings } from "@/lib/types";
 
-export const SUPPORTED_CURRENCIES: readonly Currency[] = CURRENCIES;
+export const SUPPORTED_CURRENCIES: readonly Currency[] = [...DEFAULT_CURRENCIES];
 
 export const DEFAULT_SETTINGS: Settings = {
   baseCurrency: "USD",
@@ -10,14 +10,27 @@ export const DEFAULT_SETTINGS: Settings = {
     GEL: 1,
     RUB: 1,
     EUR: 1
-  }
+  },
+  availableCurrencies: [...SUPPORTED_CURRENCIES]
 };
 
 export const isSupportedCurrency = (value: unknown): value is Currency =>
-  typeof value === "string" && SUPPORTED_CURRENCIES.includes(value as Currency);
+  typeof value === "string" && value.trim().length > 0;
 
-export const sanitizeCurrency = (value: unknown, fallback: Currency = "USD"): Currency =>
-  isSupportedCurrency(value) ? value : fallback;
+export const sanitizeCurrency = (
+  value: unknown,
+  fallback: Currency = "USD"
+): Currency => {
+  if (typeof value === "string") {
+    const normalized = value.trim().toUpperCase();
+
+    if (normalized.length > 0) {
+      return normalized;
+    }
+  }
+
+  return fallback;
+};
 
 export const convertToBase = (amount: number, currency: Currency, settings: Settings) => {
   const amountInUSD = toUSD(amount, currency, settings.rates);

--- a/lib/currencyCatalog.ts
+++ b/lib/currencyCatalog.ts
@@ -9,14 +9,13 @@ export type PopularCurrency = {
 export const POPULAR_CURRENCIES: PopularCurrency[] = [
   { code: "USD", title: "Доллар США", rateToUSD: 1 },
   { code: "EUR", title: "Евро", rateToUSD: 1.08 },
-  { code: "GBP", title: "Британский фунт", rateToUSD: 1.27 },
-  { code: "CHF", title: "Швейцарский франк", rateToUSD: 1.12 },
-  { code: "CNY", title: "Китайский юань", rateToUSD: 0.14 },
-  { code: "JPY", title: "Японская иена", rateToUSD: 0.0064 },
+  { code: "RUB", title: "Российский рубль", rateToUSD: 0.011 },
+  { code: "GEL", title: "Грузинский лари", rateToUSD: 0.37 },
+  { code: "UAH", title: "Украинская гривна", rateToUSD: 0.025 },
   { code: "INR", title: "Индийская рупия", rateToUSD: 0.012 },
-  { code: "TRY", title: "Турецкая лира", rateToUSD: 0.031 },
-  { code: "AED", title: "Дирхам ОАЭ", rateToUSD: 0.27 },
-  { code: "CAD", title: "Канадский доллар", rateToUSD: 0.74 }
+  { code: "IDR", title: "Индонезийская рупия", rateToUSD: 0.000064 },
+  { code: "THB", title: "Тайский бат", rateToUSD: 0.027 },
+  { code: "TRY", title: "Турецкая лира", rateToUSD: 0.032 }
 ];
 
 export const findPopularCurrency = (code: string) =>

--- a/lib/currencyCatalog.ts
+++ b/lib/currencyCatalog.ts
@@ -1,0 +1,25 @@
+import type { Currency } from "@/lib/types";
+
+export type PopularCurrency = {
+  code: Currency;
+  title: string;
+  rateToUSD: number;
+};
+
+export const POPULAR_CURRENCIES: PopularCurrency[] = [
+  { code: "USD", title: "Доллар США", rateToUSD: 1 },
+  { code: "EUR", title: "Евро", rateToUSD: 1.08 },
+  { code: "GBP", title: "Британский фунт", rateToUSD: 1.27 },
+  { code: "CHF", title: "Швейцарский франк", rateToUSD: 1.12 },
+  { code: "CNY", title: "Китайский юань", rateToUSD: 0.14 },
+  { code: "JPY", title: "Японская иена", rateToUSD: 0.0064 },
+  { code: "INR", title: "Индийская рупия", rateToUSD: 0.012 },
+  { code: "TRY", title: "Турецкая лира", rateToUSD: 0.031 },
+  { code: "AED", title: "Дирхам ОАЭ", rateToUSD: 0.27 },
+  { code: "CAD", title: "Канадский доллар", rateToUSD: 0.74 }
+];
+
+export const findPopularCurrency = (code: string) =>
+  POPULAR_CURRENCIES.find(
+    (item) => item.code.toUpperCase() === code.trim().toUpperCase()
+  );

--- a/lib/rates.ts
+++ b/lib/rates.ts
@@ -13,7 +13,7 @@ const sanitizeRate = (currency: Currency, rates: Record<string, number>): number
 
 export function toUSD(
   amount: number,
-  currency: "USD" | "RUB" | "GEL" | "EUR",
+  currency: Currency,
   rates: Record<string, number>
 ): number {
   const safeAmount = sanitizeAmount(amount);
@@ -29,7 +29,7 @@ export function toUSD(
 
 export function fromUSD(
   usd: number,
-  currency: "USD" | "RUB" | "GEL" | "EUR",
+  currency: Currency,
   rates: Record<string, number>
 ): number {
   const safeAmount = sanitizeAmount(usd);

--- a/lib/settingsService.ts
+++ b/lib/settingsService.ts
@@ -47,45 +47,63 @@ export const loadSettings = async (): Promise<Settings> => {
   };
 };
 
-export const applyRatesUpdate = async (
-  ratesUpdate: Partial<Record<Currency, number>>
-): Promise<Settings> => {
-  const settings = await loadSettings();
-  const operations: Promise<unknown>[] = [];
+type SettingsUpdatePayload = {
+  baseCurrency?: Currency;
+  rates?: Partial<Record<Currency, number>>;
+};
 
-  for (const currency of SUPPORTED_CURRENCIES) {
-    const newRate = ratesUpdate[currency];
+export const updateSettings = async ({
+  baseCurrency,
+  rates
+}: SettingsUpdatePayload): Promise<Settings> => {
+  const currentSettings = await loadSettings();
+  const ratesToSave: Partial<Record<Currency, number>> = {};
 
-    if (currency === settings.baseCurrency) {
-      const rateToSave =
-        currency === "USD"
-          ? 1
-          : newRate;
+  if (rates) {
+    for (const currency of SUPPORTED_CURRENCIES) {
+      const newRate = rates[currency];
 
-      if (rateToSave === undefined) {
+      if (newRate === undefined) {
         continue;
       }
 
-      operations.push(
-        prisma.currencyRate.upsert({
-          where: { currency },
-          update: { rate: rateToSave },
-          create: { currency, rate: rateToSave }
-        })
-      );
-      continue;
-    }
+      if (!isValidRate(newRate)) {
+        throw new Error(`Invalid rate for ${currency}`);
+      }
 
-    if (newRate === undefined) {
-      continue;
+      ratesToSave[currency] = currency === "USD" ? 1 : newRate;
     }
+  }
 
+  const baseCurrencyChanged =
+    baseCurrency !== undefined && baseCurrency !== currentSettings.baseCurrency;
+  const nextBaseCurrency = baseCurrencyChanged
+    ? baseCurrency
+    : currentSettings.baseCurrency;
+
+  if (nextBaseCurrency === "USD") {
+    ratesToSave.USD = 1;
+  } else if (ratesToSave[nextBaseCurrency] === undefined) {
+    const existingRate = currentSettings.rates[nextBaseCurrency];
+
+    ratesToSave[nextBaseCurrency] = isValidRate(existingRate) ? existingRate : 1;
+  }
+
+  const operations: Promise<unknown>[] = [];
+
+  for (const [currency, rate] of Object.entries(ratesToSave)) {
     operations.push(
       prisma.currencyRate.upsert({
         where: { currency },
-        update: { rate: newRate },
-        create: { currency, rate: newRate }
+        update: { rate },
+        create: { currency, rate }
       })
+    );
+  }
+
+  if (baseCurrencyChanged) {
+    operations.push(
+      prisma.settings.create({ data: { base_currency: nextBaseCurrency } })
     );
   }
 

--- a/lib/settingsService.ts
+++ b/lib/settingsService.ts
@@ -1,5 +1,5 @@
 // trigger redeploy
-import { DEFAULT_SETTINGS, SUPPORTED_CURRENCIES, sanitizeCurrency } from "@/lib/currency";
+import { DEFAULT_SETTINGS, sanitizeCurrency } from "@/lib/currency";
 import prisma from "@/lib/prisma";
 import type { Currency, Settings } from "@/lib/types";
 
@@ -17,14 +17,11 @@ export const loadSettings = async (): Promise<Settings> => {
     DEFAULT_SETTINGS.baseCurrency
   );
 
-  const rates: Settings["rates"] = { ...DEFAULT_SETTINGS.rates };
+  const rates: Settings["rates"] = { ...DEFAULT_SETTINGS.rates, USD: 1 };
+  const available = new Set<Currency>(DEFAULT_SETTINGS.availableCurrencies);
 
   for (const rate of rateRows) {
     const currency = rate.currency as Currency;
-
-    if (!SUPPORTED_CURRENCIES.includes(currency)) {
-      continue;
-    }
 
     const numericRate = Number(rate.rate);
 
@@ -32,18 +29,22 @@ export const loadSettings = async (): Promise<Settings> => {
       continue;
     }
 
-    rates[currency] = numericRate;
+    rates[currency] = currency === "USD" ? 1 : numericRate;
+    available.add(currency);
   }
 
-  if (baseCurrency === "USD") {
-    rates[baseCurrency] = 1;
-  } else if (!isValidRate(rates[baseCurrency])) {
-    rates[baseCurrency] = 1;
+  if (!available.has(baseCurrency)) {
+    available.add(baseCurrency);
+  }
+
+  if (!isValidRate(rates[baseCurrency])) {
+    rates[baseCurrency] = baseCurrency === "USD" ? 1 : 1;
   }
 
   return {
     baseCurrency,
-    rates
+    rates,
+    availableCurrencies: Array.from(available)
   };
 };
 
@@ -60,38 +61,52 @@ export const updateSettings = async ({
   const ratesToSave: Partial<Record<Currency, number>> = {};
 
   if (rates) {
-    for (const currency of SUPPORTED_CURRENCIES) {
-      const newRate = rates[currency];
-
-      if (newRate === undefined) {
+    for (const [currency, rawRate] of Object.entries(rates)) {
+      if (rawRate === undefined) {
         continue;
       }
 
-      if (!isValidRate(newRate)) {
-        throw new Error(`Invalid rate for ${currency}`);
+      const normalizedCurrency = sanitizeCurrency(currency);
+      const numericRate = Number(rawRate);
+
+      if (!isValidRate(numericRate)) {
+        throw new Error(`Invalid rate for ${normalizedCurrency}`);
       }
 
-      ratesToSave[currency] = currency === "USD" ? 1 : newRate;
+      ratesToSave[normalizedCurrency] =
+        normalizedCurrency === "USD" ? 1 : numericRate;
     }
   }
 
   const baseCurrencyChanged =
     baseCurrency !== undefined && baseCurrency !== currentSettings.baseCurrency;
   const nextBaseCurrency = baseCurrencyChanged
-    ? baseCurrency
+    ? sanitizeCurrency(baseCurrency)
     : currentSettings.baseCurrency;
 
-  if (nextBaseCurrency === "USD") {
-    ratesToSave.USD = 1;
-  } else if (ratesToSave[nextBaseCurrency] === undefined) {
+  if (
+    baseCurrencyChanged &&
+    !currentSettings.availableCurrencies.includes(nextBaseCurrency)
+  ) {
+    throw new Error("Выбранная валюта недоступна");
+  }
+
+  if (ratesToSave[nextBaseCurrency] === undefined) {
     const existingRate = currentSettings.rates[nextBaseCurrency];
 
-    ratesToSave[nextBaseCurrency] = isValidRate(existingRate) ? existingRate : 1;
+    ratesToSave[nextBaseCurrency] =
+      nextBaseCurrency === "USD" || isValidRate(existingRate)
+        ? existingRate ?? 1
+        : 1;
   }
 
   const operations: Promise<unknown>[] = [];
 
   for (const [currency, rate] of Object.entries(ratesToSave)) {
+    if (rate === undefined) {
+      continue;
+    }
+
     operations.push(
       prisma.currencyRate.upsert({
         where: { currency },
@@ -110,4 +125,54 @@ export const updateSettings = async ({
   await Promise.all(operations);
 
   return loadSettings();
+};
+
+export const addCurrency = async (
+  code: Currency,
+  rateToUSD: number
+): Promise<Settings> => {
+  const currency = sanitizeCurrency(code);
+  const numericRate = Number(rateToUSD);
+
+  if (!isValidRate(numericRate)) {
+    throw new Error("Некорректный курс");
+  }
+
+  await prisma.currencyRate.upsert({
+    where: { currency },
+    update: { rate: currency === "USD" ? 1 : numericRate },
+    create: { currency, rate: currency === "USD" ? 1 : numericRate }
+  });
+
+  return loadSettings();
+};
+
+export const removeCurrency = async (code: Currency): Promise<Settings> => {
+  const currency = sanitizeCurrency(code);
+  const currentSettings = await loadSettings();
+
+  if (!currentSettings.availableCurrencies.includes(currency)) {
+    return currentSettings;
+  }
+
+  await prisma.currencyRate
+    .delete({ where: { currency } })
+    .catch(() => undefined);
+
+  let nextSettings = await loadSettings();
+
+  const fallback =
+    nextSettings.availableCurrencies.find((item) => item !== currency) ??
+    DEFAULT_SETTINGS.baseCurrency;
+
+  if (!nextSettings.availableCurrencies.includes(fallback)) {
+    nextSettings.availableCurrencies.push(fallback);
+  }
+
+  if (nextSettings.baseCurrency === currency) {
+    await prisma.settings.create({ data: { base_currency: fallback } });
+    nextSettings = await loadSettings();
+  }
+
+  return nextSettings;
 };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,6 +1,6 @@
-export const CURRENCIES = ["USD", "RUB", "GEL", "EUR"] as const;
+export const DEFAULT_CURRENCIES = ["USD", "RUB", "GEL", "EUR"] as const;
 
-export type Currency = (typeof CURRENCIES)[number];
+export type Currency = string;
 
 export const DEFAULT_WALLETS = [
   "крипта",
@@ -72,4 +72,5 @@ export type CategoryStore = {
 export type Settings = {
   baseCurrency: Currency;
   rates: Record<Currency, number>;
+  availableCurrencies: Currency[];
 };


### PR DESCRIPTION
## Summary
- extend the settings API to accept base currency updates and reuse the unified update service
- add an admin-only control on the settings page to pick the base currency and refresh cached settings
- update the settings service to persist base currency changes alongside optional rate updates

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68e7e01b01748331b475c521c2b78526