### PR TITLE
Add Express endpoint for today's holidays

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   ],
   "devDependencies": {
     "@types/bcrypt": "^6.0.0",
+    "@types/express": "^4.17.21",
     "@types/node": "24.6.2",
     "@types/pg": "^8.15.5",
     "@types/react": "19.2.0",
@@ -49,6 +50,7 @@
   "dependencies": {
     "@prisma/client": "^6.16.3",
     "bcrypt": "^6.0.0",
+    "express": "^4.19.2",
     "next": "^14.2.5",
     "pg": "^8.16.3",
     "prisma": "^6.16.3",

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,16 @@
+import express from "express";
+
+import holidaysRouter from "./routes/holidays";
+
+const app = express();
+
+app.use(express.json());
+app.use("/api", holidaysRouter);
+
+const port = Number(process.env.PORT ?? 3001);
+
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});
+
+export default app;

--- a/server/routes/holidays.ts
+++ b/server/routes/holidays.ts
@@ -1,0 +1,53 @@
+import { Router } from "express";
+import { Pool } from "pg";
+
+const holidaysRouter = Router();
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+const formatToday = () => {
+  const now = new Date();
+  const day = `${now.getDate()}`.padStart(2, "0");
+  const month = `${now.getMonth() + 1}`.padStart(2, "0");
+  const year = now.getFullYear();
+
+  return `${day}.${month}.${year}`;
+};
+
+holidaysRouter.get("/holidays/today", async (_req, res) => {
+  if (!process.env.DATABASE_URL) {
+    res.status(500).json({ message: "DATABASE_URL is not configured." });
+    return;
+  }
+
+  try {
+    const today = formatToday();
+    const { rows } = await pool.query(
+      "SELECT date, title, description FROM holidays WHERE date = $1",
+      [today],
+    );
+
+    if (rows.length === 0) {
+      res.status(404).json({ message: "No holidays today." });
+      return;
+    }
+
+    const holiday = rows[0];
+    res.json({
+      date: holiday.date,
+      title: holiday.title,
+      description: holiday.description,
+    });
+  } catch (error) {
+    console.error("Error fetching holiday:", error);
+
+    const message =
+      error instanceof Error ? error.message : "Unknown database error";
+
+    res.status(500).json({ error: message });
+  }
+});
+
+export default holidaysRouter;


### PR DESCRIPTION
## Summary
- add an Express router that queries today's holiday from PostgreSQL using the existing DATABASE_URL connection string
- register the holidays router on the Express application entrypoint so it is served under /api/holidays/today
- declare the Express runtime and type dependencies needed by the new route

## Testing
- `bun install` *(fails: npm registry access returns 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eec579fa90833191b8da63a266a481