### PR TITLE
Persist book catalog and sales

### DIFF
--- a/app/api/books/helpers.ts
+++ b/app/api/books/helpers.ts
@@ -1,0 +1,111 @@
+import { Prisma, type BookInventoryItem, type BookSale } from "@prisma/client";
+
+import prisma from "@/lib/prisma";
+
+let hasEnsuredBookInfrastructure = false;
+let ensureBookInfrastructurePromise: Promise<void> | null = null;
+
+const ensureBookInfrastructure = async () => {
+  if (hasEnsuredBookInfrastructure) {
+    return;
+  }
+
+  if (!ensureBookInfrastructurePromise) {
+    ensureBookInfrastructurePromise = (async () => {
+      await prisma.$executeRawUnsafe(
+        'CREATE EXTENSION IF NOT EXISTS "pgcrypto"',
+      );
+      await prisma.$executeRawUnsafe(`
+        CREATE TABLE IF NOT EXISTS "book_inventory_items" (
+          "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+          "title" TEXT NOT NULL,
+          "language" TEXT NOT NULL,
+          "quantity" INTEGER NOT NULL,
+          "purchase_price" DECIMAL(65,30) NOT NULL,
+          "sale_price" DECIMAL(65,30) NOT NULL,
+          "debt" DECIMAL(65,30) NOT NULL,
+          "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT NOW(),
+          CONSTRAINT "book_inventory_items_pkey" PRIMARY KEY ("id")
+        )
+      `);
+      await prisma.$executeRawUnsafe(`
+        CREATE TABLE IF NOT EXISTS "book_sales" (
+          "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+          "book_id" UUID NOT NULL,
+          "title" TEXT NOT NULL,
+          "language" TEXT NOT NULL,
+          "quantity" INTEGER NOT NULL,
+          "sale_price" DECIMAL(65,30) NOT NULL,
+          "total" DECIMAL(65,30) NOT NULL,
+          "sold_at" TIMESTAMPTZ(6) NOT NULL DEFAULT NOW(),
+          CONSTRAINT "book_sales_pkey" PRIMARY KEY ("id"),
+          CONSTRAINT "book_sales_book_id_fkey"
+            FOREIGN KEY ("book_id")
+            REFERENCES "book_inventory_items"("id")
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE
+        )
+      `);
+      await prisma.$executeRawUnsafe(
+        'CREATE INDEX IF NOT EXISTS "book_inventory_items_title_idx" ON "book_inventory_items"("title")',
+      );
+      await prisma.$executeRawUnsafe(
+        'CREATE INDEX IF NOT EXISTS "book_inventory_items_language_idx" ON "book_inventory_items"("language")',
+      );
+      await prisma.$executeRawUnsafe(
+        'CREATE INDEX IF NOT EXISTS "book_sales_sold_at_idx" ON "book_sales"("sold_at" DESC)',
+      );
+
+      hasEnsuredBookInfrastructure = true;
+    })()
+      .catch((error) => {
+        hasEnsuredBookInfrastructure = false;
+        throw error;
+      })
+      .finally(() => {
+        ensureBookInfrastructurePromise = null;
+      });
+  }
+
+  await ensureBookInfrastructurePromise;
+};
+
+export const withBookInfrastructure = async <T>(operation: () => Promise<T>) => {
+  try {
+    await ensureBookInfrastructure();
+    return await operation();
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2021"
+    ) {
+      hasEnsuredBookInfrastructure = false;
+      await ensureBookInfrastructure();
+      return operation();
+    }
+
+    throw error;
+  }
+};
+
+export const serializeBookInventoryItem = (item: BookInventoryItem) => ({
+  id: item.id,
+  title: item.title,
+  language: item.language,
+  quantity: item.quantity,
+  purchasePrice: Number(item.purchasePrice),
+  salePrice: Number(item.salePrice),
+  debt: Number(item.debt),
+  createdAt: item.createdAt.toISOString(),
+});
+
+export const serializeBookSale = (sale: BookSale) => ({
+  id: sale.id,
+  bookId: sale.bookId,
+  title: sale.title,
+  language: sale.language,
+  quantity: sale.quantity,
+  salePrice: Number(sale.salePrice),
+  total: Number(sale.total),
+  soldAt: sale.soldAt.toISOString(),
+});

