### PR TITLE
Harden warehouse API validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 .env*
+tsconfig.tsbuildinfo

--- a/app/warehouse/page.tsx
+++ b/app/warehouse/page.tsx
@@ -1,0 +1,10 @@
+import WarehouseTabs from '@/components/Warehouse/WarehouseTabs';
+
+export default function WarehousePage() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">📦 Склад</h1>
+      <WarehouseTabs />
+    </div>
+  );
+}

--- a/components/Warehouse/BooksPanel.tsx
+++ b/components/Warehouse/BooksPanel.tsx
@@ -1,0 +1,681 @@
+"use client";
+
+import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+
+type Book = {
+  id: number;
+  title: string;
+  language: string;
+  quantity: number;
+  purchasePrice: number;
+  salePrice: number;
+  paid: number;
+  note: string | null;
+};
+
+type BookFormState = {
+  title: string;
+  language: LanguageOption;
+  quantity: string;
+  purchasePrice: string;
+  salePrice: string;
+  paid: string;
+  note: string;
+};
+
+type ToastTone = "success" | "error";
+
+type ToastState = {
+  id: number;
+  message: string;
+  tone: ToastTone;
+};
+
+type LanguageOption = (typeof LANGUAGE_OPTIONS)[number];
+
+const LANGUAGE_OPTIONS = ["Русский", "Английский", "Грузинский"] as const;
+
+const DEFAULT_FORM_STATE: BookFormState = {
+  title: "",
+  language: "Русский",
+  quantity: "",
+  purchasePrice: "",
+  salePrice: "",
+  paid: "",
+  note: "",
+};
+
+const BUTTON_BASE =
+  "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2";
+const BUTTON_SM_BASE =
+  "inline-flex items-center justify-center rounded-lg px-3 py-1.5 text-xs font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2";
+
+const PRIMARY_BUTTON =
+  `${BUTTON_BASE} bg-indigo-600 text-white shadow-sm hover:bg-indigo-500 focus-visible:ring-indigo-500`;
+const SECONDARY_BUTTON =
+  `${BUTTON_BASE} border border-slate-200 bg-white text-slate-700 shadow-sm hover:bg-slate-50 focus-visible:ring-indigo-500`;
+const DANGER_BUTTON =
+  `${BUTTON_SM_BASE} border border-red-200 bg-white text-red-600 shadow-sm hover:bg-red-50 focus-visible:ring-red-500`;
+const MUTED_BUTTON =
+  `${BUTTON_SM_BASE} border border-slate-200 bg-white text-slate-600 shadow-sm hover:bg-slate-50 focus-visible:ring-indigo-500`;
+const ACCENT_BUTTON =
+  `${BUTTON_SM_BASE} border border-amber-200 bg-white text-amber-600 shadow-sm hover:bg-amber-50 focus-visible:ring-amber-500`;
+
+const INPUT_CLASSES =
+  "w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-inner transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400/60";
+const TEXTAREA_CLASSES =
+  "w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-inner transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400/60";
+
+const formatMoney = (value: number) =>
+  new Intl.NumberFormat("ru-RU", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(Number.isFinite(value) ? value : 0);
+
+const Toast = ({ toast, onClose }: { toast: ToastState; onClose: () => void }) => {
+  const toneClasses =
+    toast.tone === "success"
+      ? "border-emerald-200 bg-white text-emerald-700"
+      : "border-red-200 bg-white text-red-700";
+
+  return (
+    <div className="fixed bottom-6 right-6 z-[60] flex max-w-sm flex-col gap-3">
+      <div
+        className={`flex items-start gap-3 rounded-2xl border px-4 py-3 shadow-xl ring-1 ring-slate-900/5 ${toneClasses}`}
+      >
+        <span className="text-base">{toast.tone === "success" ? "✓" : "⚠"}</span>
+        <div className="flex-1 text-sm font-medium leading-5">{toast.message}</div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-xs font-medium text-slate-400 transition hover:text-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
+          aria-label="Закрыть уведомление"
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+  );
+};
+
+const BooksPanel = () => {
+  const [books, setBooks] = useState<Book[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [listMessage, setListMessage] = useState<string>("Нет данных о книгах");
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isSpreadModalOpen, setIsSpreadModalOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isSpreading, setIsSpreading] = useState(false);
+  const [formState, setFormState] = useState<BookFormState>(DEFAULT_FORM_STATE);
+  const [spreadQuantity, setSpreadQuantity] = useState<string>("");
+  const [editingBookId, setEditingBookId] = useState<number | null>(null);
+  const [spreadBookId, setSpreadBookId] = useState<number | null>(null);
+  const [toast, setToast] = useState<ToastState | null>(null);
+
+  const isEditMode = useMemo(() => editingBookId !== null, [editingBookId]);
+
+  useEffect(() => {
+    if (!toast) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => setToast(null), 4000);
+    return () => window.clearTimeout(timer);
+  }, [toast]);
+
+  const showToast = useCallback((message: string, tone: ToastTone = "error") => {
+    setToast({ id: Date.now(), message, tone });
+  }, []);
+
+  const fetchBooks = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await fetch("/api/warehouse/books");
+      if (!response.ok) {
+        throw new Error("Не удалось загрузить книги");
+      }
+      const data = (await response.json()) as Book[];
+      setBooks(data);
+      setListMessage(data.length === 0 ? "Нет данных о книгах" : "");
+    } catch (error) {
+      console.error(error);
+      setBooks([]);
+      setListMessage("Не удалось загрузить книги");
+      showToast(
+        error instanceof Error ? error.message : "Произошла непредвиденная ошибка",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [showToast]);
+
+  useEffect(() => {
+    void fetchBooks();
+  }, [fetchBooks]);
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+    setFormState(DEFAULT_FORM_STATE);
+    setEditingBookId(null);
+  };
+
+  const openCreateModal = () => {
+    setEditingBookId(null);
+    setFormState(DEFAULT_FORM_STATE);
+    setIsModalOpen(true);
+  };
+
+  const openEditModal = (book: Book) => {
+    setEditingBookId(book.id);
+    setFormState({
+      title: book.title,
+      language: (LANGUAGE_OPTIONS.includes(book.language as LanguageOption)
+        ? (book.language as LanguageOption)
+        : "Русский"),
+      quantity: String(book.quantity),
+      purchasePrice: String(book.purchasePrice ?? ""),
+      salePrice: String(book.salePrice ?? ""),
+      paid: String(book.paid ?? ""),
+      note: book.note ?? "",
+    });
+    setIsModalOpen(true);
+  };
+
+  const openSpreadModal = (book: Book) => {
+    setSpreadBookId(book.id);
+    setSpreadQuantity("");
+    setIsSpreadModalOpen(true);
+  };
+
+  const closeSpreadModal = () => {
+    setIsSpreadModalOpen(false);
+    setSpreadBookId(null);
+    setSpreadQuantity("");
+    setIsSpreading(false);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const title = formState.title.trim();
+    const language = formState.language;
+    const quantity = Number.parseInt(formState.quantity, 10);
+    const purchasePrice = Number.parseFloat(formState.purchasePrice.replace(",", "."));
+    const salePrice = Number.parseFloat(formState.salePrice.replace(",", "."));
+    const paid = Number.parseFloat(formState.paid.replace(",", "."));
+    const note = formState.note.trim();
+
+    if (!title) {
+      showToast("Укажите название книги");
+      return;
+    }
+
+    if (!language) {
+      showToast("Выберите язык книги");
+      return;
+    }
+
+    if (Number.isNaN(quantity) || quantity < 0) {
+      showToast("Количество должно быть неотрицательным числом");
+      return;
+    }
+
+    if (
+      Number.isNaN(purchasePrice) ||
+      Number.isNaN(salePrice) ||
+      Number.isNaN(paid)
+    ) {
+      showToast("Проверьте денежные значения");
+      return;
+    }
+
+    const payload = {
+      title,
+      language,
+      quantity,
+      purchasePrice,
+      salePrice,
+      paid,
+      note: note || null,
+    };
+
+    setIsSubmitting(true);
+
+    try {
+      const method = isEditMode ? "PUT" : "POST";
+      const response = await fetch("/api/warehouse/books", {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(
+          isEditMode ? { id: editingBookId, ...payload } : payload,
+        ),
+      });
+
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as
+          | { error?: string }
+          | null;
+        throw new Error(body?.error ?? "Не удалось сохранить книгу");
+      }
+
+      closeModal();
+      showToast(
+        isEditMode ? "Книга обновлена" : "Книга добавлена",
+        "success",
+      );
+      await fetchBooks();
+    } catch (error) {
+      console.error(error);
+      showToast(
+        error instanceof Error ? error.message : "Произошла непредвиденная ошибка",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    const confirmDelete = window.confirm("Удалить книгу?");
+    if (!confirmDelete) return;
+
+    try {
+      const response = await fetch("/api/warehouse/books", {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ id }),
+      });
+
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as
+          | { error?: string }
+          | null;
+        throw new Error(body?.error ?? "Не удалось удалить книгу");
+      }
+
+      showToast("Книга удалена", "success");
+      await fetchBooks();
+    } catch (error) {
+      console.error(error);
+      showToast(
+        error instanceof Error ? error.message : "Произошла непредвиденная ошибка",
+      );
+    }
+  };
+
+  const handleSpreadSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (spreadBookId == null) {
+      showToast("Не выбрана книга для распространения");
+      return;
+    }
+
+    const count = Number.parseInt(spreadQuantity, 10);
+    if (Number.isNaN(count) || count <= 0) {
+      showToast("Количество должно быть положительным числом");
+      return;
+    }
+
+    setIsSpreading(true);
+
+    try {
+      const response = await fetch("/api/warehouse/books/spread", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ id: spreadBookId, count }),
+      });
+
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as
+          | { error?: string }
+          | null;
+        throw new Error(body?.error ?? "Не удалось распространить книгу");
+      }
+
+      closeSpreadModal();
+      showToast("Количество обновлено", "success");
+      await fetchBooks();
+    } catch (error) {
+      console.error(error);
+      showToast(
+        error instanceof Error ? error.message : "Произошла непредвиденная ошибка",
+      );
+    } finally {
+      setIsSpreading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-semibold text-slate-900">Книги</h2>
+          <p className="mt-1 text-sm text-slate-500">
+            Управляйте списком книг, отслеживайте остаток и распространение.
+          </p>
+        </div>
+        <button type="button" onClick={openCreateModal} className={PRIMARY_BUTTON}>
+          Добавить книгу
+        </button>
+      </div>
+
+      <div className="rounded-3xl border border-slate-200 bg-white/90 p-4 shadow-lg shadow-slate-200/60 backdrop-blur-sm">
+        <div className="overflow-x-auto">
+          <table className="min-w-full table-auto">
+            <thead>
+              <tr className="text-left text-xs font-semibold uppercase tracking-wider text-slate-500">
+                <th className="whitespace-nowrap px-4 py-3">Название</th>
+                <th className="whitespace-nowrap px-4 py-3">Язык</th>
+                <th className="whitespace-nowrap px-4 py-3">Кол-во</th>
+                <th className="whitespace-nowrap px-4 py-3">Цена закупочная</th>
+                <th className="whitespace-nowrap px-4 py-3">Цена реализации</th>
+                <th className="whitespace-nowrap px-4 py-3">Оплачено</th>
+                <th className="whitespace-nowrap px-4 py-3">Остаток долга</th>
+                <th className="whitespace-nowrap px-4 py-3">Примечание</th>
+                <th className="whitespace-nowrap px-4 py-3 text-right">Действия</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100 text-sm">
+              {loading ? (
+                <tr>
+                  <td colSpan={9} className="px-4 py-6 text-center text-slate-500">
+                    Загрузка...
+                  </td>
+                </tr>
+              ) : books.length === 0 ? (
+                <tr>
+                  <td colSpan={9} className="px-4 py-6 text-center text-slate-500">
+                    {listMessage}
+                  </td>
+                </tr>
+              ) : (
+                books.map((book) => {
+                  const debt = book.quantity * book.purchasePrice - book.paid;
+                  return (
+                    <tr
+                      key={book.id}
+                      className="transition hover:bg-slate-50/70"
+                    >
+                      <td className="px-4 py-3 font-medium text-slate-700">{book.title}</td>
+                      <td className="px-4 py-3 text-slate-600">{book.language}</td>
+                      <td className="px-4 py-3 text-slate-600">{book.quantity}</td>
+                      <td className="px-4 py-3 text-slate-600">{formatMoney(book.purchasePrice)}</td>
+                      <td className="px-4 py-3 text-slate-600">{formatMoney(book.salePrice)}</td>
+                      <td className="px-4 py-3 text-slate-600">{formatMoney(book.paid)}</td>
+                      <td className="px-4 py-3 text-slate-600">{formatMoney(debt)}</td>
+                      <td className="px-4 py-3 text-slate-600">{book.note ?? "—"}</td>
+                      <td className="px-4 py-3 text-right">
+                        <div className="flex flex-wrap justify-end gap-2">
+                          <button
+                            type="button"
+                            onClick={() => openEditModal(book)}
+                            className={MUTED_BUTTON}
+                          >
+                            Редактировать
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => openSpreadModal(book)}
+                            className={ACCENT_BUTTON}
+                          >
+                            Распространить
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleDelete(book.id)}
+                            className={DANGER_BUTTON}
+                          >
+                            Удалить
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {isModalOpen ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 backdrop-blur-sm">
+          <div className="w-full max-w-3xl rounded-3xl border border-slate-200 bg-white p-6 shadow-2xl shadow-slate-900/20">
+            <div className="mb-6 flex items-start justify-between">
+              <div>
+                <h3 className="text-xl font-semibold text-slate-900">
+                  {isEditMode ? "Редактировать книгу" : "Добавить книгу"}
+                </h3>
+                <p className="mt-1 text-sm text-slate-500">
+                  Заполните информацию о книге и её стоимости.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={closeModal}
+                className="rounded-full p-1 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
+                aria-label="Закрыть окно"
+              >
+                ✕
+              </button>
+            </div>
+
+            <form className="grid max-h-[70vh] grid-cols-1 gap-5 overflow-y-auto pr-2 md:grid-cols-2" onSubmit={handleSubmit}>
+              <div className="md:col-span-2">
+                <label className="mb-1 block text-sm font-medium text-slate-700">
+                  Название
+                </label>
+                <input
+                  type="text"
+                  value={formState.title}
+                  onChange={(event) =>
+                    setFormState((prev) => ({ ...prev, title: event.target.value }))
+                  }
+                  className={INPUT_CLASSES}
+                  required
+                />
+              </div>
+
+              <div>
+                <label className="mb-1 block text-sm font-medium text-slate-700">
+                  Язык
+                </label>
+                <select
+                  value={formState.language}
+                  onChange={(event) =>
+                    setFormState((prev) => ({
+                      ...prev,
+                      language: event.target.value as LanguageOption,
+                    }))
+                  }
+                  className={INPUT_CLASSES}
+                >
+                  {LANGUAGE_OPTIONS.map((option) => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label className="mb-1 block text-sm font-medium text-slate-700">
+                  Количество
+                </label>
+                <input
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={formState.quantity}
+                  onChange={(event) =>
+                    setFormState((prev) => ({ ...prev, quantity: event.target.value }))
+                  }
+                  className={INPUT_CLASSES}
+                  required
+                />
+              </div>
+
+              <div>
+                <label className="mb-1 block text-sm font-medium text-slate-700">
+                  Цена закупочная
+                </label>
+                <input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={formState.purchasePrice}
+                  onChange={(event) =>
+                    setFormState((prev) => ({
+                      ...prev,
+                      purchasePrice: event.target.value,
+                    }))
+                  }
+                  className={INPUT_CLASSES}
+                  required
+                />
+              </div>
+
+              <div>
+                <label className="mb-1 block text-sm font-medium text-slate-700">
+                  Цена реализации
+                </label>
+                <input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={formState.salePrice}
+                  onChange={(event) =>
+                    setFormState((prev) => ({ ...prev, salePrice: event.target.value }))
+                  }
+                  className={INPUT_CLASSES}
+                  required
+                />
+              </div>
+
+              <div>
+                <label className="mb-1 block text-sm font-medium text-slate-700">
+                  Оплачено
+                </label>
+                <input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={formState.paid}
+                  onChange={(event) =>
+                    setFormState((prev) => ({ ...prev, paid: event.target.value }))
+                  }
+                  className={INPUT_CLASSES}
+                  required
+                />
+              </div>
+
+              <div className="md:col-span-2">
+                <label className="mb-1 block text-sm font-medium text-slate-700">
+                  Примечание
+                </label>
+                <textarea
+                  value={formState.note}
+                  onChange={(event) =>
+                    setFormState((prev) => ({ ...prev, note: event.target.value }))
+                  }
+                  rows={3}
+                  className={TEXTAREA_CLASSES}
+                  placeholder="Дополнительная информация"
+                />
+              </div>
+
+              <div className="md:col-span-2 flex justify-end gap-3">
+                <button
+                  type="button"
+                  onClick={closeModal}
+                  className={SECONDARY_BUTTON}
+                  disabled={isSubmitting}
+                >
+                  Отмена
+                </button>
+                <button
+                  type="submit"
+                  className={PRIMARY_BUTTON}
+                  disabled={isSubmitting}
+                >
+                  {isSubmitting ? "Сохранение..." : "Сохранить"}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      ) : null}
+
+      {isSpreadModalOpen ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 backdrop-blur-sm">
+          <div className="w-full max-w-md rounded-3xl border border-slate-200 bg-white p-6 shadow-2xl shadow-slate-900/20">
+            <div className="mb-6 flex items-start justify-between">
+              <div>
+                <h3 className="text-xl font-semibold text-slate-900">
+                  Распространить книгу
+                </h3>
+                <p className="mt-1 text-sm text-slate-500">
+                  Укажите количество экземпляров, которые нужно списать со склада.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={closeSpreadModal}
+                className="rounded-full p-1 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
+                aria-label="Закрыть окно"
+              >
+                ✕
+              </button>
+            </div>
+
+            <form className="space-y-5" onSubmit={handleSpreadSubmit}>
+              <div>
+                <label className="mb-1 block text-sm font-medium text-slate-700">
+                  Количество
+                </label>
+                <input
+                  type="number"
+                  min="1"
+                  step="1"
+                  value={spreadQuantity}
+                  onChange={(event) => setSpreadQuantity(event.target.value)}
+                  className={INPUT_CLASSES}
+                  required
+                />
+              </div>
+
+              <div className="flex justify-end gap-3">
+                <button
+                  type="button"
+                  onClick={closeSpreadModal}
+                  className={SECONDARY_BUTTON}
+                  disabled={isSpreading}
+                >
+                  Отмена
+                </button>
+                <button
+                  type="submit"
+                  className={PRIMARY_BUTTON}
+                  disabled={isSpreading}
+                >
+                  {isSpreading ? "Отправка..." : "Подтвердить"}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      ) : null}
+
+      {toast ? <Toast toast={toast} onClose={() => setToast(null)} /> : null}
+    </div>
+  );
+};
+
+export default BooksPanel;

--- a/components/Warehouse/InventoryPanel.tsx
+++ b/components/Warehouse/InventoryPanel.tsx
@@ -1,0 +1,507 @@
+"use client";
+
+import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+
+type InventoryItem = {
+  id: number;
+  name: string;
+  category: string;
+  location: string;
+  price: number | null;
+  holder: string | null;
+  status: StatusOption | string;
+};
+
+type InventoryFormState = {
+  name: string;
+  category: string;
+  location: string;
+  price: string;
+  holder: string;
+  status: StatusOption;
+};
+
+type ToastTone = "success" | "error";
+
+type ToastState = {
+  id: number;
+  message: string;
+  tone: ToastTone;
+};
+
+type StatusOption = (typeof STATUS_OPTIONS)[number];
+
+const STATUS_OPTIONS = ["На месте", "Взято", "Передано", "Потеряно"] as const;
+
+const DEFAULT_FORM_STATE: InventoryFormState = {
+  name: "",
+  category: "",
+  location: "",
+  price: "",
+  holder: "",
+  status: "На месте",
+};
+
+const BUTTON_BASE =
+  "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2";
+const BUTTON_SM_BASE =
+  "inline-flex items-center justify-center rounded-lg px-3 py-1.5 text-xs font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2";
+
+const PRIMARY_BUTTON =
+  `${BUTTON_BASE} bg-indigo-600 text-white shadow-sm hover:bg-indigo-500 focus-visible:ring-indigo-500`;
+const SECONDARY_BUTTON =
+  `${BUTTON_BASE} border border-slate-200 bg-white text-slate-700 shadow-sm hover:bg-slate-50 focus-visible:ring-indigo-500`;
+const DANGER_BUTTON =
+  `${BUTTON_SM_BASE} border border-red-200 bg-white text-red-600 shadow-sm hover:bg-red-50 focus-visible:ring-red-500`;
+const MUTED_BUTTON =
+  `${BUTTON_SM_BASE} border border-slate-200 bg-white text-slate-600 shadow-sm hover:bg-slate-50 focus-visible:ring-indigo-500`;
+
+const INPUT_CLASSES =
+  "w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-inner transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400/60";
+const formatCurrency = (value: number | null) => {
+  if (value == null || Number.isNaN(value)) {
+    return "—";
+  }
+
+  return new Intl.NumberFormat("ru-RU", {
+    style: "currency",
+    currency: "RUB",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+};
+
+const Toast = ({ toast, onClose }: { toast: ToastState; onClose: () => void }) => {
+  const toneClasses =
+    toast.tone === "success"
+      ? "border-emerald-200 bg-white text-emerald-700"
+      : "border-red-200 bg-white text-red-700";
+
+  return (
+    <div className="fixed bottom-6 right-6 z-[60] flex max-w-sm flex-col gap-3">
+      <div
+        className={`flex items-start gap-3 rounded-2xl border px-4 py-3 shadow-xl ring-1 ring-slate-900/5 ${toneClasses}`}
+      >
+        <span className="text-base">{toast.tone === "success" ? "✓" : "⚠"}</span>
+        <div className="flex-1 text-sm font-medium leading-5">{toast.message}</div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-xs font-medium text-slate-400 transition hover:text-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
+          aria-label="Закрыть уведомление"
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+  );
+};
+
+const InventoryPanel = () => {
+  const [items, setItems] = useState<InventoryItem[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [listMessage, setListMessage] = useState<string>("Нет данных об инвентаре");
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [formState, setFormState] = useState<InventoryFormState>(DEFAULT_FORM_STATE);
+  const [editingItemId, setEditingItemId] = useState<number | null>(null);
+  const [toast, setToast] = useState<ToastState | null>(null);
+
+  const isEditMode = useMemo(() => editingItemId !== null, [editingItemId]);
+
+  useEffect(() => {
+    if (!toast) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => setToast(null), 4000);
+    return () => window.clearTimeout(timer);
+  }, [toast]);
+
+  const showToast = useCallback((message: string, tone: ToastTone = "error") => {
+    setToast({ id: Date.now(), message, tone });
+  }, []);
+
+  const fetchInventory = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await fetch("/api/warehouse/inventory");
+      if (!response.ok) {
+        throw new Error("Не удалось загрузить инвентарь");
+      }
+      const data = (await response.json()) as InventoryItem[];
+      setItems(data);
+      setListMessage(data.length === 0 ? "Нет данных об инвентаре" : "");
+    } catch (error) {
+      console.error(error);
+      setItems([]);
+      setListMessage("Не удалось загрузить инвентарь");
+      showToast(
+        error instanceof Error ? error.message : "Произошла непредвиденная ошибка",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [showToast]);
+
+  useEffect(() => {
+    void fetchInventory();
+  }, [fetchInventory]);
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+    setEditingItemId(null);
+    setFormState(DEFAULT_FORM_STATE);
+  };
+
+  const openCreateModal = () => {
+    setEditingItemId(null);
+    setFormState(DEFAULT_FORM_STATE);
+    setIsModalOpen(true);
+  };
+
+  const openEditModal = (item: InventoryItem) => {
+    setEditingItemId(item.id);
+    setFormState({
+      name: item.name ?? "",
+      category: item.category ?? "",
+      location: item.location ?? "",
+      price: item.price != null ? String(item.price) : "",
+      holder: item.holder ?? "",
+      status: STATUS_OPTIONS.includes(item.status as StatusOption)
+        ? (item.status as StatusOption)
+        : "На месте",
+    });
+    setIsModalOpen(true);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const name = formState.name.trim();
+    const category = formState.category.trim();
+    const location = formState.location.trim();
+    const holder = formState.holder.trim();
+    const status = formState.status;
+
+    if (!name || !category || !location) {
+      showToast("Заполните обязательные поля");
+      return;
+    }
+
+    let priceValue: number | null = null;
+    if (formState.price.trim()) {
+      priceValue = Number.parseFloat(formState.price.replace(",", "."));
+      if (Number.isNaN(priceValue) || priceValue < 0) {
+        showToast("Стоимость должна быть неотрицательным числом");
+        return;
+      }
+    }
+
+    const payload = {
+      name,
+      category,
+      location,
+      price: priceValue,
+      holder: holder || null,
+      status,
+    };
+
+    setIsSubmitting(true);
+
+    try {
+      const method = isEditMode ? "PUT" : "POST";
+      const response = await fetch("/api/warehouse/inventory", {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(
+          isEditMode ? { id: editingItemId, ...payload } : payload,
+        ),
+      });
+
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as
+          | { error?: string }
+          | null;
+        throw new Error(body?.error ?? "Не удалось сохранить запись");
+      }
+
+      closeModal();
+      showToast(
+        isEditMode ? "Запись обновлена" : "Запись добавлена",
+        "success",
+      );
+      await fetchInventory();
+    } catch (error) {
+      console.error(error);
+      showToast(
+        error instanceof Error ? error.message : "Произошла непредвиденная ошибка",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    const confirmDelete = window.confirm("Удалить запись?");
+    if (!confirmDelete) return;
+
+    try {
+      const response = await fetch("/api/warehouse/inventory", {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ id }),
+      });
+
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as
+          | { error?: string }
+          | null;
+        throw new Error(body?.error ?? "Не удалось удалить запись");
+      }
+
+      showToast("Запись удалена", "success");
+      await fetchInventory();
+    } catch (error) {
+      console.error(error);
+      showToast(
+        error instanceof Error ? error.message : "Произошла непредвиденная ошибка",
+      );
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-semibold text-slate-900">Инвентарь</h2>
+          <p className="mt-1 text-sm text-slate-500">
+            Следите за расположением оборудования и ответственных лиц.
+          </p>
+        </div>
+        <button type="button" onClick={openCreateModal} className={PRIMARY_BUTTON}>
+          Добавить
+        </button>
+      </div>
+
+      <div className="rounded-3xl border border-slate-200 bg-white/90 p-4 shadow-lg shadow-slate-200/60 backdrop-blur-sm">
+        <div className="overflow-x-auto">
+          <table className="min-w-full table-auto">
+            <thead>
+              <tr className="text-left text-xs font-semibold uppercase tracking-wider text-slate-500">
+                <th className="whitespace-nowrap px-4 py-3">Название</th>
+                <th className="whitespace-nowrap px-4 py-3">Категория</th>
+                <th className="whitespace-nowrap px-4 py-3">Местоположение</th>
+                <th className="whitespace-nowrap px-4 py-3">Стоимость</th>
+                <th className="whitespace-nowrap px-4 py-3">Кто отвечает</th>
+                <th className="whitespace-nowrap px-4 py-3">Статус</th>
+                <th className="whitespace-nowrap px-4 py-3 text-right">Действия</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100 text-sm">
+              {loading ? (
+                <tr>
+                  <td colSpan={7} className="px-4 py-6 text-center text-slate-500">
+                    Загрузка...
+                  </td>
+                </tr>
+              ) : items.length === 0 ? (
+                <tr>
+                  <td colSpan={7} className="px-4 py-6 text-center text-slate-500">
+                    {listMessage}
+                  </td>
+                </tr>
+              ) : (
+                items.map((item) => (
+                  <tr key={item.id} className="transition hover:bg-slate-50/70">
+                    <td className="px-4 py-3 font-medium text-slate-700">{item.name}</td>
+                    <td className="px-4 py-3 text-slate-600">{item.category}</td>
+                    <td className="px-4 py-3 text-slate-600">{item.location}</td>
+                    <td className="px-4 py-3 text-slate-600">{formatCurrency(item.price)}</td>
+                    <td className="px-4 py-3 text-slate-600">{item.holder || "—"}</td>
+                    <td className="px-4 py-3">
+                      <span className="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
+                        {item.status}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <div className="flex flex-wrap justify-end gap-2">
+                        <button
+                          type="button"
+                          onClick={() => openEditModal(item)}
+                          className={MUTED_BUTTON}
+                        >
+                          Редактировать
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleDelete(item.id)}
+                          className={DANGER_BUTTON}
+                        >
+                          Удалить
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {isModalOpen ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 backdrop-blur-sm">
+          <div className="w-full max-w-2xl rounded-3xl border border-slate-200 bg-white p-6 shadow-2xl shadow-slate-900/20">
+            <div className="mb-6 flex items-start justify-between">
+              <div>
+                <h3 className="text-xl font-semibold text-slate-900">
+                  {isEditMode ? "Редактировать запись" : "Добавить запись"}
+                </h3>
+                <p className="mt-1 text-sm text-slate-500">
+                  Заполните данные об оборудовании и ответственном лице.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={closeModal}
+                className="rounded-full p-1 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
+                aria-label="Закрыть окно"
+              >
+                ✕
+              </button>
+            </div>
+
+            <form className="grid max-h-[70vh] grid-cols-1 gap-5 overflow-y-auto pr-2 md:grid-cols-2" onSubmit={handleSubmit}>
+              <div>
+                <label className="mb-1 block text-sm font-medium text-slate-700">
+                  Название
+                </label>
+                <input
+                  type="text"
+                  value={formState.name}
+                  onChange={(event) =>
+                    setFormState((prev) => ({ ...prev, name: event.target.value }))
+                  }
+                  className={INPUT_CLASSES}
+                  required
+                />
+              </div>
+
+              <div>
+                <label className="mb-1 block text-sm font-medium text-slate-700">
+                  Категория
+                </label>
+                <input
+                  type="text"
+                  value={formState.category}
+                  onChange={(event) =>
+                    setFormState((prev) => ({ ...prev, category: event.target.value }))
+                  }
+                  className={INPUT_CLASSES}
+                  required
+                />
+              </div>
+
+              <div>
+                <label className="mb-1 block text-sm font-medium text-slate-700">
+                  Местоположение
+                </label>
+                <input
+                  type="text"
+                  value={formState.location}
+                  onChange={(event) =>
+                    setFormState((prev) => ({ ...prev, location: event.target.value }))
+                  }
+                  className={INPUT_CLASSES}
+                  required
+                />
+              </div>
+
+              <div>
+                <label className="mb-1 block text-sm font-medium text-slate-700">
+                  Стоимость
+                </label>
+                <input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={formState.price}
+                  onChange={(event) =>
+                    setFormState((prev) => ({ ...prev, price: event.target.value }))
+                  }
+                  className={INPUT_CLASSES}
+                  placeholder="Например, 1500"
+                />
+              </div>
+
+              <div>
+                <label className="mb-1 block text-sm font-medium text-slate-700">
+                  Кто отвечает
+                </label>
+                <input
+                  type="text"
+                  value={formState.holder}
+                  onChange={(event) =>
+                    setFormState((prev) => ({ ...prev, holder: event.target.value }))
+                  }
+                  className={INPUT_CLASSES}
+                  placeholder="Имя ответственного"
+                />
+              </div>
+
+              <div>
+                <label className="mb-1 block text-sm font-medium text-slate-700">
+                  Статус
+                </label>
+                <select
+                  value={formState.status}
+                  onChange={(event) =>
+                    setFormState((prev) => ({
+                      ...prev,
+                      status: event.target.value as StatusOption,
+                    }))
+                  }
+                  className={INPUT_CLASSES}
+                >
+                  {STATUS_OPTIONS.map((option) => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div className="md:col-span-2 flex justify-end gap-3">
+                <button
+                  type="button"
+                  onClick={closeModal}
+                  className={SECONDARY_BUTTON}
+                  disabled={isSubmitting}
+                >
+                  Отмена
+                </button>
+                <button
+                  type="submit"
+                  className={PRIMARY_BUTTON}
+                  disabled={isSubmitting}
+                >
+                  {isSubmitting ? "Сохранение..." : "Сохранить"}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      ) : null}
+
+      {toast ? <Toast toast={toast} onClose={() => setToast(null)} /> : null}
+    </div>
+  );
+};
+
+export default InventoryPanel;

--- a/components/Warehouse/WarehouseTabs.tsx
+++ b/components/Warehouse/WarehouseTabs.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState } from "react";
+
+import BooksPanel from "./BooksPanel";
+import InventoryPanel from "./InventoryPanel";
+
+type WarehouseTabKey = "inventory" | "books";
+
+type WarehouseTabConfig = {
+  key: WarehouseTabKey;
+  label: string;
+};
+
+const TABS: WarehouseTabConfig[] = [
+  { key: "inventory", label: "Инвентарь" },
+  { key: "books", label: "Книги" },
+];
+
+const WarehouseTabs = () => {
+  const [activeTab, setActiveTab] = useState<WarehouseTabKey>("inventory");
+
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="rounded-3xl border border-slate-200 bg-white/80 p-1 shadow-lg shadow-slate-200/60 backdrop-blur-sm">
+        <div className="grid grid-cols-2 gap-1">
+          {TABS.map((tab) => {
+            const isActive = tab.key === activeTab;
+
+            return (
+              <button
+                key={tab.key}
+                type="button"
+                onClick={() => setActiveTab(tab.key)}
+                className={`rounded-2xl px-5 py-3 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 ${
+                  isActive
+                    ? "bg-indigo-600 text-white shadow-lg shadow-indigo-200"
+                    : "text-slate-600 hover:bg-slate-100"
+                }`}
+                role="tab"
+                aria-selected={isActive}
+              >
+                {tab.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div>
+        {activeTab === "inventory" ? <InventoryPanel /> : null}
+        {activeTab === "books" ? <BooksPanel /> : null}
+      </div>
+    </div>
+  );
+};
+
+export default WarehouseTabs;

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -55,5 +55,12 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "swr": "^2.3.6"
+  },
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "postinstall": "prisma generate"
   }
 }

--- a/pages/api/warehouse/books.ts
+++ b/pages/api/warehouse/books.ts
@@ -1,0 +1,177 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+type ErrorResponse = { error: string; details?: string };
+
+type SuccessResponse = { success: true };
+
+type BookListResponse = Awaited<ReturnType<typeof prisma.book.findMany>>;
+type BookResponse = Awaited<ReturnType<typeof prisma.book.create>>;
+
+type BookPayload = {
+  title?: unknown;
+  language?: unknown;
+  quantity?: unknown;
+  purchasePrice?: unknown;
+  salePrice?: unknown;
+  paid?: unknown;
+  note?: unknown;
+  id?: unknown;
+};
+
+const normalizeString = (value: unknown) =>
+  typeof value === "string" ? value.trim() : "";
+
+const normalizeOptionalString = (value: unknown) => {
+  const normalized = normalizeString(value);
+  return normalized ? normalized : null;
+};
+
+const toNumber = (value: unknown) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const toFloat = (value: unknown) => {
+  const parsed = Number.parseFloat(typeof value === "string" ? value : String(value ?? ""));
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<BookListResponse | BookResponse | SuccessResponse | ErrorResponse>,
+) {
+  try {
+    if (req.method === "GET") {
+      const books = await prisma.book.findMany();
+      return res.status(200).json(books);
+    }
+
+    if (req.method === "POST") {
+      const { title, language, quantity, purchasePrice, salePrice, paid, note } =
+        (req.body ?? {}) as BookPayload;
+
+      const normalizedTitle = normalizeString(title);
+      const normalizedLanguage = normalizeString(language);
+
+      if (!normalizedTitle || !normalizedLanguage) {
+        return res.status(400).json({ error: "Название и язык обязательны" });
+      }
+
+      const q = toNumber(quantity);
+      const buy = toFloat(purchasePrice);
+      const sell = toFloat(salePrice);
+      const pay = toFloat(paid);
+
+      const newBook = await prisma.book.create({
+        data: {
+          title: normalizedTitle,
+          language: normalizedLanguage,
+          quantity: q,
+          purchasePrice: buy,
+          salePrice: sell,
+          paid: pay,
+          note: normalizeOptionalString(note),
+        },
+      });
+
+      return res.status(201).json(newBook);
+    }
+
+    if (req.method === "PUT") {
+      const { id, title, language, quantity, purchasePrice, salePrice, paid, note } =
+        (req.body ?? {}) as BookPayload;
+
+      const bookId = Number(id);
+      if (!Number.isInteger(bookId) || bookId <= 0) {
+        return res.status(400).json({ error: "Некорректный идентификатор" });
+      }
+
+      const updateData: Record<string, unknown> = {};
+
+      if (title !== undefined) {
+        const normalizedTitle = normalizeString(title);
+        if (!normalizedTitle) {
+          return res.status(400).json({ error: "Название не может быть пустым" });
+        }
+        updateData.title = normalizedTitle;
+      }
+
+      if (language !== undefined) {
+        const normalizedLanguage = normalizeString(language);
+        if (!normalizedLanguage) {
+          return res.status(400).json({ error: "Язык не может быть пустым" });
+        }
+        updateData.language = normalizedLanguage;
+      }
+
+      if (quantity !== undefined) {
+        const q = Number(quantity);
+        if (!Number.isFinite(q)) {
+          return res.status(400).json({ error: "Некорректное количество" });
+        }
+        updateData.quantity = q;
+      }
+
+      if (purchasePrice !== undefined) {
+        const value = Number.parseFloat(String(purchasePrice));
+        if (!Number.isFinite(value)) {
+          return res.status(400).json({ error: "Некорректная цена закупки" });
+        }
+        updateData.purchasePrice = value;
+      }
+
+      if (salePrice !== undefined) {
+        const value = Number.parseFloat(String(salePrice));
+        if (!Number.isFinite(value)) {
+          return res.status(400).json({ error: "Некорректная цена реализации" });
+        }
+        updateData.salePrice = value;
+      }
+
+      if (paid !== undefined) {
+        const value = Number.parseFloat(String(paid));
+        if (!Number.isFinite(value)) {
+          return res.status(400).json({ error: "Некорректная сумма оплаты" });
+        }
+        updateData.paid = value;
+      }
+
+      if (note !== undefined) {
+        updateData.note = normalizeOptionalString(note);
+      }
+
+      if (Object.keys(updateData).length === 0) {
+        return res.status(400).json({ error: "Нет данных для обновления" });
+      }
+
+      const updatedBook = await prisma.book.update({
+        where: { id: bookId },
+        data: updateData,
+      });
+
+      return res.status(200).json(updatedBook);
+    }
+
+    if (req.method === "DELETE") {
+      const { id } = (req.body ?? {}) as BookPayload;
+      const bookId = Number(id);
+
+      if (!Number.isInteger(bookId) || bookId <= 0) {
+        return res.status(400).json({ error: "Некорректный идентификатор" });
+      }
+
+      await prisma.book.delete({ where: { id: bookId } });
+      return res.status(200).json({ success: true });
+    }
+
+    res.setHeader("Allow", "GET,POST,PUT,DELETE");
+    return res.status(405).json({ error: "Метод не поддерживается" });
+  } catch (err) {
+    console.error("API error:", err);
+    const details = err instanceof Error ? err.message : "Неизвестная ошибка";
+    return res.status(500).json({ error: "Ошибка сервера", details });
+  }
+}

--- a/pages/api/warehouse/books/spread.ts
+++ b/pages/api/warehouse/books/spread.ts
@@ -1,0 +1,91 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { Prisma } from "@prisma/client";
+
+import { spreadBook } from "@/src/server/services/warehouseService";
+
+type ErrorResponse = { error: string };
+
+type BookResponse = Awaited<ReturnType<typeof spreadBook>>;
+
+type RawBody = Record<string, unknown> | null;
+
+type ParseResult<T> = { data: T } | { error: string };
+
+function ensureJsonBody(body: NextApiRequest["body"]): RawBody {
+  if (!body) {
+    return null;
+  }
+
+  if (typeof body === "string") {
+    try {
+      return JSON.parse(body) as RawBody;
+    } catch (error) {
+      console.error("books spread api: failed to parse body", error);
+      return null;
+    }
+  }
+
+  if (typeof body === "object") {
+    return body as RawBody;
+  }
+
+  return null;
+}
+
+function parseSpread(body: RawBody): ParseResult<{ id: number; count: number }> {
+  if (!body) {
+    return { error: "Некорректные данные" };
+  }
+
+  const id = Number(body.id);
+  const count = Number(body.count);
+
+  if (!Number.isInteger(id) || id <= 0) {
+    return { error: "Некорректный идентификатор" };
+  }
+
+  if (!Number.isInteger(count) || count <= 0) {
+    return { error: "Количество должно быть положительным" };
+  }
+
+  return { data: { id, count } };
+}
+
+function sendError(res: NextApiResponse<ErrorResponse>, status: number, message: string) {
+  res.status(status).json({ error: message });
+}
+
+function handlePrismaError(res: NextApiResponse<ErrorResponse>, error: unknown) {
+  if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2025") {
+    return sendError(res, 404, "Книга не найдена");
+  }
+
+  if (error instanceof Error && error.message === "Недостаточно книг") {
+    return sendError(res, 400, error.message);
+  }
+
+  console.error("books spread api: unexpected error", error);
+  return sendError(res, 500, "Не удалось распространить книгу");
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<BookResponse | ErrorResponse>,
+) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).json({ error: "Метод не поддерживается" });
+  }
+
+  const result = parseSpread(ensureJsonBody(req.body));
+  if ("error" in result) {
+    return sendError(res, 400, result.error);
+  }
+
+  try {
+    const updated = await spreadBook(result.data.id, result.data.count);
+    return res.status(200).json(updated);
+  } catch (error) {
+    return handlePrismaError(res, error);
+  }
+}

--- a/pages/api/warehouse/inventory.ts
+++ b/pages/api/warehouse/inventory.ts
@@ -1,0 +1,178 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+type ErrorResponse = { error: string; details?: string };
+
+type SuccessResponse = { success: true };
+
+type InventoryListResponse = Awaited<ReturnType<typeof prisma.inventory.findMany>>;
+type InventoryRecord = Awaited<ReturnType<typeof prisma.inventory.create>>;
+
+type InventoryPayload = {
+  id?: unknown;
+  name?: unknown;
+  category?: unknown;
+  location?: unknown;
+  price?: unknown;
+  holder?: unknown;
+  status?: unknown;
+};
+
+const normalizeString = (value: unknown) =>
+  typeof value === "string" ? value.trim() : "";
+
+const normalizeOptionalString = (value: unknown) => {
+  const normalized = normalizeString(value);
+  return normalized ? normalized : null;
+};
+
+const parsePrice = (value: unknown) => {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  const raw = String(value).trim();
+  if (!raw) {
+    return null;
+  }
+
+  const parsed = Number.parseFloat(raw) || 0;
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return null;
+  }
+
+  return parsed;
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    InventoryListResponse | InventoryRecord | SuccessResponse | ErrorResponse
+  >,
+) {
+  try {
+    if (req.method === "GET") {
+      const inventory = await prisma.inventory.findMany();
+      return res.status(200).json(inventory);
+    }
+
+    if (req.method === "POST") {
+      const { name, category, location, price, holder, status } =
+        (req.body ?? {}) as InventoryPayload;
+
+      const normalizedName = normalizeString(name);
+      const normalizedCategory = normalizeString(category);
+      const normalizedLocation = normalizeString(location);
+
+      if (!normalizedName || !normalizedCategory || !normalizedLocation) {
+        return res.status(400).json({ error: "Не заполнены обязательные поля" });
+      }
+
+      const priceValue = parsePrice(price);
+      if (price !== undefined && price !== null && priceValue === null) {
+        return res.status(400).json({ error: "Некорректная стоимость" });
+      }
+
+      const newItem = await prisma.inventory.create({
+        data: {
+          name: normalizedName,
+          category: normalizedCategory,
+          location: normalizedLocation,
+          price: priceValue,
+          holder: normalizeOptionalString(holder),
+          status: normalizeString(status) || "На месте",
+        },
+      });
+
+      return res.status(201).json(newItem);
+    }
+
+    if (req.method === "PUT") {
+      const { id, name, category, location, price, holder, status } =
+        (req.body ?? {}) as InventoryPayload;
+
+      const itemId = Number(id);
+      if (!Number.isInteger(itemId) || itemId <= 0) {
+        return res.status(400).json({ error: "Некорректный идентификатор" });
+      }
+
+      const updateData: Record<string, unknown> = {};
+
+      if (name !== undefined) {
+        const value = normalizeString(name);
+        if (!value) {
+          return res.status(400).json({ error: "Название не может быть пустым" });
+        }
+        updateData.name = value;
+      }
+
+      if (category !== undefined) {
+        const value = normalizeString(category);
+        if (!value) {
+          return res.status(400).json({ error: "Категория не может быть пустой" });
+        }
+        updateData.category = value;
+      }
+
+      if (location !== undefined) {
+        const value = normalizeString(location);
+        if (!value) {
+          return res.status(400).json({ error: "Местоположение не может быть пустым" });
+        }
+        updateData.location = value;
+      }
+
+      if (status !== undefined) {
+        const value = normalizeString(status);
+        if (!value) {
+          return res.status(400).json({ error: "Статус не может быть пустым" });
+        }
+        updateData.status = value;
+      }
+
+      if (holder !== undefined) {
+        updateData.holder = normalizeOptionalString(holder);
+      }
+
+      if (price !== undefined) {
+        const priceValue = parsePrice(price);
+        if (priceValue === null && String(price ?? "").trim() !== "") {
+          return res.status(400).json({ error: "Некорректная стоимость" });
+        }
+        updateData.price = priceValue;
+      }
+
+      if (Object.keys(updateData).length === 0) {
+        return res.status(400).json({ error: "Нет данных для обновления" });
+      }
+
+      const updatedItem = await prisma.inventory.update({
+        where: { id: itemId },
+        data: updateData,
+      });
+
+      return res.status(200).json(updatedItem);
+    }
+
+    if (req.method === "DELETE") {
+      const { id } = (req.body ?? {}) as InventoryPayload;
+      const itemId = Number(id);
+
+      if (!Number.isInteger(itemId) || itemId <= 0) {
+        return res.status(400).json({ error: "Некорректный идентификатор" });
+      }
+
+      await prisma.inventory.delete({ where: { id: itemId } });
+      return res.status(200).json({ success: true });
+    }
+
+    res.setHeader("Allow", "GET,POST,PUT,DELETE");
+    return res.status(405).json({ error: "Метод не поддерживается" });
+  } catch (err) {
+    console.error("API error:", err);
+    const details = err instanceof Error ? err.message : "Неизвестная ошибка";
+    return res.status(500).json({ error: "Ошибка сервера", details });
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -103,3 +103,24 @@ model exchange_rates {
 
   @@unique([base_currency, target_currency], map: "baseCurrency_targetCurrency")
 }
+
+model Inventory {
+  id       Int     @id @default(autoincrement())
+  name     String
+  category String
+  location String
+  price    Float?
+  holder   String?
+  status   String  @default("На месте")
+}
+
+model Book {
+  id            Int     @id @default(autoincrement())
+  title         String
+  language      String
+  quantity      Int
+  purchasePrice Float
+  salePrice     Float
+  paid          Float
+  note          String?
+}

--- a/src/server/services/warehouseService.ts
+++ b/src/server/services/warehouseService.ts
@@ -1,0 +1,41 @@
+import { Prisma, PrismaClient } from '@prisma/client';
+const prisma = new PrismaClient();
+
+// Инвентарь
+export async function getAllInventory() {
+  return prisma.inventory.findMany();
+}
+export async function createInventory(data: Prisma.InventoryCreateInput) {
+  return prisma.inventory.create({ data });
+}
+export async function updateInventory(id: number, data: Prisma.InventoryUpdateInput) {
+  return prisma.inventory.update({ where: { id }, data });
+}
+export async function deleteInventory(id: number) {
+  return prisma.inventory.delete({ where: { id } });
+}
+
+// Книги
+export async function getAllBooks() {
+  return prisma.book.findMany();
+}
+export async function createBook(data: Prisma.BookCreateInput) {
+  return prisma.book.create({ data });
+}
+export async function updateBook(id: number, data: Prisma.BookUpdateInput) {
+  return prisma.book.update({ where: { id }, data });
+}
+export async function deleteBook(id: number) {
+  return prisma.book.delete({ where: { id } });
+}
+
+// Распространение книги
+export async function spreadBook(id: number, count: number) {
+  const book = await prisma.book.findUnique({ where: { id } });
+  if (!book) throw new Error('Книга не найдена');
+  if (book.quantity < count) throw new Error('Недостаточно книг');
+  return prisma.book.update({
+    where: { id },
+    data: { quantity: book.quantity - count },
+  });
+}


### PR DESCRIPTION
## Summary
- wrap the books and inventory API handlers in a single try/catch that logs failures and returns consistent JSON error payloads
- validate required fields, coerce numeric inputs, and send normalized data to Prisma before performing CRUD operations

## Testing
- `npx prisma generate`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68e80dd9ed508331b45abb00196ab36f