### PR TITLE
Add Первая tab with today's holiday view

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -711,6 +711,59 @@ ol {
   gap: 0.4rem;
 }
 
+.holiday-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.holiday-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+  border-radius: var(--radius-2xl);
+  border: 1px solid var(--border-strong);
+  background-color: var(--surface-primary);
+  box-shadow: var(--shadow-card);
+  min-width: min(320px, 100%);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease,
+    background-color 0.2s ease;
+}
+
+.holiday-card__label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.holiday-card__date {
+  font-size: 1.9rem;
+  font-weight: 700;
+  color: var(--text-strong);
+}
+
+.holiday-card__status {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.holiday-card__holiday {
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.holiday-card__note {
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  max-width: 40ch;
+}
+
 .task-calendar__cell {
   border-radius: var(--radius-2xl);
   border: 1px solid var(--border-muted);

--- a/app/pervaya/page.tsx
+++ b/app/pervaya/page.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import useSWR from "swr";
+
+import AuthGate from "@/components/AuthGate";
+import PageContainer from "@/components/PageContainer";
+import { useSession } from "@/components/SessionProvider";
+import { fetcher, type FetcherError } from "@/lib/fetcher";
+
+type HolidayInfo = {
+  title: string;
+  description: string | null;
+};
+
+type TodayHolidayResponse = {
+  date: string;
+  holiday: HolidayInfo | null;
+};
+
+const formatDisplayDate = (date: Date) => {
+  const label = date.toLocaleDateString("ru-RU", {
+    day: "2-digit",
+    month: "long",
+    year: "numeric"
+  });
+
+  return label.charAt(0).toUpperCase() + label.slice(1);
+};
+
+const HolidayView = () => {
+  const { user, refresh } = useSession();
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const { data, error, isLoading } = useSWR<TodayHolidayResponse>(
+    user ? "/api/holidays/today" : null,
+    fetcher,
+    {
+      revalidateOnFocus: true,
+      refreshInterval: 1000 * 60 * 60
+    }
+  );
+
+  useEffect(() => {
+    if (!error) {
+      setErrorMessage(null);
+      return;
+    }
+
+    const fetchError = error as FetcherError;
+
+    if (fetchError.status === 401) {
+      setErrorMessage("Сессия истекла, войдите заново.");
+      void refresh();
+      return;
+    }
+
+    setErrorMessage("Не удалось загрузить данные о празднике.");
+  }, [error, refresh]);
+
+  const todayLabel = formatDisplayDate(new Date());
+
+  useEffect(() => {
+    if (errorMessage) {
+      setStatusMessage(errorMessage);
+      return;
+    }
+
+    if (isLoading || !data) {
+      setStatusMessage("Загружаем данные...");
+      return;
+    }
+
+    if (data.holiday) {
+      setStatusMessage("Сегодня праздник");
+      return;
+    }
+
+    setStatusMessage("Сегодня праздников нет");
+  }, [data, errorMessage, isLoading]);
+
+  if (!user) {
+    return null;
+  }
+
+  const holidayTitle =
+    data?.holiday?.title ??
+    (errorMessage ? "Нет данных" : isLoading ? "Загружаем..." : "Нет праздника");
+  const holidayDescription = data?.holiday?.description ?? null;
+
+  return (
+    <PageContainer activeTab="pervaya">
+      <section className="holiday-layout">
+        <div className="holiday-card">
+          <span className="holiday-card__label">Сегодня</span>
+          <p className="holiday-card__date">{todayLabel}</p>
+          {statusMessage ? (
+            <p className="holiday-card__status">{statusMessage}</p>
+          ) : null}
+          <p className="holiday-card__holiday">{holidayTitle}</p>
+          {holidayDescription ? (
+            <p className="holiday-card__note">{holidayDescription}</p>
+          ) : null}
+        </div>
+      </section>
+    </PageContainer>
+  );
+};
+
+const PervayaPage = () => (
+  <AuthGate>
+    <HolidayView />
+  </AuthGate>
+);
+
+export default PervayaPage;

--- a/components/AppNavigation.tsx
+++ b/components/AppNavigation.tsx
@@ -3,10 +3,19 @@
 import Link from "next/link";
 import { forwardRef } from "react";
 import type { IconProps, LucideIcon } from "lucide-react";
-import { BarChart3, HandCoins, LayoutDashboard, ListChecks, Settings, Wallet } from "lucide-react";
+import {
+  BarChart3,
+  HandCoins,
+  LayoutDashboard,
+  ListChecks,
+  PartyPopper,
+  Settings,
+  Wallet
+} from "lucide-react";
 
 export type AppTabKey =
   | "home"
+  | "pervaya"
   | "wallets"
   | "debts"
   | "planning"
@@ -74,6 +83,7 @@ CalendarIcon.displayName = "CalendarIcon";
 
 const TABS: TabConfig[] = [
   { key: "home", href: "/", label: "Главная", icon: LayoutDashboard },
+  { key: "pervaya", href: "/pervaya", label: "Первая", icon: PartyPopper },
   { key: "debts", href: "/debts", label: "Долги", icon: HandCoins },
   { key: "wallets", href: "/wallets", label: "Кошельки", icon: Wallet },
   { key: "planning", href: "/planning", label: "Планирование", icon: ListChecks },

--- a/components/AppNavigation.tsx
+++ b/components/AppNavigation.tsx
@@ -8,7 +8,6 @@ import {
   HandCoins,
   LayoutDashboard,
   ListChecks,
-  PartyPopper,
   Settings,
   Wallet
 } from "lucide-react";
@@ -81,9 +80,35 @@ const CalendarIcon = forwardRef<SVGSVGElement, IconProps>(
 
 CalendarIcon.displayName = "CalendarIcon";
 
+const CelebrationIcon = forwardRef<SVGSVGElement, IconProps>(
+  ({ strokeWidth = 2, width = 24, height = 24, ...props }, ref) => (
+    <svg
+      ref={ref}
+      xmlns="http://www.w3.org/2000/svg"
+      width={width}
+      height={height}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <path d="m5 15 4-12 6 6Z" />
+      <path d="m3 21 8-4" />
+      <path d="m12 3 7 7" />
+      <path d="M14 11.5 17 21" />
+      <path d="m7 13 7-2" />
+    </svg>
+  )
+);
+
+CelebrationIcon.displayName = "CelebrationIcon";
+
 const TABS: TabConfig[] = [
   { key: "home", href: "/", label: "Главная", icon: LayoutDashboard },
-  { key: "pervaya", href: "/pervaya", label: "Первая", icon: PartyPopper },
+  { key: "pervaya", href: "/pervaya", label: "Первая", icon: CelebrationIcon },
   { key: "debts", href: "/debts", label: "Долги", icon: HandCoins },
   { key: "wallets", href: "/wallets", label: "Кошельки", icon: Wallet },
   { key: "planning", href: "/planning", label: "Планирование", icon: ListChecks },

--- a/pages/api/holidays/today.ts
+++ b/pages/api/holidays/today.ts
@@ -1,0 +1,70 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import prisma from "@/lib/prisma";
+
+const formatDateForQuery = (date: Date) => {
+  const day = String(date.getDate()).padStart(2, "0");
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const year = date.getFullYear();
+
+  return `${day}.${month}.${year}`;
+};
+
+type HolidayRecord = {
+  title: string;
+  description: string | null;
+};
+
+type TodayHolidayResponse = {
+  date: string;
+  holiday: HolidayRecord | null;
+};
+
+type ErrorResponse = {
+  message: string;
+};
+
+const handler = async (
+  req: NextApiRequest,
+  res: NextApiResponse<TodayHolidayResponse | ErrorResponse>
+) => {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res
+      .status(405)
+      .json({ message: "Метод не поддерживается для этого ресурса" });
+  }
+
+  const today = new Date();
+  const formatted = formatDateForQuery(today);
+
+  try {
+    const rows = await prisma.$queryRaw<
+      Array<{ title: string | null; description: string | null }>
+    >`
+      SELECT "title", "description"
+      FROM "holidays"
+      WHERE "date" = ${formatted}
+      LIMIT 1
+    `;
+
+    const holidayRow = rows[0];
+
+    const holiday =
+      holidayRow && holidayRow.title
+        ? {
+            title: holidayRow.title,
+            description: holidayRow.description ?? null
+          }
+        : null;
+
+    return res.status(200).json({ date: formatted, holiday });
+  } catch (error) {
+    console.error("Failed to load holiday", error);
+    return res
+      .status(500)
+      .json({ message: "Не удалось получить данные о празднике" });
+  }
+};
+
+export default handler;


### PR DESCRIPTION
## Summary
- add the Первая tab to the main navigation
- implement a page that shows today's date and the holiday name if present
- expose an API route and supporting styles for the holiday card

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68eec7433890833192bc2009896188b1