### PR TITLE
feat: add task scheduler with calendar interface

### DIFF
--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -3,6 +3,7 @@ import { ensureAccountant } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { serializeTask } from "@/lib/serializers";
 import type { TaskStatus } from "@/lib/types";
+import { withTaskTable } from "@/lib/task-table";
 
 const VALID_STATUSES: TaskStatus[] = ["pending", "in_progress", "completed"];
 
@@ -49,7 +50,13 @@ export const PATCH = async (
     return NextResponse.json({ error: "Некорректные данные" }, { status: 400 });
   }
 
-  const task = await prisma.task.findUnique({ where: { id: params.id } });
+  let task;
+
+  try {
+    task = await withTaskTable(() => prisma.task.findUnique({ where: { id: params.id } }));
+  } catch {
+    return NextResponse.json({ error: "Не удалось загрузить задачу" }, { status: 500 });
+  }
 
   if (!task) {
     return NextResponse.json({ error: "Задача не найдена" }, { status: 404 });
@@ -141,9 +148,15 @@ export const PATCH = async (
     return NextResponse.json(serializeTask(task));
   }
 
-  const updated = await prisma.task.update({ where: { id: params.id }, data });
+  try {
+    const updated = await withTaskTable(() =>
+      prisma.task.update({ where: { id: params.id }, data })
+    );
 
-  return NextResponse.json(serializeTask(updated));
+    return NextResponse.json(serializeTask(updated));
+  } catch {
+    return NextResponse.json({ error: "Не удалось сохранить изменения" }, { status: 500 });
+  }
 };
 
 export const DELETE = async (
@@ -156,13 +169,23 @@ export const DELETE = async (
     return auth.response;
   }
 
-  const task = await prisma.task.findUnique({ where: { id: params.id } });
+  let task;
+
+  try {
+    task = await withTaskTable(() => prisma.task.findUnique({ where: { id: params.id } }));
+  } catch {
+    return NextResponse.json({ error: "Не удалось загрузить задачу" }, { status: 500 });
+  }
 
   if (!task) {
     return NextResponse.json({ error: "Задача не найдена" }, { status: 404 });
   }
 
-  await prisma.task.delete({ where: { id: params.id } });
+  try {
+    await withTaskTable(() => prisma.task.delete({ where: { id: params.id } }));
+  } catch {
+    return NextResponse.json({ error: "Не удалось удалить задачу" }, { status: 500 });
+  }
 
   return NextResponse.json(serializeTask(task));
 };

--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -1,0 +1,168 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { ensureAccountant } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+import { serializeTask } from "@/lib/serializers";
+import type { TaskStatus } from "@/lib/types";
+
+const VALID_STATUSES: TaskStatus[] = ["pending", "in_progress", "completed"];
+
+const normalizeText = (value: unknown) =>
+  typeof value === "string" ? value.trim().replace(/\s+/g, " ") : undefined;
+
+const parseDeadline = (value: unknown) => {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+
+  return date;
+};
+
+type TaskUpdateInput = {
+  title?: string;
+  description?: string;
+  deadline?: string;
+  responsible?: string;
+  status?: TaskStatus;
+  notify?: boolean;
+  notifyBeforeMinutes?: number | null;
+};
+
+export const PATCH = async (
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) => {
+  const auth = await ensureAccountant(request);
+
+  if (auth.response) {
+    return auth.response;
+  }
+
+  const payload = (await request.json().catch(() => null)) as Partial<TaskUpdateInput> | null;
+
+  if (!payload) {
+    return NextResponse.json({ error: "Некорректные данные" }, { status: 400 });
+  }
+
+  const task = await prisma.task.findUnique({ where: { id: params.id } });
+
+  if (!task) {
+    return NextResponse.json({ error: "Задача не найдена" }, { status: 404 });
+  }
+
+  const data: Record<string, unknown> = {};
+
+  if ("title" in payload) {
+    const title = normalizeText(payload.title);
+
+    if (!title) {
+      return NextResponse.json({ error: "Укажите название задачи" }, { status: 400 });
+    }
+
+    data.title = title;
+  }
+
+  if ("description" in payload) {
+    const description =
+      typeof payload.description === "string" && payload.description.trim().length > 0
+        ? payload.description.trim()
+        : null;
+    data.description = description;
+  }
+
+  if ("responsible" in payload) {
+    const responsible = normalizeText(payload.responsible);
+
+    if (!responsible) {
+      return NextResponse.json({ error: "Укажите ответственного" }, { status: 400 });
+    }
+
+    data.responsible = responsible;
+  }
+
+  if ("deadline" in payload) {
+    const deadline = parseDeadline(payload.deadline);
+
+    if (!deadline) {
+      return NextResponse.json({ error: "Укажите корректный дедлайн" }, { status: 400 });
+    }
+
+    data.due_date = deadline;
+  }
+
+  if ("status" in payload) {
+    const status = payload.status ?? "";
+
+    if (!VALID_STATUSES.includes(status)) {
+      return NextResponse.json({ error: "Некорректный статус" }, { status: 400 });
+    }
+
+    data.status = status;
+  }
+
+  let notifyEnabled = task.notify_enabled;
+
+  if ("notify" in payload) {
+    notifyEnabled = payload.notify === true;
+    data.notify_enabled = notifyEnabled;
+
+    if (!notifyEnabled) {
+      data.notify_before_minutes = null;
+    }
+  }
+
+  if ("notifyBeforeMinutes" in payload) {
+    const notifyBefore = payload.notifyBeforeMinutes;
+
+    if (notifyBefore == null) {
+      data.notify_before_minutes = null;
+    } else {
+      const numericValue = Number(notifyBefore);
+
+      if (!Number.isFinite(numericValue) || numericValue < 0) {
+        return NextResponse.json({ error: "Укажите корректное время напоминания" }, { status: 400 });
+      }
+
+      data.notify_before_minutes = Math.round(numericValue);
+
+      if (!notifyEnabled) {
+        data.notify_enabled = true;
+        notifyEnabled = true;
+      }
+    }
+  }
+
+  if (Object.keys(data).length === 0) {
+    return NextResponse.json(serializeTask(task));
+  }
+
+  const updated = await prisma.task.update({ where: { id: params.id }, data });
+
+  return NextResponse.json(serializeTask(updated));
+};
+
+export const DELETE = async (
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) => {
+  const auth = await ensureAccountant(request);
+
+  if (auth.response) {
+    return auth.response;
+  }
+
+  const task = await prisma.task.findUnique({ where: { id: params.id } });
+
+  if (!task) {
+    return NextResponse.json({ error: "Задача не найдена" }, { status: 404 });
+  }
+
+  await prisma.task.delete({ where: { id: params.id } });
+
+  return NextResponse.json(serializeTask(task));
+};

