### PR TITLE
Add organizations and membership support

### DIFF
--- a/prisma/migrations/20250215000000_add_organizations/migration.sql
+++ b/prisma/migrations/20250215000000_add_organizations/migration.sql
@@ -1,0 +1,128 @@
+-- DropIndex
+DROP INDEX "categories_type_name_key";
+
+-- AlterTable
+ALTER TABLE "operations" ADD COLUMN     "organization_id" UUID NOT NULL;
+
+-- AlterTable
+ALTER TABLE "debts" ADD COLUMN     "organization_id" UUID NOT NULL;
+
+-- AlterTable
+ALTER TABLE "goals" ADD COLUMN     "organization_id" UUID NOT NULL;
+
+-- AlterTable
+ALTER TABLE "wallets" ADD COLUMN     "organization_id" UUID NOT NULL;
+
+-- AlterTable
+ALTER TABLE "categories" ADD COLUMN     "organization_id" UUID NOT NULL;
+
+-- AlterTable
+ALTER TABLE "inventory_items" ADD COLUMN     "organization_id" UUID NOT NULL;
+
+-- AlterTable
+ALTER TABLE "book_inventory_items" ADD COLUMN     "organization_id" UUID NOT NULL;
+
+-- AlterTable
+ALTER TABLE "book_sales" ADD COLUMN     "organization_id" UUID NOT NULL;
+
+-- AlterTable
+ALTER TABLE "tasks" ADD COLUMN     "organization_id" UUID NOT NULL;
+
+-- AlterTable
+ALTER TABLE "settings" ADD COLUMN     "organization_id" UUID NOT NULL;
+
+-- AlterTable
+ALTER TABLE "currency_rates" DROP CONSTRAINT "currency_rates_pkey",
+ADD COLUMN     "organization_id" UUID NOT NULL,
+ALTER COLUMN "currency" SET DATA TYPE VARCHAR(255),
+ADD CONSTRAINT "currency_rates_pkey" PRIMARY KEY ("currency", "organization_id");
+
+-- CreateTable
+CREATE TABLE "organizations" (
+    "id" UUID NOT NULL,
+    "name" TEXT NOT NULL,
+    "created_at" TIMESTAMPTZ(6) DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "organizations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "user_organizations" (
+    "id" UUID NOT NULL,
+    "role" TEXT NOT NULL,
+    "is_owner" BOOLEAN NOT NULL DEFAULT false,
+    "user_id" UUID NOT NULL,
+    "organization_id" UUID NOT NULL,
+
+    CONSTRAINT "user_organizations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_organizations_user_id_organization_id_key" ON "user_organizations"("user_id", "organization_id");
+
+-- CreateIndex
+CREATE INDEX "operations_organization_id_idx" ON "operations"("organization_id");
+
+-- CreateIndex
+CREATE INDEX "debts_organization_id_idx" ON "debts"("organization_id");
+
+-- CreateIndex
+CREATE INDEX "categories_organization_id_idx" ON "categories"("organization_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "categories_organization_id_type_name_key" ON "categories"("organization_id", "type", "name");
+
+-- CreateIndex
+CREATE INDEX "inventory_items_organization_id_idx" ON "inventory_items"("organization_id");
+
+-- CreateIndex
+CREATE INDEX "book_inventory_items_organization_id_idx" ON "book_inventory_items"("organization_id");
+
+-- CreateIndex
+CREATE INDEX "book_sales_organization_id_idx" ON "book_sales"("organization_id");
+
+-- CreateIndex
+CREATE INDEX "tasks_organization_id_idx" ON "tasks"("organization_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "settings_organization_id_key" ON "settings"("organization_id");
+
+-- AddForeignKey
+ALTER TABLE "user_organizations" ADD CONSTRAINT "user_organizations_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_organizations" ADD CONSTRAINT "user_organizations_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "operations" ADD CONSTRAINT "operations_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "debts" ADD CONSTRAINT "debts_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "goals" ADD CONSTRAINT "goals_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "wallets" ADD CONSTRAINT "wallets_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "categories" ADD CONSTRAINT "categories_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "inventory_items" ADD CONSTRAINT "inventory_items_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "book_inventory_items" ADD CONSTRAINT "book_inventory_items_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "book_sales" ADD CONSTRAINT "book_sales_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tasks" ADD CONSTRAINT "tasks_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "settings" ADD CONSTRAINT "settings_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "currency_rates" ADD CONSTRAINT "currency_rates_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,37 +14,82 @@ model User {
   password  String
   createdAt DateTime? @default(now()) @map("created_at") @db.Timestamp(6)
 
+  memberships UserOrganization[]
+
   @@map("users")
 }
 
+model Organization {
+  id        String    @id @default(uuid()) @db.Uuid
+  name      String
+  createdAt DateTime? @default(now()) @map("created_at") @db.Timestamptz(6)
+
+  memberships    UserOrganization[]
+  operations     Operation[]
+  debts          Debt[]
+  goals          Goal[]
+  wallets        Wallet[]
+  categories     Category[]
+  inventoryItems InventoryItem[]
+  bookInventory  BookInventoryItem[]
+  bookSales      BookSale[]
+  tasks          Task[]
+  settings       Settings[]
+  currencyRates  CurrencyRate[]
+
+  @@map("organizations")
+}
+
+model UserOrganization {
+  id             String  @id @default(uuid()) @db.Uuid
+  role           String
+  isOwner        Boolean @default(false) @map("is_owner")
+  userId         String  @map("user_id") @db.Uuid
+  organizationId String  @map("organization_id") @db.Uuid
+
+  user         User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, organizationId])
+  @@map("user_organizations")
+}
+
 model Operation {
-  id          String   @id @db.Uuid
-  type        String
-  amount      Decimal  @db.Decimal
-  currency    String
-  category    String
-  wallet      String
-  comment     String?
-  source      String?
-  occurred_at DateTime @db.Timestamptz(6)
+  id             String   @id @db.Uuid
+  type           String
+  amount         Decimal  @db.Decimal
+  currency       String
+  category       String
+  wallet         String
+  comment        String?
+  source         String?
+  occurred_at    DateTime @db.Timestamptz(6)
+  organizationId String   @map("organization_id") @db.Uuid
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   @@index([occurred_at(sort: Desc)])
+  @@index([organizationId])
   @@map("operations")
 }
 
 model Debt {
-  id            String   @id @db.Uuid
-  type          String
-  status        String
-  amount        Decimal  @db.Decimal
-  currency      String
-  wallet        String
-  from_contact  String?
-  to_contact    String?
-  comment       String?
-  registered_at DateTime @db.Timestamptz(6)
+  id             String   @id @db.Uuid
+  type           String
+  status         String
+  amount         Decimal  @db.Decimal
+  currency       String
+  wallet         String
+  from_contact   String?
+  to_contact     String?
+  comment        String?
+  registered_at  DateTime @db.Timestamptz(6)
+  organizationId String   @map("organization_id") @db.Uuid
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   @@index([registered_at(sort: Desc)])
+  @@index([organizationId])
   @@map("debts")
 }
 
