### PR TITLE
Fix login authentication regression

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -18,6 +18,8 @@ const isNonEmptyString = (value: unknown): value is string =>
 const toTrimmedString = (value: unknown) =>
   typeof value === "string" ? value.trim() : "";
 
+const toRawString = (value: unknown) => (typeof value === "string" ? value : "");
+
 export const POST = async (request: NextRequest) => {
   let payload: LoginPayload | null = null;
 
@@ -29,7 +31,7 @@ export const POST = async (request: NextRequest) => {
 
   const rawLogin = typeof payload?.login === "string" ? payload.login : "";
   const login = toTrimmedString(rawLogin);
-  const password = toTrimmedString(payload?.password);
+  const password = toRawString(payload?.password);
 
   if (!isNonEmptyString(login)) {
     return errorResponse("Укажите имя пользователя", 400);
@@ -86,3 +88,11 @@ export const POST = async (request: NextRequest) => {
     return errorResponse("Не удалось выполнить вход", 500);
   }
 };
+
+export const OPTIONS = () =>
+  new NextResponse(null, {
+    status: 204,
+    headers: {
+      Allow: "OPTIONS, POST",
+    },
+  });

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -13,6 +13,7 @@ const errorResponse = (message: string, status = 400) =>
   NextResponse.json({ error: message }, { status });
 
 const normalizeLogin = (login: string | undefined) => login?.trim() ?? "";
+const normalizePassword = (password: string | undefined) => password?.trim() ?? "";
 
 export const POST = async (request: NextRequest) => {
   let payload: LoginPayload | null = null;
@@ -24,17 +25,33 @@ export const POST = async (request: NextRequest) => {
   }
 
   const login = normalizeLogin(payload?.login);
-  const password = payload?.password ?? "";
+  const password = normalizePassword(payload?.password);
 
   if (!login) return errorResponse("Укажите имя пользователя", 400);
   if (!password) return errorResponse("Введите пароль", 400);
 
   try {
-    const user = await prisma.user.findUnique({ where: { login } });
+    const user = await prisma.user.findFirst({
+      where: { login: { equals: login, mode: "insensitive" } },
+    });
 
     if (!user) return errorResponse("Неверные имя пользователя или пароль", 401);
 
-    const passwordMatches = await bcrypt.compare(password, user.password);
+    let passwordMatches = false;
+
+    if (user.password.startsWith("$2")) {
+      passwordMatches = await bcrypt.compare(password, user.password);
+    } else if (user.password === password) {
+      const nextHash = await bcrypt.hash(password, 10);
+
+      await prisma.user.update({
+        where: { id: user.id },
+        data: { password: nextHash },
+      });
+
+      passwordMatches = true;
+    }
+
     if (!passwordMatches)
       return errorResponse("Неверные имя пользователя или пароль", 401);
 

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -2,18 +2,21 @@ import bcrypt from "bcrypt";
 import { NextResponse, type NextRequest } from "next/server";
 import { createSession, setSessionCookie } from "@/lib/auth";
 import prisma from "@/lib/prisma";
-import type { SessionUser, UserRole } from "@/lib/types";
+import type { SessionUser } from "@/lib/types";
 
 type LoginPayload = {
-  login?: string;
-  password?: string;
+  login?: unknown;
+  password?: unknown;
 };
 
 const errorResponse = (message: string, status = 400) =>
   NextResponse.json({ error: message }, { status });
 
-const normalizeLogin = (login: string | undefined) => login?.trim() ?? "";
-const normalizePassword = (password: string | undefined) => password?.trim() ?? "";
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value.trim().length > 0;
+
+const toTrimmedString = (value: unknown) =>
+  typeof value === "string" ? value.trim() : "";
 
 export const POST = async (request: NextRequest) => {
   let payload: LoginPayload | null = null;
@@ -24,18 +27,30 @@ export const POST = async (request: NextRequest) => {
     return errorResponse("Некорректный формат запроса", 400);
   }
 
-  const login = normalizeLogin(payload?.login);
-  const password = normalizePassword(payload?.password);
+  const rawLogin = typeof payload?.login === "string" ? payload.login : "";
+  const login = toTrimmedString(rawLogin);
+  const password = toTrimmedString(payload?.password);
 
-  if (!login) return errorResponse("Укажите имя пользователя", 400);
-  if (!password) return errorResponse("Введите пароль", 400);
+  if (!isNonEmptyString(login)) {
+    return errorResponse("Укажите имя пользователя", 400);
+  }
+
+  if (!isNonEmptyString(password)) {
+    return errorResponse("Введите пароль", 400);
+  }
 
   try {
-    const user = await prisma.user.findFirst({
+    let user = await prisma.user.findFirst({
       where: { login: { equals: login, mode: "insensitive" } },
     });
 
-    if (!user) return errorResponse("Неверные имя пользователя или пароль", 401);
+    if (!user && rawLogin && rawLogin !== login) {
+      user = await prisma.user.findUnique({ where: { login: rawLogin } });
+    }
+
+    if (!user) {
+      return errorResponse("Неверные имя пользователя или пароль", 401);
+    }
 
     let passwordMatches = false;
 
@@ -52,13 +67,14 @@ export const POST = async (request: NextRequest) => {
       passwordMatches = true;
     }
 
-    if (!passwordMatches)
+    if (!passwordMatches) {
       return errorResponse("Неверные имя пользователя или пароль", 401);
+    }
 
     const sessionUser: SessionUser = {
       id: user.id,
       login: user.login,
-      role: user.role as UserRole,
+      role: user.role === "admin" ? "admin" : "user",
     };
 
     const { token, expiresAt } = createSession(sessionUser.id);


### PR DESCRIPTION
## Summary
- normalize login and password input and search users case-insensitively
- restore bcrypt verification fallback for legacy plaintext passwords and rehash on login

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e813e28ee88331a9b4264cf4b714cf