--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -96,9 +96,9 @@ export const PATCH = async (
   }
 
   if ("status" in payload) {
-    const status = payload.status ?? "";
+    const status = payload.status;
 
-    if (!VALID_STATUSES.includes(status)) {
+    if (!status || !VALID_STATUSES.includes(status)) {
       return NextResponse.json({ error: "Некорректный статус" }, { status: 400 });
     }
 

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -1,0 +1,100 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { ensureAccountant } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+import { serializeTask } from "@/lib/serializers";
+import type { TaskStatus } from "@/lib/types";
+
+const VALID_STATUSES: TaskStatus[] = ["pending", "in_progress", "completed"];
+
+const normalizeText = (value: string) => value.trim().replace(/\s+/g, " ");
+
+const parseDeadline = (value: unknown) => {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return date;
+};
+
+type TaskInput = {
+  title: string;
+  description?: string;
+  deadline: string;
+  responsible: string;
+  status?: TaskStatus;
+  notify?: boolean;
+  notifyBeforeMinutes?: number | null;
+};
+
+export const GET = async () => {
+  const tasks = await prisma.task.findMany({
+    orderBy: { due_date: "asc" }
+  });
+
+  return NextResponse.json(tasks.map(serializeTask));
+};
+
+export const POST = async (request: NextRequest) => {
+  const auth = await ensureAccountant(request);
+
+  if (auth.response) {
+    return auth.response;
+  }
+
+  const payload = (await request.json().catch(() => null)) as Partial<TaskInput> | null;
+
+  if (!payload || typeof payload.title !== "string" || typeof payload.deadline !== "string") {
+    return NextResponse.json({ error: "Некорректные данные" }, { status: 400 });
+  }
+
+  const title = normalizeText(payload.title);
+  const responsible = typeof payload.responsible === "string" ? normalizeText(payload.responsible) : "";
+  const description =
+    typeof payload.description === "string" && payload.description.trim().length > 0
+      ? payload.description.trim()
+      : null;
+  const deadline = parseDeadline(payload.deadline);
+
+  if (!title) {
+    return NextResponse.json({ error: "Укажите название задачи" }, { status: 400 });
+  }
+
+  if (!deadline) {
+    return NextResponse.json({ error: "Укажите корректный дедлайн" }, { status: 400 });
+  }
+
+  if (!responsible) {
+    return NextResponse.json({ error: "Укажите ответственного" }, { status: 400 });
+  }
+
+  const status = VALID_STATUSES.includes(payload.status ?? "pending") ? payload.status ?? "pending" : "pending";
+  const notify = payload.notify === true;
+  const rawNotifyBefore = notify ? payload.notifyBeforeMinutes ?? 0 : null;
+  const notifyBefore =
+    rawNotifyBefore === null ? null : Number.isFinite(Number(rawNotifyBefore)) ? Number(rawNotifyBefore) : null;
+
+  if (notify && (notifyBefore === null || notifyBefore < 0)) {
+    return NextResponse.json({ error: "Укажите корректное время напоминания" }, { status: 400 });
+  }
+
+  const created = await prisma.task.create({
+    data: {
+      id: crypto.randomUUID(),
+      title,
+      description,
+      due_date: deadline,
+      responsible,
+      status,
+      notify_enabled: notify,
+      notify_before_minutes: notifyBefore !== null ? Math.round(notifyBefore) : null
+    }
+  });
+
+  return NextResponse.json(serializeTask(created), { status: 201 });
+};

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -3,6 +3,7 @@ import { ensureAccountant } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { serializeTask } from "@/lib/serializers";
 import type { TaskStatus } from "@/lib/types";
+import { withTaskTable } from "@/lib/task-table";
 
 const VALID_STATUSES: TaskStatus[] = ["pending", "in_progress", "completed"];
 
@@ -33,11 +34,17 @@ type TaskInput = {
 };
 
 export const GET = async () => {
-  const tasks = await prisma.task.findMany({
-    orderBy: { due_date: "asc" }
-  });
+  try {
+    const tasks = await withTaskTable(() =>
+      prisma.task.findMany({
+        orderBy: { due_date: "asc" }
+      })
+    );
 
-  return NextResponse.json(tasks.map(serializeTask));
+    return NextResponse.json(tasks.map(serializeTask));
+  } catch {
+    return NextResponse.json({ error: "Не удалось загрузить задачи" }, { status: 500 });
+  }
 };
 
 export const POST = async (request: NextRequest) => {
@@ -83,18 +90,24 @@ export const POST = async (request: NextRequest) => {
     return NextResponse.json({ error: "Укажите корректное время напоминания" }, { status: 400 });
   }
 
-  const created = await prisma.task.create({
-    data: {
-      id: crypto.randomUUID(),
-      title,
-      description,
-      due_date: deadline,
-      responsible,
-      status,
-      notify_enabled: notify,
-      notify_before_minutes: notifyBefore !== null ? Math.round(notifyBefore) : null
-    }
-  });
+  try {
+    const created = await withTaskTable(() =>
+      prisma.task.create({
+        data: {
+          id: crypto.randomUUID(),
+          title,
+          description,
+          due_date: deadline,
+          responsible,
+          status,
+          notify_enabled: notify,
+          notify_before_minutes: notifyBefore !== null ? Math.round(notifyBefore) : null
+        }
+      })
+    );
 
-  return NextResponse.json(serializeTask(created), { status: 201 });
+    return NextResponse.json(serializeTask(created), { status: 201 });
+  } catch {
+    return NextResponse.json({ error: "Не удалось сохранить задачу" }, { status: 500 });
+  }
 };

--- a/app/globals.css
+++ b/app/globals.css
@@ -632,3 +632,309 @@ ol {
 .shadow {
   box-shadow: var(--shadow-soft);
 }
+
+.task-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 1rem;
+  border-radius: var(--radius-2xl);
+  border: 1px solid var(--border-strong);
+  background-color: var(--surface-primary);
+  box-shadow: var(--shadow-card);
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.task-summary span {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.task-summary strong {
+  font-size: 1.5rem;
+  color: var(--text-strong);
+}
+
+.task-summary[data-variant="danger"] {
+  background-color: var(--surface-danger);
+  border-color: var(--accent-danger);
+}
+
+.dark .task-summary[data-variant="danger"] {
+  background-color: rgba(248, 113, 113, 0.18);
+}
+
+.task-layout {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+}
+
+.task-calendar,
+.task-list {
+  background-color: var(--surface-subtle);
+  border-radius: var(--radius-2xl);
+  border: 1px solid var(--border-strong);
+  padding: 1.25rem;
+  box-shadow: var(--shadow-card);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.task-calendar__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.task-calendar__header h2 {
+  font-size: 1.2rem;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.task-calendar__weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.5rem;
+  text-align: center;
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.task-calendar__grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.6rem;
+}
+
+.task-calendar__cell {
+  border-radius: var(--radius-2xl);
+  border: 1px solid var(--border-muted);
+  background-color: var(--surface-primary);
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-height: 140px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.task-calendar__cell[data-active="false"] {
+  opacity: 0.55;
+}
+
+.task-calendar__cell[data-today="true"] {
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
+}
+
+.dark .task-calendar__cell[data-today="true"] {
+  box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.25);
+}
+
+.task-calendar__cell-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: var(--text-secondary-strong);
+}
+
+.task-calendar__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.1rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  background-color: var(--surface-indigo);
+  color: var(--text-strong);
+}
+
+.task-calendar__cell ul {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.task-calendar__cell li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.task-calendar__cell li span:first-child {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.task-calendar__more {
+  color: var(--accent-primary);
+  font-weight: 600;
+}
+
+.task-notify {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  padding: 1rem;
+  border-radius: var(--radius-2xl);
+  border: 1px solid var(--border-muted);
+  background-color: var(--surface-primary);
+}
+
+.task-notify__toggle {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.task-notify__toggle input {
+  width: auto;
+  accent-color: var(--accent-primary);
+}
+
+.task-notify__input {
+  flex: 1 1 200px;
+}
+
+.task-status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  background-color: var(--surface-muted);
+  color: var(--text-secondary);
+}
+
+.task-status-badge[data-status="pending"] {
+  background-color: var(--surface-amber-soft);
+  color: var(--accent-amber);
+}
+
+.task-status-badge[data-status="in_progress"] {
+  background-color: var(--surface-teal-bright);
+  color: var(--accent-teal);
+}
+
+.task-status-badge[data-status="completed"] {
+  background-color: var(--surface-success);
+  color: var(--accent-success);
+}
+
+.task-list h2,
+.task-list h3 {
+  font-weight: 600;
+}
+
+.task-list ul {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.task-list li {
+  background-color: var(--surface-primary);
+  border-radius: var(--radius-2xl);
+  border: 1px solid var(--border-muted);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.task-list__main {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.task-list__info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.task-list__info strong {
+  font-size: 1.05rem;
+  color: var(--text-strong);
+}
+
+.task-list__info span {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.task-list__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.task-list__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-end;
+}
+
+.task-list__controls label {
+  flex: 1 1 200px;
+}
+
+.task-list__completed {
+  border-top: 1px solid var(--border-strong);
+  padding-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.task-list__completed ul {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.task-list__completed li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.task-list__completed li > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+@media (max-width: 768px) {
+  .task-calendar__grid {
+    gap: 0.4rem;
+  }
+
+  .task-calendar__cell {
+    min-height: 120px;
+  }
+}

--- a/app/tasks/page.tsx
+++ b/app/tasks/page.tsx
@@ -1,0 +1,729 @@
+"use client";
+
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+import useSWR from "swr";
+import AuthGate from "@/components/AuthGate";
+import PageContainer from "@/components/PageContainer";
+import { useSession } from "@/components/SessionProvider";
+import { fetcher, type FetcherError } from "@/lib/fetcher";
+import type { Task, TaskStatus } from "@/lib/types";
+
+const STATUS_LABELS: Record<TaskStatus, string> = {
+  pending: "Запланирована",
+  in_progress: "В работе",
+  completed: "Завершена"
+};
+
+const formatDateKey = (date: Date) =>
+  `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+
+const toLocalInputValue = (date: Date) => {
+  const copy = new Date(date.getTime() - date.getTimezoneOffset() * 60000);
+
+  return copy.toISOString().slice(0, 16);
+};
+
+const defaultDeadlineInput = () => {
+  const date = new Date();
+  date.setHours(date.getHours() + 2, 0, 0, 0);
+
+  return toLocalInputValue(date);
+};
+
+const formatMonthLabel = (date: Date) => {
+  const label = date.toLocaleDateString("ru-RU", { month: "long", year: "numeric" });
+
+  return label.charAt(0).toUpperCase() + label.slice(1);
+};
+
+const TaskSchedulerContent = () => {
+  const { user, refresh } = useSession();
+  const canManage = (user?.role ?? "") === "admin";
+
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [responsible, setResponsible] = useState("");
+  const [deadline, setDeadline] = useState<string>(() => defaultDeadlineInput());
+  const [notify, setNotify] = useState(false);
+  const [notifyBefore, setNotifyBefore] = useState("60");
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [updatingId, setUpdatingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [currentMonth, setCurrentMonth] = useState(() => {
+    const now = new Date();
+
+    return new Date(now.getFullYear(), now.getMonth(), 1);
+  });
+
+  const {
+    data: tasksData,
+    error: tasksError,
+    isLoading: tasksLoading,
+    mutate: mutateTasks
+  } = useSWR<Task[]>(user ? "/api/tasks" : null, fetcher, {
+    revalidateOnFocus: true,
+    refreshInterval: 60000
+  });
+
+  useEffect(() => {
+    if (tasksData) {
+      setTasks(tasksData);
+    }
+  }, [tasksData]);
+
+  useEffect(() => {
+    if (!tasksError) {
+      setError(null);
+      return;
+    }
+
+    if ((tasksError as FetcherError).status === 401) {
+      setError("Сессия истекла, войдите заново.");
+      void refresh();
+      return;
+    }
+
+    setError("Не удалось загрузить задачи");
+  }, [tasksError, refresh]);
+
+  if (!user) {
+    return null;
+  }
+
+  const initialLoading = tasksLoading;
+  const now = Date.now();
+  const soonThreshold = 7 * 24 * 60 * 60 * 1000;
+
+  const sortedTasks = useMemo(
+    () =>
+      [...tasks].sort(
+        (a, b) => new Date(a.deadline).getTime() - new Date(b.deadline).getTime()
+      ),
+    [tasks]
+  );
+
+  const activeTasks = useMemo(
+    () => sortedTasks.filter((task) => task.status !== "completed"),
+    [sortedTasks]
+  );
+
+  const completedTasks = useMemo(
+    () => sortedTasks.filter((task) => task.status === "completed"),
+    [sortedTasks]
+  );
+
+  const overdueTasks = useMemo(
+    () =>
+      activeTasks.filter((task) => new Date(task.deadline).getTime() < now),
+    [activeTasks, now]
+  );
+
+  const upcomingTasks = useMemo(
+    () =>
+      activeTasks.filter((task) => {
+        const due = new Date(task.deadline).getTime();
+
+        return due >= now && due <= now + soonThreshold;
+      }),
+    [activeTasks, now, soonThreshold]
+  );
+
+  const tasksByDate = useMemo(() => {
+    const map: Record<string, Task[]> = {};
+
+    sortedTasks.forEach((task) => {
+      const key = formatDateKey(new Date(task.deadline));
+
+      if (!map[key]) {
+        map[key] = [];
+      }
+
+      map[key].push(task);
+    });
+
+    return map;
+  }, [sortedTasks]);
+
+  const calendarDays = useMemo(() => {
+    const start = new Date(currentMonth.getFullYear(), currentMonth.getMonth(), 1);
+    const end = new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 0);
+    const startOffset = (start.getDay() + 6) % 7;
+    const endOffset = (end.getDay() + 6) % 7;
+    const totalCells = startOffset + end.getDate() + (6 - endOffset);
+    const cells = Math.max(totalCells, 42);
+    const firstDay = new Date(start);
+    firstDay.setDate(firstDay.getDate() - startOffset);
+    const todayKey = formatDateKey(new Date());
+
+    return Array.from({ length: cells }, (_, index) => {
+      const date = new Date(firstDay);
+      date.setDate(firstDay.getDate() + index);
+      const key = formatDateKey(date);
+
+      return {
+        key,
+        date,
+        isCurrentMonth: date.getMonth() === currentMonth.getMonth(),
+        isToday: key === todayKey
+      };
+    });
+  }, [currentMonth]);
+
+  const monthLabel = useMemo(() => formatMonthLabel(currentMonth), [currentMonth]);
+
+  const dueFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat("ru-RU", {
+        day: "2-digit",
+        month: "long",
+        hour: "2-digit",
+        minute: "2-digit"
+      }),
+    []
+  );
+
+  const timeFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat("ru-RU", {
+        hour: "2-digit",
+        minute: "2-digit"
+      }),
+    []
+  );
+
+  const summaryCards = [
+    {
+      label: "Всего задач",
+      value: tasks.length.toString()
+    },
+    {
+      label: "Просрочено",
+      value: overdueTasks.length.toString(),
+      variant: overdueTasks.length > 0 ? "danger" : undefined
+    },
+    {
+      label: "На неделю",
+      value: upcomingTasks.length.toString()
+    },
+    {
+      label: "Завершено",
+      value: completedTasks.length.toString()
+    }
+  ];
+
+  const resetForm = () => {
+    setTitle("");
+    setDescription("");
+    setResponsible("");
+    setDeadline(defaultDeadlineInput());
+    setNotify(false);
+    setNotifyBefore("60");
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setMessage(null);
+
+    if (!canManage) {
+      setError("Недостаточно прав для добавления задач");
+      return;
+    }
+
+    const sanitizedTitle = title.trim();
+    const sanitizedResponsible = responsible.trim();
+    const deadlineDate = new Date(deadline);
+
+    if (!sanitizedTitle) {
+      setError("Укажите название задачи");
+      return;
+    }
+
+    if (Number.isNaN(deadlineDate.getTime())) {
+      setError("Укажите корректный дедлайн");
+      return;
+    }
+
+    if (!sanitizedResponsible) {
+      setError("Укажите ответственного");
+      return;
+    }
+
+    const payload: Record<string, unknown> = {
+      title: sanitizedTitle,
+      responsible: sanitizedResponsible,
+      deadline: deadlineDate.toISOString(),
+      notify
+    };
+
+    if (description.trim()) {
+      payload.description = description.trim();
+    }
+
+    if (notify) {
+      const notifyValue = Number(notifyBefore);
+
+      if (!Number.isFinite(notifyValue) || notifyValue < 0) {
+        setError("Укажите корректное время напоминания");
+        return;
+      }
+
+      payload.notifyBeforeMinutes = Math.round(notifyValue);
+    }
+
+    setLoading(true);
+
+    try {
+      const response = await fetch("/api/tasks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      });
+
+      const data = (await response.json().catch(() => null)) as Task | { error?: string } | null;
+
+      if (!response.ok || !data || ("error" in data && data.error)) {
+        throw new Error((data as { error?: string } | null)?.error ?? "Не удалось создать задачу");
+      }
+
+      const created = data as Task;
+
+      setTasks((current) =>
+        [...current, created].sort(
+          (a, b) => new Date(a.deadline).getTime() - new Date(b.deadline).getTime()
+        )
+      );
+      setMessage("Задача добавлена");
+      resetForm();
+      void mutateTasks();
+    } catch (submitError) {
+      const message =
+        submitError instanceof Error && submitError.message
+          ? submitError.message
+          : "Не удалось создать задачу";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleStatusChange = async (taskId: string, status: TaskStatus) => {
+    if (!canManage) {
+      return;
+    }
+
+    setError(null);
+    setMessage(null);
+    setUpdatingId(taskId);
+
+    try {
+      const response = await fetch(`/api/tasks/${taskId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status })
+      });
+
+      const data = (await response.json().catch(() => null)) as Task | { error?: string } | null;
+
+      if (!response.ok || !data || ("error" in data && data.error)) {
+        throw new Error((data as { error?: string } | null)?.error ?? "Не удалось обновить задачу");
+      }
+
+      const updated = data as Task;
+      setTasks((current) => current.map((item) => (item.id === taskId ? updated : item)));
+      void mutateTasks();
+    } catch (updateError) {
+      const message =
+        updateError instanceof Error && updateError.message
+          ? updateError.message
+          : "Не удалось обновить задачу";
+      setError(message);
+    } finally {
+      setUpdatingId(null);
+    }
+  };
+
+  const handleDelete = async (taskId: string) => {
+    if (!canManage) {
+      return;
+    }
+
+    setError(null);
+    setMessage(null);
+    setDeletingId(taskId);
+
+    try {
+      const response = await fetch(`/api/tasks/${taskId}`, { method: "DELETE" });
+
+      const data = (await response.json().catch(() => null)) as Task | { error?: string } | null;
+
+      if (!response.ok || !data || ("error" in data && data.error)) {
+        throw new Error((data as { error?: string } | null)?.error ?? "Не удалось удалить задачу");
+      }
+
+      setTasks((current) => current.filter((item) => item.id !== taskId));
+      void mutateTasks();
+    } catch (deleteError) {
+      const message =
+        deleteError instanceof Error && deleteError.message
+          ? deleteError.message
+          : "Не удалось удалить задачу";
+      setError(message);
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const goToPreviousMonth = () => {
+    setCurrentMonth((month) => new Date(month.getFullYear(), month.getMonth() - 1, 1));
+  };
+
+  const goToNextMonth = () => {
+    setCurrentMonth((month) => new Date(month.getFullYear(), month.getMonth() + 1, 1));
+  };
+
+  const renderTaskStatusBadge = (task: Task) => (
+    <span className="task-status-badge" data-status={task.status}>
+      {STATUS_LABELS[task.status]}
+    </span>
+  );
+
+  const renderDueHint = (task: Task) => {
+    if (task.status === "completed") {
+      return "Завершена";
+    }
+
+    const deadlineDate = new Date(task.deadline);
+    const diffMs = deadlineDate.getTime() - now;
+
+    if (diffMs < 0) {
+      const overdueDays = Math.ceil(Math.abs(diffMs) / (24 * 60 * 60 * 1000));
+
+      return `Просрочено на ${overdueDays} д.`;
+    }
+
+    if (diffMs <= 24 * 60 * 60 * 1000) {
+      return "Срок сегодня";
+    }
+
+    const daysLeft = Math.ceil(diffMs / (24 * 60 * 60 * 1000));
+
+    return `Через ${daysLeft} д.`;
+  };
+
+  return (
+    <PageContainer activeTab="tasks">
+      <section style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}>
+        <header style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+          <h1 style={{ fontSize: "1.75rem", fontWeight: 700 }}>Планировщик задач</h1>
+          <p style={{ color: "var(--text-secondary)", lineHeight: 1.5 }}>
+            Создавайте задачи, отслеживайте дедлайны и распределяйте ответственность по служениям.
+          </p>
+        </header>
+
+        <div
+          style={{
+            display: "grid",
+            gap: "1rem",
+            gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))"
+          }}
+        >
+          {summaryCards.map((card) => (
+            <div
+              key={card.label}
+              className="task-summary"
+              data-variant={card.variant ?? "default"}
+            >
+              <span>{card.label}</span>
+              <strong>{card.value}</strong>
+            </div>
+          ))}
+        </div>
+
+        {initialLoading ? (
+          <p style={{ color: "var(--text-muted)" }}>Загружаем задачи...</p>
+        ) : null}
+
+        {error ? <p style={{ color: "var(--accent-danger)" }}>{error}</p> : null}
+        {message ? <p style={{ color: "var(--accent-success)" }}>{message}</p> : null}
+
+        {!canManage ? (
+          <p style={{ color: "var(--text-muted)" }}>
+            Вы вошли как наблюдатель — задачи доступны только для просмотра.
+          </p>
+        ) : null}
+
+        {canManage ? (
+          <form
+            onSubmit={handleSubmit}
+            className="task-form"
+            style={{ display: "flex", flexDirection: "column", gap: "1rem" }}
+          >
+            <h2 style={{ fontSize: "1.25rem", fontWeight: 600 }}>Новая задача</h2>
+
+            <div
+              style={{
+                display: "grid",
+                gap: "1rem",
+                gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))"
+              }}
+            >
+              <label>
+                <span>Название</span>
+                <input
+                  type="text"
+                  value={title}
+                  onChange={(event) => setTitle(event.target.value)}
+                  placeholder="Например, подготовить рассылку"
+                  disabled={loading}
+                />
+              </label>
+
+              <label>
+                <span>Ответственный</span>
+                <input
+                  type="text"
+                  value={responsible}
+                  onChange={(event) => setResponsible(event.target.value)}
+                  placeholder="Имя служителя"
+                  disabled={loading}
+                />
+              </label>
+
+              <label>
+                <span>Дедлайн</span>
+                <input
+                  type="datetime-local"
+                  value={deadline}
+                  onChange={(event) => setDeadline(event.target.value)}
+                  disabled={loading}
+                  required
+                />
+              </label>
+            </div>
+
+            <label>
+              <span>Описание</span>
+              <textarea
+                rows={3}
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                placeholder="Кратко опишите задачу"
+                disabled={loading}
+              />
+            </label>
+
+            <div className="task-notify">
+              <label className="task-notify__toggle">
+                <input
+                  type="checkbox"
+                  checked={notify}
+                  onChange={(event) => setNotify(event.target.checked)}
+                  disabled={loading}
+                />
+                <span>Включить напоминание</span>
+              </label>
+
+              {notify ? (
+                <label className="task-notify__input">
+                  <span>За сколько минут напомнить</span>
+                  <input
+                    type="number"
+                    min="0"
+                    step="5"
+                    value={notifyBefore}
+                    onChange={(event) => setNotifyBefore(event.target.value)}
+                    disabled={loading}
+                  />
+                </label>
+              ) : null}
+            </div>
+
+            <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
+              <button type="submit" disabled={loading}>
+                {loading ? "Добавляем..." : "Добавить задачу"}
+              </button>
+              <button
+                type="button"
+                data-variant="outline"
+                onClick={resetForm}
+                disabled={loading}
+              >
+                Очистить
+              </button>
+            </div>
+          </form>
+        ) : null}
+
+        <div className="task-layout">
+          <section className="task-calendar" data-variant="plain">
+            <div className="task-calendar__header">
+              <button
+                type="button"
+                data-variant="ghost"
+                aria-label="Предыдущий месяц"
+                onClick={goToPreviousMonth}
+              >
+                ←
+              </button>
+              <h2>{monthLabel}</h2>
+              <button
+                type="button"
+                data-variant="ghost"
+                aria-label="Следующий месяц"
+                onClick={goToNextMonth}
+              >
+                →
+              </button>
+            </div>
+
+            <div className="task-calendar__weekdays">
+              {[
+                "Пн",
+                "Вт",
+                "Ср",
+                "Чт",
+                "Пт",
+                "Сб",
+                "Вс"
+              ].map((day) => (
+                <span key={day}>{day}</span>
+              ))}
+            </div>
+
+            <div className="task-calendar__grid">
+              {calendarDays.map((day) => {
+                const dayTasks = tasksByDate[day.key] ?? [];
+
+                return (
+                  <div
+                    key={day.key}
+                    className="task-calendar__cell"
+                    data-active={day.isCurrentMonth ? "true" : "false"}
+                    data-today={day.isToday ? "true" : "false"}
+                  >
+                    <div className="task-calendar__cell-header">
+                      <span>{day.date.getDate()}</span>
+                      {dayTasks.length > 0 ? (
+                        <span className="task-calendar__count">{dayTasks.length}</span>
+                      ) : null}
+                    </div>
+
+                    <ul>
+                      {dayTasks.slice(0, 3).map((task) => (
+                        <li key={task.id}>
+                          <span>{timeFormatter.format(new Date(task.deadline))}</span>
+                          <span>{task.title}</span>
+                        </li>
+                      ))}
+                      {dayTasks.length > 3 ? (
+                        <li className="task-calendar__more">
+                          + ещё {dayTasks.length - 3}
+                        </li>
+                      ) : null}
+                    </ul>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+
+          <section className="task-list" data-variant="plain">
+            <h2>Активные задачи</h2>
+            {activeTasks.length === 0 ? (
+              <p className="muted">Нет активных задач</p>
+            ) : (
+              <ul>
+                {activeTasks.map((task) => {
+                  const deadlineDate = new Date(task.deadline);
+
+                  return (
+                    <li key={task.id}>
+                      <div className="task-list__main">
+                        <div className="task-list__info">
+                          <strong>{task.title}</strong>
+                          <span>{renderDueHint(task)}</span>
+                        </div>
+                        {renderTaskStatusBadge(task)}
+                      </div>
+
+                      <div className="task-list__meta">
+                        <span>Ответственный: {task.responsible}</span>
+                        <span>Срок: {dueFormatter.format(deadlineDate)}</span>
+                        <span>
+                          {task.notify
+                            ? `Напоминание за ${task.notifyBeforeMinutes ?? 0} мин.`
+                            : "Без уведомления"}
+                        </span>
+                      </div>
+
+                      <div className="task-list__controls">
+                        <label>
+                          <span>Статус</span>
+                          <select
+                            value={task.status}
+                            onChange={(event) =>
+                              handleStatusChange(task.id, event.target.value as TaskStatus)
+                            }
+                            disabled={!canManage || updatingId === task.id}
+                          >
+                            {(Object.keys(STATUS_LABELS) as TaskStatus[]).map((status) => (
+                              <option key={status} value={status}>
+                                {STATUS_LABELS[status]}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+
+                        {canManage ? (
+                          <button
+                            type="button"
+                            data-variant="danger"
+                            onClick={() => handleDelete(task.id)}
+                            disabled={deletingId === task.id}
+                          >
+                            {deletingId === task.id ? "Удаляем..." : "Удалить"}
+                          </button>
+                        ) : null}
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+
+            {completedTasks.length > 0 ? (
+              <div className="task-list__completed">
+                <h3>Завершенные</h3>
+                <ul>
+                  {completedTasks.map((task) => (
+                    <li key={task.id}>
+                      <div>
+                        <strong>{task.title}</strong>
+                        <span className="muted">
+                          Завершено {dueFormatter.format(new Date(task.deadline))}
+                        </span>
+                      </div>
+                      <span>{task.responsible}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+          </section>
+        </div>
+      </section>
+    </PageContainer>
+  );
+};
+
+const TaskSchedulerPage = () => (
+  <AuthGate>
+    <TaskSchedulerContent />
+  </AuthGate>
+);
+
+export default TaskSchedulerPage;

--- a/components/AppNavigation.tsx
+++ b/components/AppNavigation.tsx
@@ -10,6 +10,7 @@ export type AppTabKey =
   | "wallets"
   | "debts"
   | "planning"
+  | "tasks"
   | "reports"
   | "settings"
   | "warehouse";
@@ -46,11 +47,37 @@ const WarehouseIcon = forwardRef<SVGSVGElement, IconProps>(
 
 WarehouseIcon.displayName = "WarehouseIcon";
 
+const CalendarIcon = forwardRef<SVGSVGElement, IconProps>(
+  ({ strokeWidth = 2, width = 24, height = 24, ...props }, ref) => (
+    <svg
+      ref={ref}
+      xmlns="http://www.w3.org/2000/svg"
+      width={width}
+      height={height}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <rect x="3" y="4" width="18" height="18" rx="2" />
+      <line x1="16" y1="2" x2="16" y2="6" />
+      <line x1="8" y1="2" x2="8" y2="6" />
+      <line x1="3" y1="10" x2="21" y2="10" />
+    </svg>
+  )
+);
+
+CalendarIcon.displayName = "CalendarIcon";
+
 const TABS: TabConfig[] = [
   { key: "home", href: "/", label: "Главная", icon: LayoutDashboard },
   { key: "debts", href: "/debts", label: "Долги", icon: HandCoins },
   { key: "wallets", href: "/wallets", label: "Кошельки", icon: Wallet },
   { key: "planning", href: "/planning", label: "Планирование", icon: ListChecks },
+  { key: "tasks", href: "/tasks", label: "Задачи", icon: CalendarIcon },
   { key: "reports", href: "/reports", label: "Отчёты", icon: BarChart3 },
   { key: "warehouse", href: "/warehouse", label: "Склад", icon: WarehouseIcon },
   { key: "settings", href: "/settings", label: "Настройки", icon: Settings }

--- a/lib/serializers.ts
+++ b/lib/serializers.ts
@@ -1,9 +1,10 @@
 import type {
   Operation as PrismaOperation,
   Debt as PrismaDebt,
-  Goal as PrismaGoal
+  Goal as PrismaGoal,
+  Task as PrismaTask
 } from "@prisma/client";
-import type { Currency, Debt, Goal, Operation } from "@/lib/types";
+import type { Currency, Debt, Goal, Operation, Task, TaskStatus } from "@/lib/types";
 
 type StoredDebtComment = {
   note?: unknown;
@@ -74,4 +75,25 @@ export const serializeGoal = (goal: PrismaGoal): Goal => ({
   currentAmount: Number(goal.current_amount),
   status: goal.status === "done" ? "done" : "active",
   currency: goal.currency as Currency
+});
+
+const normalizeTaskStatus = (status: string): TaskStatus => {
+  if (status === "completed" || status === "in_progress") {
+    return status;
+  }
+
+  return "pending";
+};
+
+export const serializeTask = (task: PrismaTask): Task => ({
+  id: task.id,
+  title: task.title,
+  description: task.description ?? undefined,
+  deadline: task.due_date.toISOString(),
+  responsible: task.responsible,
+  status: normalizeTaskStatus(task.status),
+  notify: task.notify_enabled,
+  notifyBeforeMinutes: task.notify_before_minutes ?? null,
+  createdAt: task.created_at.toISOString(),
+  updatedAt: task.updated_at.toISOString()
 });

--- a/lib/task-table.ts
+++ b/lib/task-table.ts
@@ -1,0 +1,52 @@
+import { Prisma } from "@prisma/client";
+import prisma from "@/lib/prisma";
+
+const isMissingTableError = (error: unknown) =>
+  error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2021";
+
+let ensurePromise: Promise<void> | null = null;
+
+const ensureTasksTable = async () => {
+  if (!ensurePromise) {
+    ensurePromise = (async () => {
+      await prisma.$executeRawUnsafe(`
+        CREATE TABLE IF NOT EXISTS "tasks" (
+          "id" uuid PRIMARY KEY,
+          "title" text NOT NULL,
+          "description" text,
+          "due_date" timestamptz NOT NULL,
+          "responsible" text NOT NULL,
+          "status" text NOT NULL DEFAULT 'pending',
+          "notify_enabled" boolean NOT NULL DEFAULT false,
+          "notify_before_minutes" integer,
+          "created_at" timestamptz NOT NULL DEFAULT now(),
+          "updated_at" timestamptz NOT NULL DEFAULT now()
+        )
+      `);
+
+      await prisma.$executeRawUnsafe(
+        'CREATE INDEX IF NOT EXISTS "tasks_due_date_idx" ON "tasks" ("due_date" ASC)'
+      );
+    })()
+      .catch((error) => {
+        ensurePromise = null;
+        throw error;
+      });
+  }
+
+  return ensurePromise;
+};
+
+export const withTaskTable = async <T>(operation: () => Promise<T>): Promise<T> => {
+  try {
+    return await operation();
+  } catch (error) {
+    if (isMissingTableError(error)) {
+      await ensureTasksTable();
+
+      return operation();
+    }
+
+    throw error;
+  }
+};

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -52,6 +52,21 @@ export type Goal = {
   currency: Currency;
 };
 
+export type TaskStatus = "pending" | "in_progress" | "completed";
+
+export type Task = {
+  id: string;
+  title: string;
+  description?: string;
+  deadline: string;
+  responsible: string;
+  status: TaskStatus;
+  notify: boolean;
+  notifyBeforeMinutes: number | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
 export type UserRole = "user" | "admin";
 
 export type User = {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -93,6 +93,22 @@ model InventoryItem {
   @@map("inventory_items")
 }
 
+model Task {
+  id                    String   @id @default(uuid()) @db.Uuid
+  title                 String
+  description           String?
+  due_date              DateTime @db.Timestamptz(6)
+  responsible           String
+  status                String   @default("pending")
+  notify_enabled        Boolean  @default(false)
+  notify_before_minutes Int?
+  created_at            DateTime @default(now()) @db.Timestamptz(6)
+  updated_at            DateTime @updatedAt @db.Timestamptz(6)
+
+  @@index([due_date(sort: Asc)])
+  @@map("tasks")
+}
+
 model Settings {
   id            Int      @id @default(autoincrement())
   base_currency String


### PR DESCRIPTION
## Summary
- add a Prisma Task model with serialization helpers and REST endpoints for listing, creating, updating and deleting tasks
- build a task scheduler page with creation form, calendar view, status management and notification options
- extend the app navigation and global styles to surface the new planner experience

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ea76002d108331903997fea7746ec2