@@ -56,73 +101,93 @@ model Goal {
   current_amount Decimal @default(0) @db.Decimal
   status         String
   currency       String
+  organizationId String  @map("organization_id") @db.Uuid
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   @@map("goals")
 }
 
 /// This model contains an expression index which requires additional setup for migrations. Visit https://pris.ly/d/expression-indexes for more info.
 model Wallet {
-  wallet       String @id
-  display_name String
-  currency     String @default("USD")
+  wallet         String @id
+  display_name   String
+  currency       String @default("USD")
+  organizationId String @map("organization_id") @db.Uuid
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   @@map("wallets")
 }
 
 model Category {
-  id   Int    @id @default(autoincrement())
-  type String
-  name String
+  id             Int    @id @default(autoincrement())
+  type           String
+  name           String
+  organizationId String @map("organization_id") @db.Uuid
 
-  @@unique([type, name])
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  @@unique([organizationId, type, name])
+  @@index([organizationId])
   @@map("categories")
 }
 
 model InventoryItem {
-  id           String   @id @default(uuid()) @db.Uuid
-  name         String
-  category     String
-  responsible  String
-  location     String
-  amount       Decimal  @db.Decimal
-  createdAt    DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  id             String   @id @default(uuid()) @db.Uuid
+  name           String
+  category       String
+  responsible    String
+  location       String
+  amount         Decimal  @db.Decimal
+  createdAt      DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  organizationId String   @map("organization_id") @db.Uuid
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   @@index([name])
   @@index([category])
   @@index([responsible])
+  @@index([organizationId])
   @@map("inventory_items")
 }
 
 model BookInventoryItem {
-  id            String  @id @default(uuid()) @db.Uuid
-  title         String
-  language      String
-  quantity      Int
-  purchasePrice Decimal @map("purchase_price") @db.Decimal
-  salePrice     Decimal @map("sale_price") @db.Decimal
-  debt          Decimal @db.Decimal
-  createdAt     DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  id             String   @id @default(uuid()) @db.Uuid
+  title          String
+  language       String
+  quantity       Int
+  purchasePrice  Decimal  @map("purchase_price") @db.Decimal
+  salePrice      Decimal  @map("sale_price") @db.Decimal
+  debt           Decimal  @db.Decimal
+  createdAt      DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  organizationId String   @map("organization_id") @db.Uuid
 
-  sales BookSale[]
+  sales        BookSale[]
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   @@index([title])
   @@index([language])
+  @@index([organizationId])
   @@map("book_inventory_items")
 }
 
 model BookSale {
-  id        String  @id @default(uuid()) @db.Uuid
-  bookId    String  @map("book_id") @db.Uuid
-  title     String
-  language  String
-  quantity  Int
-  salePrice Decimal @map("sale_price") @db.Decimal
-  total     Decimal @db.Decimal
-  soldAt    DateTime @default(now()) @map("sold_at") @db.Timestamptz(6)
+  id             String   @id @default(uuid()) @db.Uuid
+  bookId         String   @map("book_id") @db.Uuid
+  title          String
+  language       String
+  quantity       Int
+  salePrice      Decimal  @map("sale_price") @db.Decimal
+  total          Decimal  @db.Decimal
+  soldAt         DateTime @default(now()) @map("sold_at") @db.Timestamptz(6)
+  organizationId String   @map("organization_id") @db.Uuid
 
-  book BookInventoryItem @relation(fields: [bookId], references: [id])
+  book         BookInventoryItem @relation(fields: [bookId], references: [id])
+  organization Organization      @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   @@index([soldAt(sort: Desc)])
+  @@index([organizationId])
   @@map("book_sales")
 }
 
