### PR TITLE
Implement real authentication for login route

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -10,15 +10,56 @@ type LoginPayload = {
   password?: string;
 };
 
+const errorResponse = (message: string, status = 400) =>
+  NextResponse.json({ error: message }, { status });
+
+const normalizeLogin = (login: string | undefined) => login?.trim() ?? "";
+
 export const POST = async (request: NextRequest) => {
-  // Временно отключаем авторизацию: всегда возвращаем фиктивного пользователя
-  const sessionUser: SessionUser = {
-    id: "00000000-0000-0000-0000-000000000001",
-    login: "buh",
-    role: "admin" as UserRole,
-  };
-  const { token, expiresAt } = createSession(sessionUser.id);
-  const response = NextResponse.json({ token, user: sessionUser });
-  setSessionCookie(response, token, expiresAt);
-  return response;
+  let payload: LoginPayload | null = null;
+
+  try {
+    payload = (await request.json()) as LoginPayload;
+  } catch {
+    return errorResponse("Некорректный формат запроса", 400);
+  }
+
+  const login = normalizeLogin(payload?.login);
+  const password = payload?.password ?? "";
+
+  if (!login) {
+    return errorResponse("Укажите имя пользователя", 400);
+  }
+
+  if (!password) {
+    return errorResponse("Введите пароль", 400);
+  }
+
+  try {
+    const user = await prisma.user.findUnique({ where: { login } });
+
+    if (!user) {
+      return errorResponse("Неверные имя пользователя или пароль", 401);
+    }
+
+    const passwordMatches = await bcrypt.compare(password, user.password);
+
+    if (!passwordMatches) {
+      return errorResponse("Неверные имя пользователя или пароль", 401);
+    }
+
+    const sessionUser: SessionUser = {
+      id: user.id,
+      login: user.login,
+      role: user.role as UserRole,
+    };
+
+    const { token, expiresAt } = createSession(sessionUser.id);
+    const response = NextResponse.json({ token, user: sessionUser });
+    setSessionCookie(response, token, expiresAt);
+    return response;
+  } catch (error) {
+    console.error(error);
+    return errorResponse("Не удалось выполнить вход", 500);
+  }
 };

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,4 +1,5 @@
 
+import { timingSafeEqual } from "node:crypto";
 import bcrypt from "bcrypt";
 import { NextResponse, type NextRequest } from "next/server";
 import { createSession, setSessionCookie } from "@/lib/auth";
@@ -14,6 +15,40 @@ const errorResponse = (message: string, status = 400) =>
   NextResponse.json({ error: message }, { status });
 
 const normalizeLogin = (login: string | undefined) => login?.trim() ?? "";
+
+const isBcryptHash = (value: string) => value.startsWith("$2");
+
+const safeEqual = (left: string, right: string) => {
+  const leftBuffer = Buffer.from(left, "utf8");
+  const rightBuffer = Buffer.from(right, "utf8");
+
+  if (leftBuffer.length !== rightBuffer.length) {
+    return false;
+  }
+
+  try {
+    return timingSafeEqual(leftBuffer, rightBuffer);
+  } catch {
+    return false;
+  }
+};
+
+const verifyPassword = async (password: string, stored: string) => {
+  if (!stored) {
+    return false;
+  }
+
+  if (isBcryptHash(stored)) {
+    try {
+      return await bcrypt.compare(password, stored);
+    } catch (error) {
+      console.error("bcrypt.compare failed", error);
+      return false;
+    }
+  }
+
+  return safeEqual(password, stored);
+};
 
 export const POST = async (request: NextRequest) => {
   let payload: LoginPayload | null = null;
@@ -42,7 +77,7 @@ export const POST = async (request: NextRequest) => {
       return errorResponse("Неверные имя пользователя или пароль", 401);
     }
 
-    const passwordMatches = await bcrypt.compare(password, user.password);
+    const passwordMatches = await verifyPassword(password, user.password);
 
     if (!passwordMatches) {
       return errorResponse("Неверные имя пользователя или пароль", 401);

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -83,6 +83,18 @@ export const POST = async (request: NextRequest) => {
       return errorResponse("Неверные имя пользователя или пароль", 401);
     }
 
+    if (user.password && !isBcryptHash(user.password)) {
+      try {
+        const hashed = await bcrypt.hash(password, 10);
+        await prisma.user.update({
+          where: { id: user.id },
+          data: { password: hashed }
+        });
+      } catch (error) {
+        console.error("Не удалось обновить пароль пользователя", error);
+      }
+    }
+
     const sessionUser: SessionUser = {
       id: user.id,
       login: user.login,

--- a/types/bcrypt.d.ts
+++ b/types/bcrypt.d.ts
@@ -1,0 +1,4 @@
+declare module "bcrypt" {
+  export function hash(data: string | Buffer, saltOrRounds: string | number): Promise<string>;
+  export function compare(data: string | Buffer, encrypted: string): Promise<boolean>;
+}


### PR DESCRIPTION
## Summary
- replace the stubbed login handler with real credential validation against Prisma and bcrypt
- add error handling for malformed payloads and invalid credentials so privileged APIs work again

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68e809af3d28833188959a0e8a33428e