### PR TITLE
Add Express route for today's holiday lookup

### DIFF
--- a/holidays-api/api/holidays/today.ts
+++ b/holidays-api/api/holidays/today.ts
@@ -1,76 +1,30 @@
-import { createServer, IncomingMessage, ServerResponse } from 'http';
-import { Client } from 'pg';
+import express from 'express';
+import { Pool } from 'pg';
 
-const PORT = Number(process.env.PORT ?? 3000);
-const { DATABASE_URL } = process.env;
+const router = express.Router();
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 
-const sendJson = (res: ServerResponse, statusCode: number, payload: Record<string, unknown>) => {
-  res.statusCode = statusCode;
-  res.setHeader('Content-Type', 'application/json');
-  res.end(JSON.stringify(payload));
-};
-
-const formatToday = (): string => {
-  const today = new Date();
-  const day = `${today.getDate()}`.padStart(2, '0');
-  const month = `${today.getMonth() + 1}`.padStart(2, '0');
-  const year = today.getFullYear();
-
-  return `${day}.${month}.${year}`;
-};
-
-const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
-  if (!DATABASE_URL) {
-    sendJson(res, 500, { message: 'DATABASE_URL not configured.' });
-    return;
-  }
-
-  if (req.method !== 'GET') {
-    sendJson(res, 405, { message: 'Method not allowed.' });
-    return;
-  }
-
-  if ((req.url ?? '/') !== '/' && (req.url ?? '').split('?')[0] !== '/today') {
-    sendJson(res, 404, { message: 'Not found.' });
-    return;
-  }
-
-  const client = new Client({ connectionString: DATABASE_URL });
-
+router.get('/api/holidays/today', async (_req, res) => {
   try {
-    await client.connect();
+    const today = new Date().toLocaleDateString('ru-RU').replace(/\//g, '.');
+    const { rows } = await pool.query('SELECT * FROM holidays WHERE date = $1', [today]);
 
-    const formattedDate = formatToday();
-    const query = 'SELECT date, title, description FROM holidays WHERE date = $1';
-    const result = await client.query(query, [formattedDate]);
-
-    if (result.rows.length > 0) {
-      const holiday = result.rows[0];
-      sendJson(res, 200, {
-        date: holiday.date,
-        title: holiday.title,
-        description: holiday.description,
-      });
-    } else {
-      sendJson(res, 200, { message: 'No holidays today.' });
+    if (rows.length === 0) {
+      return res.status(404).json({ message: 'No holidays today.' });
     }
-  } catch (error) {
-    console.error('Database error:', error);
-    sendJson(res, 500, { message: 'Internal server error.' });
-  } finally {
-    await client.end().catch(() => {
-      // Ignore closing errors to avoid masking the main response.
+
+    const holiday = rows[0];
+
+    return res.json({
+      date: holiday.date,
+      title: holiday.title,
+      description: holiday.description ?? null,
     });
+  } catch (error) {
+    console.error('Failed to fetch today\'s holiday:', error);
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return res.status(500).json({ error: message });
   }
-};
-
-const server = createServer((req, res) => {
-  handleRequest(req, res).catch((error) => {
-    console.error('Unexpected error:', error);
-    sendJson(res, 500, { message: 'Internal server error.' });
-  });
 });
 
-server.listen(PORT, () => {
-  console.log(`Holiday API listening on port ${PORT}`);
-});
+export default router;

--- a/holidays-api/api/server.ts
+++ b/holidays-api/api/server.ts
@@ -1,0 +1,14 @@
+import express from 'express';
+import holidaysRouter from './holidays/today';
+
+const app = express();
+
+app.use(holidaysRouter);
+
+const PORT = Number(process.env.PORT ?? 3000);
+
+app.listen(PORT, () => {
+  console.log(`Holiday API listening on port ${PORT}`);
+});
+
+export default app;

--- a/holidays-api/package.json
+++ b/holidays-api/package.json
@@ -2,9 +2,10 @@
   "name": "holidays-api",
   "type": "module",
   "dependencies": {
+    "express": "^4.19.2",
     "pg": "^8.11.3"
   },
   "scripts": {
-    "start": "node api/holidays/today.ts"
+    "start": "node api/server.ts"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,7 +40,8 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    "types/**/*.d.ts"
   ],
   "exclude": [
     "node_modules"

--- a/types/express.d.ts
+++ b/types/express.d.ts
@@ -1,0 +1,37 @@
+import type { IncomingMessage, ServerResponse } from 'http';
+
+declare module 'express' {
+  export interface Request extends IncomingMessage {
+    path: string;
+  }
+
+  export interface Response extends ServerResponse {
+    status(code: number): Response;
+    json(body: unknown): Response;
+  }
+
+  export type NextFunction = () => void;
+  export type RequestHandler = (
+    req: Request,
+    res: Response,
+    next?: NextFunction
+  ) => void | Promise<void>;
+
+  export interface Router {
+    get(path: string, handler: RequestHandler): this;
+    use(handler: Router | RequestHandler): this;
+  }
+
+  export interface Application extends Router {
+    listen(port: number, callback?: () => void): import('http').Server;
+  }
+
+  interface ExpressNamespace {
+    (): Application;
+    Router(): Router;
+  }
+
+  const express: ExpressNamespace;
+
+  export default express;
+}


### PR DESCRIPTION
## Summary
- replace the standalone HTTP server with an Express router that serves GET /api/holidays/today
- reuse a shared pg Pool to query the holidays table for the current date and return either the holiday row or a 404 message
- add a lightweight Express bootstrapper that mounts the router and starts listening with the existing DATABASE_URL connection configuration

## Testing
- not run (network restrictions prevented installing new backend dependencies)

------
https://chatgpt.com/codex/tasks/task_e_68eebe4a6b348331be4bad0e70261b0d