@@ -137,24 +202,36 @@ model Task {
   notify_before_minutes Int?
   created_at            DateTime @default(now()) @db.Timestamptz(6)
   updated_at            DateTime @updatedAt @db.Timestamptz(6)
+  organizationId        String   @map("organization_id") @db.Uuid
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   @@index([due_date(sort: Asc)])
+  @@index([organizationId])
   @@map("tasks")
 }
 
 model Settings {
-  id            Int      @id @default(autoincrement())
-  base_currency String
-  updated_at    DateTime @default(now()) @updatedAt @db.Timestamptz(6)
+  id             Int      @id @default(autoincrement())
+  base_currency  String
+  updated_at     DateTime @default(now()) @updatedAt @db.Timestamptz(6)
+  organizationId String   @map("organization_id") @db.Uuid
 
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  @@unique([organizationId])
   @@map("settings")
 }
 
 model CurrencyRate {
-  currency   String   @id
-  rate       Decimal  @db.Decimal
-  updated_at DateTime @default(now()) @updatedAt @db.Timestamptz(6)
+  currency       String   @db.VarChar(255)
+  rate           Decimal  @db.Decimal
+  updated_at     DateTime @default(now()) @updatedAt @db.Timestamptz(6)
+  organizationId String   @map("organization_id") @db.Uuid
 
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  @@id([currency, organizationId])
   @@map("currency_rates")
 }
 
@@ -167,4 +244,3 @@ model exchange_rates {
 
   @@unique([base_currency, target_currency], map: "baseCurrency_targetCurrency")
 }
-