--- a/app/api/books/inventory/route.ts
+++ b/app/api/books/inventory/route.ts
@@ -1,0 +1,131 @@
+import { NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+
+import prisma from "@/lib/prisma";
+
+import {
+  serializeBookInventoryItem,
+  withBookInfrastructure,
+} from "../helpers";
+
+const MAX_LIMIT = 200;
+const DEFAULT_LIMIT = 100;
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const limitParam = Number(searchParams.get("limit"));
+  const take = Number.isFinite(limitParam)
+    ? Math.min(MAX_LIMIT, Math.max(1, limitParam))
+    : DEFAULT_LIMIT;
+
+  try {
+    const items = await withBookInfrastructure(() =>
+      prisma.bookInventoryItem.findMany({
+        orderBy: { createdAt: "desc" },
+        take,
+      }),
+    );
+
+    return NextResponse.json({
+      items: items.map(serializeBookInventoryItem),
+    });
+  } catch (error) {
+    console.error("Failed to load book inventory", error);
+    return NextResponse.json(
+      { message: "Не удалось загрузить каталог книг" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  let payload: Record<string, unknown>;
+  try {
+    payload = (await request.json()) as Record<string, unknown>;
+  } catch (error) {
+    console.error("Invalid book inventory payload", error);
+    return NextResponse.json(
+      { message: "Некорректный формат данных" },
+      { status: 400 },
+    );
+  }
+
+  const title = String(payload.title ?? "").trim();
+  const language = String(payload.language ?? "").trim();
+  const rawQuantity = Number(payload.quantity);
+  const quantity = Number.isFinite(rawQuantity) ? Math.floor(rawQuantity) : NaN;
+  const purchasePriceRaw = Number(payload.purchasePrice);
+  const salePriceRaw = Number(payload.salePrice);
+  const debtRaw = Number(payload.debt);
+
+  if (!title) {
+    return NextResponse.json(
+      { message: "Укажите название книги" },
+      { status: 400 },
+    );
+  }
+
+  if (!language) {
+    return NextResponse.json(
+      { message: "Выберите язык книги" },
+      { status: 400 },
+    );
+  }
+
+  if (!Number.isFinite(quantity) || quantity <= 0) {
+    return NextResponse.json(
+      { message: "Введите корректное количество" },
+      { status: 400 },
+    );
+  }
+
+  const purchasePrice = Math.round(purchasePriceRaw * 100) / 100;
+  if (!Number.isFinite(purchasePrice) || purchasePrice < 0) {
+    return NextResponse.json(
+      { message: "Введите корректную цену закупки" },
+      { status: 400 },
+    );
+  }
+
+  const salePrice = Math.round(salePriceRaw * 100) / 100;
+  if (!Number.isFinite(salePrice) || salePrice < 0) {
+    return NextResponse.json(
+      { message: "Введите корректную цену реализации" },
+      { status: 400 },
+    );
+  }
+
+  const debt = Math.round(debtRaw * 100) / 100;
+  if (!Number.isFinite(debt) || debt < 0) {
+    return NextResponse.json(
+      { message: "Введите корректную сумму долга" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const created = await withBookInfrastructure(() =>
+      prisma.bookInventoryItem.create({
+        data: {
+          title,
+          language,
+          quantity,
+          purchasePrice: new Prisma.Decimal(purchasePrice.toFixed(2)),
+          salePrice: new Prisma.Decimal(salePrice.toFixed(2)),
+          debt: new Prisma.Decimal(debt.toFixed(2)),
+        },
+      }),
+    );
+
+    return NextResponse.json(
+      { item: serializeBookInventoryItem(created) },
+      { status: 201 },
+    );
+  } catch (error) {
+    console.error("Failed to save book inventory item", error);
+    return NextResponse.json(
+      { message: "Не удалось сохранить книгу" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/books/sales/route.ts
+++ b/app/api/books/sales/route.ts
@@ -1,0 +1,148 @@
+import { NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+
+import prisma from "@/lib/prisma";
+
+import { serializeBookInventoryItem, serializeBookSale, withBookInfrastructure } from "../helpers";
+
+const MAX_LIMIT = 200;
+const DEFAULT_LIMIT = 100;
+
+class HttpError extends Error {
+  constructor(public status: number, message: string) {
+    super(message);
+  }
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const limitParam = Number(searchParams.get("limit"));
+  const take = Number.isFinite(limitParam)
+    ? Math.min(MAX_LIMIT, Math.max(1, limitParam))
+    : DEFAULT_LIMIT;
+
+  try {
+    const sales = await withBookInfrastructure(() =>
+      prisma.bookSale.findMany({
+        orderBy: { soldAt: "desc" },
+        take,
+      }),
+    );
+
+    return NextResponse.json({ sales: sales.map(serializeBookSale) });
+  } catch (error) {
+    console.error("Failed to load book sales", error);
+    return NextResponse.json(
+      { message: "Не удалось загрузить продажи" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  let payload: Record<string, unknown>;
+  try {
+    payload = (await request.json()) as Record<string, unknown>;
+  } catch (error) {
+    console.error("Invalid book sale payload", error);
+    return NextResponse.json(
+      { message: "Некорректный формат данных" },
+      { status: 400 },
+    );
+  }
+
+  const bookId = String(payload.bookId ?? "").trim();
+  const rawQuantity = Number(payload.quantity);
+  const quantity = Number.isFinite(rawQuantity) ? Math.floor(rawQuantity) : NaN;
+  const salePriceRaw = Number(payload.salePrice);
+
+  if (!bookId) {
+    return NextResponse.json(
+      { message: "Выберите книгу для продажи" },
+      { status: 400 },
+    );
+  }
+
+  if (!Number.isFinite(quantity) || quantity <= 0) {
+    return NextResponse.json(
+      { message: "Введите корректное количество" },
+      { status: 400 },
+    );
+  }
+
+  const salePrice = Math.round(salePriceRaw * 100) / 100;
+  if (!Number.isFinite(salePrice) || salePrice < 0) {
+    return NextResponse.json(
+      { message: "Введите корректную цену реализации" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await withBookInfrastructure(() =>
+      prisma.$transaction(async (transaction) => {
+        const book = await transaction.bookInventoryItem.findUnique({
+          where: { id: bookId },
+        });
+
+        if (!book) {
+          throw new HttpError(404, "Книга не найдена");
+        }
+
+        if (quantity > book.quantity) {
+          throw new HttpError(
+            400,
+            `На складе доступно только ${book.quantity} экземпляров`,
+          );
+        }
+
+        const salePriceDecimal = new Prisma.Decimal(salePrice.toFixed(2));
+        const totalValue = Math.round(salePrice * quantity * 100) / 100;
+        const totalDecimal = new Prisma.Decimal(totalValue.toFixed(2));
+
+        const sale = await transaction.bookSale.create({
+          data: {
+            bookId: book.id,
+            title: book.title,
+            language: book.language,
+            quantity,
+            salePrice: salePriceDecimal,
+            total: totalDecimal,
+          },
+        });
+
+        const updatedBook = await transaction.bookInventoryItem.update({
+          where: { id: book.id },
+          data: {
+            quantity: book.quantity - quantity,
+          },
+        });
+
+        return { sale, updatedBook };
+      }),
+    );
+
+    return NextResponse.json(
+      {
+        sale: serializeBookSale(result.sale),
+        book: serializeBookInventoryItem(result.updatedBook),
+      },
+      { status: 201 },
+    );
+  } catch (error) {
+    if (error instanceof HttpError) {
+      return NextResponse.json({ message: error.message }, { status: error.status });
+    }
+
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      console.error("Prisma error while saving book sale", error);
+    } else {
+      console.error("Failed to save book sale", error);
+    }
+
+    return NextResponse.json(
+      { message: "Не удалось сохранить продажу" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/warehouse/page.tsx
+++ b/app/warehouse/page.tsx
@@ -63,6 +63,14 @@ type InventoryResponse = {
   items: InventoryRecord[];
 };
 
+type BookInventoryResponse = {
+  items: BookRecord[];
+};
+
+type BookSalesResponse = {
+  sales: SoldBookRecord[];
+};
+
 const cardClass =
   "rounded-lg border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900/70";
 const listCardClass =
@@ -109,17 +117,13 @@ const WarehousePage = () => {
   const [bookSaleFormError, setBookSaleFormError] = useState<string | null>(null);
   const [bookSaleFormSuccess, setBookSaleFormSuccess] = useState<string | null>(null);
   const [saleBookId, setSaleBookId] = useState("");
+  const [isBookCatalogLoading, setIsBookCatalogLoading] = useState(true);
+  const [bookCatalogError, setBookCatalogError] = useState<string | null>(null);
+  const [isBookSalesLoading, setIsBookSalesLoading] = useState(true);
+  const [bookSalesError, setBookSalesError] = useState<string | null>(null);
 
   const itemRefs = useRef(new Map<string, HTMLLIElement>());
   const blurTimeoutRef = useRef<number | null>(null);
-
-  const generateLocalId = useCallback(() => {
-    if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
-      return crypto.randomUUID();
-    }
-
-    return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
-  }, []);
 
   const normalizeMoney = useCallback((value: number) => {
     if (!Number.isFinite(value) || value < 0) {
@@ -262,6 +266,58 @@ const WarehousePage = () => {
     });
   }, []);
 
+  const sortBookRecords = useCallback((items: BookRecord[]) => {
+    return [...items].sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    );
+  }, []);
+
+  const sortSoldBookRecords = useCallback((items: SoldBookRecord[]) => {
+    return [...items].sort(
+      (a, b) =>
+        new Date(b.soldAt).getTime() - new Date(a.soldAt).getTime(),
+    );
+  }, []);
+
+  const replaceBookItems = useCallback(
+    (items: BookRecord[]) => {
+      setBookItems(sortBookRecords(items));
+    },
+    [sortBookRecords],
+  );
+
+  const upsertBookItem = useCallback(
+    (item: BookRecord) => {
+      setBookItems((previous) => {
+        const next = previous.filter((existing) => existing.id !== item.id);
+        if (item.quantity > 0) {
+          next.push(item);
+        }
+        return sortBookRecords(next);
+      });
+    },
+    [sortBookRecords],
+  );
+
+  const replaceSoldBookItems = useCallback(
+    (items: SoldBookRecord[]) => {
+      setSoldBookItems(sortSoldBookRecords(items));
+    },
+    [sortSoldBookRecords],
+  );
+
+  const upsertSoldBookRecord = useCallback(
+    (record: SoldBookRecord) => {
+      setSoldBookItems((previous) => {
+        const next = previous.filter((existing) => existing.id !== record.id);
+        next.push(record);
+        return sortSoldBookRecords(next);
+      });
+    },
+    [sortSoldBookRecords],
+  );
+
   useEffect(() => {
     const controller = new AbortController();
 
@@ -298,6 +354,80 @@ const WarehousePage = () => {
       controller.abort();
     };
   }, [mergeInventoryItems]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    const loadBookCatalog = async () => {
+      try {
+        setIsBookCatalogLoading(true);
+        setBookCatalogError(null);
+        const response = await fetch("/api/books/inventory?limit=100", {
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          throw new Error("Не удалось загрузить каталог книг");
+        }
+
+        const data = (await response.json()) as BookInventoryResponse;
+        replaceBookItems(data.items);
+      } catch (error) {
+        if (controller.signal.aborted) {
+          return;
+        }
+        console.error("Book catalog fetch failed", error);
+        setBookCatalogError("Не удалось загрузить каталог книг");
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsBookCatalogLoading(false);
+        }
+      }
+    };
+
+    void loadBookCatalog();
+
+    return () => {
+      controller.abort();
+    };
+  }, [replaceBookItems]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    const loadBookSales = async () => {
+      try {
+        setIsBookSalesLoading(true);
+        setBookSalesError(null);
+        const response = await fetch("/api/books/sales?limit=100", {
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          throw new Error("Не удалось загрузить продажи книг");
+        }
+
+        const data = (await response.json()) as BookSalesResponse;
+        replaceSoldBookItems(data.sales);
+      } catch (error) {
+        if (controller.signal.aborted) {
+          return;
+        }
+        console.error("Book sales fetch failed", error);
+        setBookSalesError("Не удалось загрузить продажи книг");
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsBookSalesLoading(false);
+        }
+      }
+    };
+
+    void loadBookSales();
+
+    return () => {
+      controller.abort();
+    };
+  }, [replaceSoldBookItems]);
 
   useEffect(() => {
     if (!trimmedQuery) {
@@ -618,25 +748,38 @@ const WarehousePage = () => {
       setBookFormSuccess(null);
 
       try {
-        const newRecord: BookRecord = {
-          id: generateLocalId(),
-          title,
-          language: selectedLanguage.value,
-          quantity: Math.floor(quantityValue),
-          purchasePrice,
-          salePrice,
-          debt,
-          createdAt: new Date().toISOString(),
-        };
+        const response = await fetch("/api/books/inventory", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            title,
+            language: selectedLanguage.value,
+            quantity: Math.floor(quantityValue),
+            purchasePrice,
+            salePrice,
+            debt,
+          }),
+        });
 
-        setBookItems((previous) => [newRecord, ...previous]);
+        if (!response.ok) {
+          const payload = await response.json().catch(() => null);
+          throw new Error(payload?.message ?? "Не удалось сохранить книгу");
+        }
+
+        const data = (await response.json()) as { item: BookRecord };
+        upsertBookItem(data.item);
         setBookFormSuccess("Книга добавлена в список");
         form.reset();
+      } catch (error) {
+        console.error("Book submit failed", error);
+        setBookFormError(
+          error instanceof Error ? error.message : "Не удалось сохранить книгу",
+        );
       } finally {
         setIsBookSubmitting(false);
       }
     },
-    [generateLocalId, isBookSubmitting, normalizeMoney],
+    [isBookSubmitting, normalizeMoney, upsertBookItem],
   );
 
   const handleBookSaleSubmit = useCallback(
@@ -690,43 +833,43 @@ const WarehousePage = () => {
         return;
       }
 
-      const totalRevenue = normalizeMoney(salePrice * quantityValue);
-
-      if (Number.isNaN(totalRevenue)) {
-        setBookSaleFormError("Не удалось рассчитать сумму продажи");
-        return;
-      }
-
       setIsBookSaleSubmitting(true);
       setBookSaleFormError(null);
       setBookSaleFormSuccess(null);
 
       try {
-        const newQuantity = targetBook.quantity - quantityValue;
+        const response = await fetch("/api/books/sales", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            bookId,
+            quantity: Math.floor(quantityValue),
+            salePrice,
+          }),
+        });
 
-        setBookItems((previous) =>
-          previous.map((item) =>
-            item.id === targetBook.id
-              ? { ...item, quantity: item.quantity - quantityValue }
-              : item,
-          ),
-        );
+        if (!response.ok) {
+          const payload = await response.json().catch(() => null);
+          throw new Error(payload?.message ?? "Не удалось сохранить продажу");
+        }
 
-        const saleRecord: SoldBookRecord = {
-          id: generateLocalId(),
-          bookId: targetBook.id,
-          title: targetBook.title,
-          language: targetBook.language,
-          quantity: quantityValue,
-          salePrice,
-          total: totalRevenue,
-          soldAt: new Date().toISOString(),
+        const data = (await response.json()) as {
+          sale: SoldBookRecord;
+          book: BookRecord;
         };
 
-        setSoldBookItems((previous) => [saleRecord, ...previous]);
+        upsertSoldBookRecord(data.sale);
+        upsertBookItem(data.book);
         setBookSaleFormSuccess("Продажа зафиксирована");
         form.reset();
-        setSaleBookId(newQuantity > 0 ? targetBook.id : "");
+        setSaleBookId(data.book.quantity > 0 ? data.book.id : "");
+      } catch (error) {
+        console.error("Book sale submit failed", error);
+        setBookSaleFormError(
+          error instanceof Error
+            ? error.message
+            : "Не удалось сохранить продажу",
+        );
       } finally {
         setIsBookSaleSubmitting(false);
       }
@@ -734,9 +877,10 @@ const WarehousePage = () => {
     [
       bookItems,
       bookQuantityFormatter,
-      generateLocalId,
       isBookSaleSubmitting,
       normalizeMoney,
+      upsertBookItem,
+      upsertSoldBookRecord,
     ],
   );
 
@@ -1882,7 +2026,15 @@ const WarehousePage = () => {
                   <p className="text-sm text-slate-500 dark:text-slate-400">Всего: {bookQuantityFormatter.format(totalBooksCount)} шт.</p>
                 </div>
 
-                {bookItems.length ? (
+                {isBookCatalogLoading ? (
+                  <div className={`${cardClass} text-center text-sm text-slate-600 dark:text-slate-300`}>
+                    Загрузка каталога...
+                  </div>
+                ) : bookCatalogError ? (
+                  <div className={`${cardClass} text-center text-sm text-rose-500 dark:text-rose-300`}>
+                    {bookCatalogError}
+                  </div>
+                ) : bookItems.length ? (
                   <div className={listCardClass}>
                     <ul className="divide-y divide-slate-200 dark:divide-slate-700">
                       {bookItems.map((item) => (
@@ -1922,7 +2074,15 @@ const WarehousePage = () => {
                   </div>
                 </div>
 
-                {soldBookItems.length ? (
+                {isBookSalesLoading ? (
+                  <div className="mt-4 rounded-md border border-slate-200 bg-white p-6 text-center text-sm text-slate-600 shadow-sm dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-300">
+                    Загрузка продаж...
+                  </div>
+                ) : bookSalesError ? (
+                  <div className="mt-4 rounded-md border border-slate-200 bg-white p-6 text-center text-sm text-rose-500 shadow-sm dark:border-slate-700 dark:bg-slate-900/60 dark:text-rose-300">
+                    {bookSalesError}
+                  </div>
+                ) : soldBookItems.length ? (
                   <ul className="mt-4 space-y-3">
                     {soldBookItems.map((record) => (
                       <li

--- a/app/warehouse/page.tsx
+++ b/app/warehouse/page.tsx
@@ -686,7 +686,7 @@ const WarehousePage = () => {
   };
 
   const handleBookSubmit = useCallback(
-    (event: FormEvent<HTMLFormElement>) => {
+    async (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
 
       if (isBookSubmitting) {
@@ -783,7 +783,7 @@ const WarehousePage = () => {
   );
 
   const handleBookSaleSubmit = useCallback(
-    (event: FormEvent<HTMLFormElement>) => {
+    async (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
 
       if (isBookSaleSubmitting) {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -93,6 +93,39 @@ model InventoryItem {
   @@map("inventory_items")
 }
 
+model BookInventoryItem {
+  id            String  @id @default(uuid()) @db.Uuid
+  title         String
+  language      String
+  quantity      Int
+  purchasePrice Decimal @map("purchase_price") @db.Decimal
+  salePrice     Decimal @map("sale_price") @db.Decimal
+  debt          Decimal @db.Decimal
+  createdAt     DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+
+  sales BookSale[]
+
+  @@index([title])
+  @@index([language])
+  @@map("book_inventory_items")
+}
+
+model BookSale {
+  id        String  @id @default(uuid()) @db.Uuid
+  bookId    String  @map("book_id") @db.Uuid
+  title     String
+  language  String
+  quantity  Int
+  salePrice Decimal @map("sale_price") @db.Decimal
+  total     Decimal @db.Decimal
+  soldAt    DateTime @default(now()) @map("sold_at") @db.Timestamptz(6)
+
+  book BookInventoryItem @relation(fields: [bookId], references: [id])
+
+  @@index([soldAt(sort: Desc)])
+  @@map("book_sales")
+}
+
 model Task {
   id                    String   @id @default(uuid()) @db.Uuid
   title                 String


### PR DESCRIPTION
## Summary
- define Prisma models and helpers for book inventory and sales persistence, including API routes for listing and saving entries
- ensure supporting infrastructure for the new tables and serialization helpers used by the routes
- update the warehouse page to load book data from the backend, submit changes through the API, and surface loading or error states in the UI

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ea98edef5c833193fb0812e5e29500