--- a/prisma/seed-data.json
+++ b/prisma/seed-data.json
@@ -13,6 +13,26 @@
       "role": "user"
     }
   ],
+  "organizations": [
+    {
+      "id": "10000000-0000-0000-0000-000000000001",
+      "name": "ISKCON Finance"
+    }
+  ],
+  "memberships": [
+    {
+      "userId": "00000000-0000-0000-0000-000000000001",
+      "organizationId": "10000000-0000-0000-0000-000000000001",
+      "role": "owner",
+      "isOwner": true
+    },
+    {
+      "userId": "00000000-0000-0000-0000-000000000002",
+      "organizationId": "10000000-0000-0000-0000-000000000001",
+      "role": "member",
+      "isOwner": false
+    }
+  ],
   "categories": {
     "income": [
       "йога",

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -7,7 +7,21 @@ const prisma = new PrismaClient();
 const normalizeWalletSlug = (value) => value.trim().toLowerCase().replace(/\s+/g, "-");
 
 async function main() {
-  const { users, categories, wallets, currencies, baseCurrency } = seedData;
+  const {
+    users,
+    organizations,
+    memberships,
+    categories,
+    wallets,
+    currencies,
+    baseCurrency,
+  } = seedData;
+
+  const organizationIds = organizations.map(({ id }) => id);
+
+  if (!organizationIds.length) {
+    throw new Error("Seed data must include at least one organization");
+  }
 
   const hashedUsers = await Promise.all(
     users.map(async ({ id, login, password, role }) => {
@@ -19,10 +33,37 @@ async function main() {
 
   await prisma.user.createMany({ data: hashedUsers, skipDuplicates: true });
 
+  await prisma.organization.createMany({
+    data: organizations.map(({ id, name }) => ({ id, name })),
+    skipDuplicates: true,
+  });
+
+  if (memberships.length) {
+    await prisma.userOrganization.createMany({
+      data: memberships.map(({ userId, organizationId, role, isOwner = false }) => ({
+        userId,
+        organizationId,
+        role,
+        isOwner,
+      })),
+      skipDuplicates: true,
+    });
+  }
+
+  const defaultOrganizationId = organizationIds[0];
+
   await prisma.category.createMany({
     data: [
-      ...categories.income.map((name) => ({ type: "income", name })),
-      ...categories.expense.map((name) => ({ type: "expense", name })),
+      ...categories.income.map((name) => ({
+        type: "income",
+        name,
+        organizationId: defaultOrganizationId,
+      })),
+      ...categories.expense.map((name) => ({
+        type: "expense",
+        name,
+        organizationId: defaultOrganizationId,
+      })),
     ],
     skipDuplicates: true,
   });
@@ -32,23 +73,30 @@ async function main() {
       wallet: normalizeWalletSlug(name),
       display_name: name,
       currency,
+      organizationId: defaultOrganizationId,
     })),
     skipDuplicates: true,
   });
 
-  const existingSettings = await prisma.settings.findFirst({ orderBy: { id: "desc" } });
-
-  if (!existingSettings) {
-    await prisma.settings.create({ data: { base_currency: baseCurrency } });
-  }
+  await Promise.all(
+    organizationIds.map((organizationId) =>
+      prisma.settings.upsert({
+        where: { organizationId },
+        update: { base_currency: baseCurrency },
+        create: { base_currency: baseCurrency, organizationId },
+      })
+    )
+  );
 
   await Promise.all(
-    currencies.map((currency) =>
-      prisma.currencyRate.upsert({
-        where: { currency },
-        update: { rate: 1 },
-        create: { currency, rate: new Prisma.Decimal(1) },
-      })
+    organizationIds.flatMap((organizationId) =>
+      currencies.map((currency) =>
+        prisma.currencyRate.upsert({
+          where: { currency_organizationId: { currency, organizationId } },
+          update: { rate: new Prisma.Decimal(1) },
+          create: { currency, rate: new Prisma.Decimal(1), organizationId },
+        })
+      )
     )
   );
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -7,13 +7,29 @@ const prisma = new PrismaClient();
 const normalizeWalletSlug = (value: string) => value.trim().toLowerCase().replace(/\s+/g, "-");
 
 const main = async () => {
-  const { users, categories, wallets, currencies, baseCurrency } = seedData as {
+  const {
+    users,
+    organizations,
+    memberships,
+    categories,
+    wallets,
+    currencies,
+    baseCurrency,
+  } = seedData as {
     users: Array<{ id: string; login: string; password: string; role: string }>;
+    organizations: Array<{ id: string; name: string }>;
+    memberships: Array<{ userId: string; organizationId: string; role: string; isOwner?: boolean }>;
     categories: { income: string[]; expense: string[] };
     wallets: Array<{ name: string; currency: string }>;
     currencies: string[];
     baseCurrency: string;
   };
+
+  const organizationIds = organizations.map(({ id }) => id);
+
+  if (!organizationIds.length) {
+    throw new Error("Seed data must include at least one organization");
+  }
 
   const hashedUsers = await Promise.all(
     users.map(async ({ id, login, password, role }) => {
@@ -25,10 +41,37 @@ const main = async () => {
 
   await prisma.user.createMany({ data: hashedUsers, skipDuplicates: true });
 
+  await prisma.organization.createMany({
+    data: organizations.map(({ id, name }) => ({ id, name })),
+    skipDuplicates: true,
+  });
+
+  if (memberships.length) {
+    await prisma.userOrganization.createMany({
+      data: memberships.map(({ userId, organizationId, role, isOwner = false }) => ({
+        userId,
+        organizationId,
+        role,
+        isOwner,
+      })),
+      skipDuplicates: true,
+    });
+  }
+
+  const defaultOrganizationId = organizationIds[0];
+
   await prisma.category.createMany({
     data: [
-      ...categories.income.map((name) => ({ type: "income" as const, name })),
-      ...categories.expense.map((name) => ({ type: "expense" as const, name })),
+      ...categories.income.map((name) => ({
+        type: "income" as const,
+        name,
+        organizationId: defaultOrganizationId,
+      })),
+      ...categories.expense.map((name) => ({
+        type: "expense" as const,
+        name,
+        organizationId: defaultOrganizationId,
+      })),
     ],
     skipDuplicates: true,
   });
@@ -38,23 +81,30 @@ const main = async () => {
       wallet: normalizeWalletSlug(name),
       display_name: name,
       currency,
+      organizationId: defaultOrganizationId,
     })),
     skipDuplicates: true,
   });
 
-  const existingSettings = await prisma.settings.findFirst({ orderBy: { id: "desc" } });
-
-  if (!existingSettings) {
-    await prisma.settings.create({ data: { base_currency: baseCurrency } });
-  }
+  await Promise.all(
+    organizationIds.map((organizationId) =>
+      prisma.settings.upsert({
+        where: { organizationId },
+        update: { base_currency: baseCurrency },
+        create: { base_currency: baseCurrency, organizationId },
+      })
+    )
+  );
 
   await Promise.all(
-    currencies.map((currency) =>
-      prisma.currencyRate.upsert({
-        where: { currency },
-        update: { rate: 1 },
-        create: { currency, rate: new Prisma.Decimal(1) },
-      })
+    organizationIds.flatMap((organizationId) =>
+      currencies.map((currency) =>
+        prisma.currencyRate.upsert({
+          where: { currency_organizationId: { currency, organizationId } },
+          update: { rate: new Prisma.Decimal(1) },
+          create: { currency, rate: new Prisma.Decimal(1), organizationId },
+        })
+      )
     )
   );
 };


### PR DESCRIPTION
## Summary
- introduce Organization and UserOrganization models and link all business entities to an organization with indexes
- update Prisma schema constraints for categories, settings, and currency rates to scope records per organization
- refresh seed data and scripts to populate organizations, memberships, and organization-aware reference data

## Testing
- DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres" npx prisma migrate dev --name add-organizations --create-only *(fails: database server unavailable)*
- npx prisma migrate diff --from-schema-datamodel /tmp/schema_before.prisma --to-schema-datamodel prisma/schema.prisma --script

------
https://chatgpt.com/codex/tasks/task_e_68f70f6580888331ae59fdf631da0cdb